### PR TITLE
#43: Add "Last connected" timestamp to PersonDetailView hero

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -271,6 +271,12 @@ struct PersonDetailView: View {
                     .font(DS.Typography.metadata)
                     .foregroundStyle(DS.Colors.secondaryText)
             }
+
+            if let lastTouch = viewModel.person.lastTouchAt {
+                Text("Last connected \(lastTouchTimeAgo(lastTouch))")
+                    .font(DS.Typography.metadata)
+                    .foregroundStyle(DS.Colors.secondaryText)
+            }
         }
     }
 
@@ -649,6 +655,12 @@ struct PersonDetailView: View {
         case .overdue: return "Overdue"
         case .unknown: return "Unknown"
         }
+    }
+
+    private func lastTouchTimeAgo(_ date: Date) -> String {
+        let days = Calendar.current.dateComponents([.day], from: date, to: Date()).day ?? 0
+        if days == 0 { return "today" }
+        return "\(days)d ago"
     }
 
     private func statusColor() -> Color {


### PR DESCRIPTION
## Summary
- Show "Last connected Xd ago" (or "today") below the status indicator in the hero zone
- Hidden when no touch history exists (new contacts)
- Uses same relative time format as ContactCard for consistency

## Test plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Manual: verify "Last connected X ago" appears below status in person detail
- [x] Manual: verify hidden for contacts with no touch history
- [x] Manual: verify correct in both light and dark mode

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)