### PR TITLE
#98: Add NSContactsUsageDescription to Info.plist

### DIFF
--- a/StayInTouch/StayInTouch/Info.plist
+++ b/StayInTouch/StayInTouch/Info.plist
@@ -10,6 +10,8 @@
 	<array>
 		<string>fetch</string>
 	</array>
+	<key>NSContactsUsageDescription</key>
+	<string>We need access to your contacts to help you stay in touch with the people who matter.</string>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>We'll send you gentle reminders when it's time to reconnect with someone.</string>
 </dict>


### PR DESCRIPTION
## Summary
- Adds the missing `NSContactsUsageDescription` privacy key to Info.plist
- Uses the description string specified in CLAUDE.md: "We need access to your contacts to help you stay in touch with the people who matter."
- Prevents App Store rejection and runtime crash when requesting Contacts permission

## Test plan
- [ ] Build succeeds (verified)
- [ ] All tests pass (verified)
- [ ] Fresh install shows Contacts permission dialog with custom description string
- [ ] App does not crash when requesting Contacts permission

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)