### PR TITLE
#44: Replace method Picker with icon grid

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/EditTouchModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/EditTouchModal.swift
@@ -32,9 +32,28 @@ struct EditTouchModal: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
-                Picker("Method", selection: $selectedMethod) {
-                    ForEach(TouchMethod.allCases, id: \.self) { method in
-                        Label(method.rawValue, systemImage: DS.touchMethodIcon(method)).tag(method)
+                HStack(spacing: DS.Spacing.md) {
+                    ForEach(TouchMethod.allCases, id: \.self) { touchMethod in
+                        Button {
+                            selectedMethod = touchMethod
+                        } label: {
+                            VStack(spacing: DS.Spacing.xs) {
+                                Image(systemName: DS.touchMethodIcon(touchMethod))
+                                    .font(.title2)
+                                Text(touchMethod.rawValue)
+                                    .font(DS.Typography.caption)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, DS.Spacing.sm)
+                            .background(
+                                selectedMethod == touchMethod
+                                    ? DS.Colors.accent.opacity(0.12)
+                                    : Color.clear
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(selectedMethod == touchMethod ? DS.Colors.accent : DS.Colors.secondaryText)
                     }
                 }
 

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/LogTouchModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/LogTouchModal.swift
@@ -20,9 +20,28 @@ struct LogTouchModal: View {
     var body: some View {
         NavigationStack {
             Form {
-                Picker("Method", selection: $selectedMethod) {
-                    ForEach(TouchMethod.allCases, id: \.self) { method in
-                        Label(method.rawValue, systemImage: DS.touchMethodIcon(method)).tag(method)
+                HStack(spacing: DS.Spacing.md) {
+                    ForEach(TouchMethod.allCases, id: \.self) { touchMethod in
+                        Button {
+                            selectedMethod = touchMethod
+                        } label: {
+                            VStack(spacing: DS.Spacing.xs) {
+                                Image(systemName: DS.touchMethodIcon(touchMethod))
+                                    .font(.title2)
+                                Text(touchMethod.rawValue)
+                                    .font(DS.Typography.caption)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, DS.Spacing.sm)
+                            .background(
+                                selectedMethod == touchMethod
+                                    ? DS.Colors.accent.opacity(0.12)
+                                    : Color.clear
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(selectedMethod == touchMethod ? DS.Colors.accent : DS.Colors.secondaryText)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Replaced Menu-style Picker with a 5-column icon grid for touch method selection
- Each method shows its SF Symbol icon + label, highlighted with accent color when selected
- Applied to both `LogTouchModal` and `EditTouchModal`
- Uses DS spacing tokens (`md`, `xs`, `sm`) and `DS.Radius.sm` for consistent styling

Closes #44