### PR TITLE
#74: Add touch events and group/tag names to data export

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -25,17 +25,20 @@ final class SettingsViewModel: ObservableObject {
     private let groupRepository: GroupRepository
     private let tagRepository: TagRepository
     private let personRepository: PersonRepository
+    private let touchEventRepository: TouchEventRepository
 
     init(
         settingsRepository: AppSettingsRepository = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext),
         groupRepository: GroupRepository = CoreDataGroupRepository(context: CoreDataStack.shared.viewContext),
         tagRepository: TagRepository = CoreDataTagRepository(context: CoreDataStack.shared.viewContext),
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext)
+        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
+        touchEventRepository: TouchEventRepository = CoreDataTouchEventRepository(context: CoreDataStack.shared.viewContext)
     ) {
         self.settingsRepository = settingsRepository
         self.groupRepository = groupRepository
         self.tagRepository = tagRepository
         self.personRepository = personRepository
+        self.touchEventRepository = touchEventRepository
         self.settings = settingsRepository.fetch() ?? AppSettingsDefaults.defaultSettings()
         load()
     }
@@ -142,8 +145,25 @@ final class SettingsViewModel: ObservableObject {
 
     func exportContacts() -> URL? {
         let people = personRepository.fetchAll()
-        let payload = people.map { ExportPerson.from($0) }
-        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+        let groups = groupRepository.fetchAll()
+        let tags = tagRepository.fetchAll()
+
+        let groupNameById = Dictionary(uniqueKeysWithValues: groups.map { ($0.id, $0.name) })
+        let tagNameById = Dictionary(uniqueKeysWithValues: tags.map { ($0.id, $0.name) })
+
+        let payload = people.map { person in
+            ExportPerson.from(
+                person,
+                groupName: groupNameById[person.groupId],
+                tagNames: person.tagIds.compactMap { tagNameById[$0] },
+                touchEvents: touchEventRepository.fetchAll(for: person.id)
+            )
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(payload) else { return nil }
 
         let filename = "contacts-export-\(ISO8601DateFormatter().string(from: Date())).json"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
@@ -289,31 +309,50 @@ final class SettingsViewModel: ObservableObject {
     }
 }
 
+struct ExportTouchEvent: Codable {
+    let at: Date
+    let method: String
+    let notes: String?
+
+    static func from(_ event: TouchEvent) -> ExportTouchEvent {
+        ExportTouchEvent(
+            at: event.at,
+            method: event.method.rawValue,
+            notes: event.notes
+        )
+    }
+}
+
 struct ExportPerson: Codable {
     let id: UUID
     let displayName: String
     let cnIdentifier: String?
     let groupId: UUID?
+    let groupName: String?
     let tagIds: [UUID]
+    let tagNames: [String]
     let lastTouchAt: Date?
     let isPaused: Bool
     let createdAt: Date
     let modifiedAt: Date
+    let touchEvents: [ExportTouchEvent]
 
-    static func from(_ person: Person) -> ExportPerson {
+    static func from(_ person: Person, groupName: String?, tagNames: [String], touchEvents: [TouchEvent]) -> ExportPerson {
         ExportPerson(
             id: person.id,
             displayName: person.displayName,
             cnIdentifier: person.cnIdentifier,
             groupId: person.groupId,
+            groupName: groupName,
             tagIds: person.tagIds,
+            tagNames: tagNames,
             lastTouchAt: person.lastTouchAt,
             isPaused: person.isPaused,
             createdAt: person.createdAt,
-            modifiedAt: person.modifiedAt
+            modifiedAt: person.modifiedAt,
+            touchEvents: touchEvents.map { ExportTouchEvent.from($0) }
         )
     }
-
 }
 
 struct AppSettingsDefaults {


### PR DESCRIPTION
## Summary
- Add `groupName` and `tagNames` fields to export JSON for human-readable output
- Include full touch event history (date, method, notes) per contact
- Use ISO 8601 date encoding and pretty-printed JSON
- All existing export fields preserved (backward compatible)

## Test plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Manual: export contacts and verify JSON includes groupName, tagNames, and touchEvents
- [x] Manual: verify existing fields (id, displayName, etc.) are still present

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)