### PR TITLE
#103: Verify and reorder PrivacyInfo.xcprivacy declarations

### DIFF
--- a/StayInTouch/StayInTouch/PrivacyInfo.xcprivacy
+++ b/StayInTouch/StayInTouch/PrivacyInfo.xcprivacy
@@ -6,6 +6,8 @@
 	<false/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>
@@ -21,7 +23,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #103

## Summary

- Reordered privacy manifest keys to match Apple's recommended order (`NSPrivacyAccessedAPITypes` before `NSPrivacyCollectedDataTypes`)
- Verified manifest completeness against Apple's current privacy requirements

## Verification Results

**NSPrivacyAccessedAPITypes (Required Reason APIs):** The app uses none of Apple's five Required Reason API categories:
- No `UserDefaults` / `@AppStorage` usage
- No file timestamp APIs
- No disk space APIs
- No system boot time APIs
- No active keyboard APIs

**Contacts framework:** NOT a Required Reason API. Access is governed by `NSContactsUsageDescription` in Info.plist and runtime permission dialogs, not the privacy manifest.

**NSPrivacyCollectedDataTypes:** `ProductInteraction` for TelemetryDeck analytics is correctly declared (not linked to identity, not used for tracking, purpose: analytics).

**TelemetryDeck SDK:** Ships its own `PrivacyInfo.xcprivacy` declaring `UserDefaults` access (reason CA92.1) and `DeviceID` collection. Xcode merges SDK manifests automatically.

**Build:** Zero privacy-related warnings.

## Test plan

- [x] Build succeeds with no privacy warnings
- [x] Pre-existing test failure (`testExportContactsReturnsFileWithValidJSON`) confirmed on main — unrelated
- [x] Privacy manifest passes Xcode validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)