### PR TITLE
#51: Show picker when contact has multiple phone numbers or emails

### DIFF
--- a/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
+++ b/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
@@ -43,9 +43,22 @@ struct ContactSummary: Identifiable, Equatable {
 }
 
 enum ContactsFetcher {
+    struct LabeledValue: Identifiable, Equatable {
+        let id = UUID()
+        let label: String
+        let value: String
+
+        static func == (lhs: LabeledValue, rhs: LabeledValue) -> Bool {
+            lhs.label == rhs.label && lhs.value == rhs.value
+        }
+    }
+
     struct ContactInfo: Equatable {
-        let phone: String?
-        let email: String?
+        let phoneNumbers: [LabeledValue]
+        let emailAddresses: [LabeledValue]
+
+        var phone: String? { phoneNumbers.first?.value }
+        var email: String? { emailAddresses.first?.value }
     }
 
     static func requestAccess() async -> Bool {
@@ -124,9 +137,15 @@ enum ContactsFetcher {
 
         do {
             let contact = try store.unifiedContact(withIdentifier: identifier, keysToFetch: keys)
-            let phone = contact.phoneNumbers.first?.value.stringValue
-            let email = contact.emailAddresses.first?.value as String?
-            return ContactInfo(phone: phone, email: email)
+            let phones = contact.phoneNumbers.map { labeled in
+                let label = CNLabeledValue<CNPhoneNumber>.localizedString(forLabel: labeled.label ?? "")
+                return LabeledValue(label: label, value: labeled.value.stringValue)
+            }
+            let emails = contact.emailAddresses.map { labeled in
+                let label = CNLabeledValue<NSString>.localizedString(forLabel: labeled.label ?? "")
+                return LabeledValue(label: label, value: labeled.value as String)
+            }
+            return ContactInfo(phoneNumbers: phones, emailAddresses: emails)
         } catch let error as NSError {
             if error.domain == CNErrorDomain && error.code == CNError.recordDoesNotExist.rawValue {
                 AppLogger.logWarning("Contact not found: \(identifier)", category: AppLogger.contacts)

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -17,7 +17,12 @@ final class PersonDetailViewModel: ObservableObject {
     @Published private(set) var touchEvents: [TouchEvent] = []
     @Published private(set) var phone: String?
     @Published private(set) var email: String?
+    @Published private(set) var phoneNumbers: [ContactsFetcher.LabeledValue] = []
+    @Published private(set) var emailAddresses: [ContactsFetcher.LabeledValue] = []
     @Published var quickActionMessage: String?
+    @Published var showPhonePicker = false
+    @Published var showEmailPicker = false
+    var pendingPhoneAction: QuickActionType?
 
     private let personRepository: PersonRepository
     private let groupRepository: GroupRepository
@@ -51,6 +56,8 @@ final class PersonDetailViewModel: ObservableObject {
         guard let cnId = person.cnIdentifier else {
             phone = nil
             email = nil
+            phoneNumbers = []
+            emailAddresses = []
             return
         }
 
@@ -67,6 +74,8 @@ final class PersonDetailViewModel: ObservableObject {
         case .success(let info):
             phone = info.phone
             email = info.email
+            phoneNumbers = info.phoneNumbers
+            emailAddresses = info.emailAddresses
             if person.contactUnavailable {
                 var updated = person
                 updated.contactUnavailable = false
@@ -76,6 +85,8 @@ final class PersonDetailViewModel: ObservableObject {
         case .failure(let error):
             phone = nil
             email = nil
+            phoneNumbers = []
+            emailAddresses = []
             if case ContactsFetcherError.contactNotFound = error {
                 if !person.contactUnavailable {
                     var updated = person
@@ -291,45 +302,58 @@ final class PersonDetailViewModel: ObservableObject {
     func openAction(type: QuickActionType) -> URL? {
         quickActionMessage = nil
         switch type {
-        case .message:
+        case .message, .call:
+            if phoneNumbers.count > 1 {
+                pendingPhoneAction = type
+                showPhonePicker = true
+                return nil
+            }
             guard let phone else {
                 quickActionMessage = "Whoops — no phone number found."
                 return nil
             }
-            // Use proper URL encoding for SMS
-            let sanitizedPhone = sanitize(phone)
-            guard let encoded = sanitizedPhone.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-                  let url = URL(string: "sms:\(encoded)") else {
-                AppLogger.logWarning("Failed to create SMS URL for phone: \(phone)", category: AppLogger.viewModel)
-                return nil
-            }
-            return url
-        case .call:
-            guard let phone else {
-                quickActionMessage = "Whoops — no phone number found."
-                return nil
-            }
-            // Use proper URL encoding for tel
-            let sanitizedPhone = sanitize(phone)
-            guard let encoded = sanitizedPhone.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-                  let url = URL(string: "tel:\(encoded)") else {
-                AppLogger.logWarning("Failed to create tel URL for phone: \(phone)", category: AppLogger.viewModel)
-                return nil
-            }
-            return url
+            return buildPhoneURL(type: type, phone: phone)
         case .email:
+            if emailAddresses.count > 1 {
+                showEmailPicker = true
+                return nil
+            }
             guard let email else {
                 quickActionMessage = "Whoops — no email address found."
                 return nil
             }
-            // Use proper URL encoding for mailto
-            guard let encoded = email.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                  let url = URL(string: "mailto:\(encoded)") else {
-                AppLogger.logWarning("Failed to create mailto URL for email: \(email)", category: AppLogger.viewModel)
-                return nil
-            }
-            return url
+            return buildEmailURL(email: email)
         }
+    }
+
+    func openActionWithValue(type: QuickActionType, value: String) -> URL? {
+        quickActionMessage = nil
+        switch type {
+        case .message, .call:
+            return buildPhoneURL(type: type, phone: value)
+        case .email:
+            return buildEmailURL(email: value)
+        }
+    }
+
+    private func buildPhoneURL(type: QuickActionType, phone: String) -> URL? {
+        let sanitizedPhone = sanitize(phone)
+        let scheme = type == .message ? "sms" : "tel"
+        guard let encoded = sanitizedPhone.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let url = URL(string: "\(scheme):\(encoded)") else {
+            AppLogger.logWarning("Failed to create \(scheme) URL for phone: \(phone)", category: AppLogger.viewModel)
+            return nil
+        }
+        return url
+    }
+
+    private func buildEmailURL(email: String) -> URL? {
+        guard let encoded = email.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "mailto:\(encoded)") else {
+            AppLogger.logWarning("Failed to create mailto URL for email: \(email)", category: AppLogger.viewModel)
+            return nil
+        }
+        return url
     }
 
     private func savePerson(_ updated: Person) {

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -202,6 +202,46 @@ struct PersonDetailView: View {
                     }
             }
         }
+        .confirmationDialog("Choose a number", isPresented: $viewModel.showPhonePicker) {
+            ForEach(viewModel.phoneNumbers) { phone in
+                Button("\(phone.label): \(phone.value)") {
+                    guard let action = viewModel.pendingPhoneAction,
+                          let url = viewModel.openActionWithValue(type: action, value: phone.value) else {
+                        viewModel.pendingPhoneAction = nil
+                        return
+                    }
+                    openURL(url) { accepted in
+                        if accepted {
+                            Haptics.light()
+                            let method = action.touchMethod
+                            viewModel.logTouch(method: method, notes: nil, date: Date())
+                            pendingQuickActionTouch = viewModel.touchEvents.first
+                            pendingQuickActionMethod = method
+                        }
+                    }
+                    viewModel.pendingPhoneAction = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.pendingPhoneAction = nil
+            }
+        }
+        .confirmationDialog("Choose an email", isPresented: $viewModel.showEmailPicker) {
+            ForEach(viewModel.emailAddresses) { email in
+                Button("\(email.label): \(email.value)") {
+                    guard let url = viewModel.openActionWithValue(type: .email, value: email.value) else { return }
+                    openURL(url) { accepted in
+                        if accepted {
+                            Haptics.light()
+                            viewModel.logTouch(method: .email, notes: nil, date: Date())
+                            pendingQuickActionTouch = viewModel.touchEvents.first
+                            pendingQuickActionMethod = .email
+                        }
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         .overlay(alignment: .top) {
             if showQuickActionUndo, let method = pendingQuickActionMethod {
                 quickActionUndoBanner(method: method)


### PR DESCRIPTION
Closes #51

## Summary
- Expand `ContactInfo` to return all phone numbers and email addresses with human-readable labels (Home, Work, iPhone, etc.)
- Show `confirmationDialog` when tapping Message/Call with multiple phone numbers
- Show `confirmationDialog` when tapping Email with multiple email addresses
- Single-value contacts bypass the picker and open directly (no UX change)
- Touch auto-logging works correctly after picking from the dialog

## Test plan
- [x] Contact with 1 phone number: Message/Call opens directly
- [x] Contact with 2+ phone numbers: Message shows picker with labels
- [x] Contact with 2+ phone numbers: Call shows picker with labels
- [x] Contact with 2+ emails: Email shows picker with labels
- [x] Contact with no phone: shows "Whoops" message as before
- [x] Touch auto-logging fires after selecting from picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)