### PR TITLE
Update onboarding copy to 'stay in touch with'

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Onboarding/ContactPickerView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Onboarding/ContactPickerView.swift
@@ -12,7 +12,7 @@ struct ContactPickerView: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            Text("Who Do You Want to Track?")
+            Text("Who Do You Want to Stay in Touch With?")
                 .font(.title2)
                 .padding(.top)
 


### PR DESCRIPTION
Closes #1

Changed the onboarding contact picker heading from "Who Do You Want to Track?" to "Who Do You Want to Stay in Touch With?"

This aligns with the app's friendly, relationship-focused messaging and makes the app feel warmer and more inviting.

## Changes
- Updated ContactPickerView.swift Line 15

## Testing
- ✅ Build succeeds without warnings
- ✅ Verified new copy displays correctly in onboarding flow
- ✅ Text doesn't overflow on smaller devices