### PR TITLE
#42: Animate section count changes on home screen

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -132,8 +132,16 @@ struct HomeView: View {
         .padding(.bottom, DS.Spacing.sm)
     }
 
-    private func statusCountText(count: Int, label: String, color: Color) -> Text {
-        Text("\(count)").foregroundColor(color) + Text(" \(label)").foregroundColor(DS.Colors.secondaryText)
+    @ViewBuilder
+    private func statusCountText(count: Int, label: String, color: Color) -> some View {
+        HStack(spacing: 0) {
+            Text("\(count)")
+                .foregroundColor(color)
+                .contentTransition(.numericText())
+            Text(" \(label)")
+                .foregroundColor(DS.Colors.secondaryText)
+        }
+        .animation(.easeInOut(duration: 0.3), value: count)
     }
 
     // MARK: - Filters


### PR DESCRIPTION
## Summary
- Refactored `statusCountText` from `Text` return type to `some View` to support SwiftUI content transitions
- Applied `.contentTransition(.numericText())` to count digits for smooth roll animation
- Added `.animation(.easeInOut(duration: 0.3), value: count)` scoped to each status count

Closes #42