### PR TITLE
#72: Display contact photos from iOS Contacts

### DIFF
--- a/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
+++ b/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
@@ -136,4 +136,24 @@ enum ContactsFetcher {
             throw ContactsFetcherError.fetchFailed(error)
         }
     }
+
+    static func fetchThumbnailImageData(identifier: String) -> Data? {
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        switch status {
+        case .denied, .restricted, .notDetermined:
+            return nil
+        case .authorized, .limited:
+            break
+        @unknown default:
+            break
+        }
+
+        let store = CNContactStore()
+        let keys: [CNKeyDescriptor] = [CNContactThumbnailImageDataKey as CNKeyDescriptor]
+
+        guard let contact = try? store.unifiedContact(withIdentifier: identifier, keysToFetch: keys) else {
+            return nil
+        }
+        return contact.thumbnailImageData
+    }
 }

--- a/StayInTouch/StayInTouch/UI/Views/Components/ContactPhotoView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Components/ContactPhotoView.swift
@@ -1,0 +1,64 @@
+//
+//  ContactPhotoView.swift
+//  StayInTouch
+//
+
+import SwiftUI
+
+struct ContactPhotoView: View {
+    let cnIdentifier: String?
+    let displayName: String
+    var size: CGFloat = 36
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        SwiftUI.Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Text(InitialsBuilder.initials(for: displayName))
+                    .font(.system(size: size * 0.4, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: size, height: size)
+                    .background(DS.Colors.accent.opacity(0.7))
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .task(id: cnIdentifier) {
+            image = await loadImage()
+        }
+    }
+
+    private func loadImage() async -> UIImage? {
+        guard let cnIdentifier else { return nil }
+
+        if let cached = ContactPhotoCache.image(for: cnIdentifier) {
+            return cached
+        }
+
+        return await Task.detached(priority: .utility) {
+            guard let data = ContactsFetcher.fetchThumbnailImageData(identifier: cnIdentifier),
+                  let uiImage = UIImage(data: data) else {
+                return nil
+            }
+            ContactPhotoCache.setImage(uiImage, for: cnIdentifier)
+            return uiImage
+        }.value
+    }
+}
+
+private enum ContactPhotoCache {
+    static let shared = NSCache<NSString, UIImage>()
+
+    static func image(for identifier: String) -> UIImage? {
+        shared.object(forKey: identifier as NSString)
+    }
+
+    static func setImage(_ image: UIImage, for identifier: String) {
+        shared.setObject(image, forKey: identifier as NSString)
+    }
+}

--- a/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
@@ -17,9 +17,16 @@ struct ContactCard: View {
     let lastMethod: TouchMethod?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
-            // Row 1: Name + inline tags + status
-            HStack(spacing: DS.Spacing.sm) {
+        HStack(alignment: .center, spacing: DS.Spacing.md) {
+            ContactPhotoView(
+                cnIdentifier: person.cnIdentifier,
+                displayName: person.displayName,
+                size: 36
+            )
+
+            VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+                // Row 1: Name + inline tags + status
+                HStack(spacing: DS.Spacing.sm) {
                 Text(person.displayName)
                     .font(DS.Typography.contactName)
                     .lineLimit(1)
@@ -43,8 +50,9 @@ struct ContactCard: View {
                 StatusIndicator(status: status, daysOverdue: daysOverdue)
             }
 
-            // Row 2: Icon-labeled metadata
-            metadataRow
+                // Row 2: Icon-labeled metadata
+                metadataRow
+            }
         }
         .padding(.vertical, DS.Spacing.md)
         .contentShape(Rectangle())

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -243,33 +243,41 @@ struct PersonDetailView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
-            HStack(spacing: DS.Spacing.sm) {
-                Text(viewModel.person.displayName)
-                    .font(DS.Typography.heroTitle)
-                    .lineLimit(1)
-                    .layoutPriority(1)
+        HStack(alignment: .top, spacing: DS.Spacing.md) {
+            ContactPhotoView(
+                cnIdentifier: viewModel.person.cnIdentifier,
+                displayName: viewModel.person.displayName,
+                size: 56
+            )
 
-                if !personTags.isEmpty {
-                    HStack(spacing: DS.Spacing.xs) {
-                        ForEach(personTags.prefix(3), id: \.id) { tag in
-                            TagPill(tag: tag)
+            VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+                HStack(spacing: DS.Spacing.sm) {
+                    Text(viewModel.person.displayName)
+                        .font(DS.Typography.heroTitle)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+
+                    if !personTags.isEmpty {
+                        HStack(spacing: DS.Spacing.xs) {
+                            ForEach(personTags.prefix(3), id: \.id) { tag in
+                                TagPill(tag: tag)
+                            }
+                            if personTags.count > 3 {
+                                Text("+\(personTags.count - 3)")
+                                    .font(DS.Typography.caption)
+                                    .foregroundStyle(DS.Colors.secondaryText)
+                            }
                         }
-                        if personTags.count > 3 {
-                            Text("+\(personTags.count - 3)")
-                                .font(DS.Typography.caption)
-                                .foregroundStyle(DS.Colors.secondaryText)
-                        }
+                        .lineLimit(1)
                     }
-                    .lineLimit(1)
                 }
-            }
 
-            HStack(spacing: DS.Spacing.sm) {
-                StatusIndicator(status: currentStatus, daysOverdue: daysOverdue)
-                Text(statusLabel())
-                    .font(DS.Typography.metadata)
-                    .foregroundStyle(DS.Colors.secondaryText)
+                HStack(spacing: DS.Spacing.sm) {
+                    StatusIndicator(status: currentStatus, daysOverdue: daysOverdue)
+                    Text(statusLabel())
+                        .font(DS.Typography.metadata)
+                        .foregroundStyle(DS.Colors.secondaryText)
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #72

## Summary
- Fetch `CNContact.thumbnailImageData` on-demand from CNContactStore (never stored in Core Data)
- New `ContactPhotoView` component with NSCache for scroll performance
- Circular photo avatars in ContactCard (home screen) and PersonDetailView header
- Graceful initials fallback when no photo exists

## Test plan
- [x] Contacts with photos show circular thumbnails on home list
- [x] Contacts with photos show larger circular thumbnail in detail header
- [x] Contacts without photos show initials in a colored circle
- [ ] Manually-added contacts (no cnIdentifier) show initials
- [ ] Scrolling 100+ contacts has no visible lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)