### PR TITLE
#102: Fix notification handler thread safety in AppDelegate

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDelegate.swift
+++ b/StayInTouch/StayInTouch/App/AppDelegate.swift
@@ -46,7 +46,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     }
 
     private func logConnectionFromNotification(personId: UUID) {
-        let context = CoreDataStack.shared.viewContext
+        // Use background context — notification handlers may run off main thread
+        let context = CoreDataStack.shared.newBackgroundContext()
         let personRepo = CoreDataPersonRepository(context: context)
         let touchRepo = CoreDataTouchEventRepository(context: context)
 
@@ -72,7 +73,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             person.snoozedUntil = nil
             person.modifiedAt = now
             try personRepo.save(person)
-            NotificationCenter.default.post(name: .personDidChange, object: personId)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .personDidChange, object: personId)
+            }
         } catch {
             AppLogger.logError(error, category: AppLogger.notifications, context: "AppDelegate.logConnectionFromNotification")
         }


### PR DESCRIPTION
## Summary
- Replace `viewContext` with `newBackgroundContext()` in `logConnectionFromNotification`
- `UNUserNotificationCenterDelegate.didReceive` may be called on an arbitrary thread, but `viewContext` is bound to the main thread
- Dispatch `NotificationCenter.post` to main thread for UI safety

## Test plan
- [x] Build succeeds (verified)
- [x] All tests pass (verified)
- [x] Tap "Log Connection" notification action → touch logged without crash
- [ ] No Core Data thread violation warnings in console

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)