### PR TITLE
#109: Sanitize userInfo forwarding in deep link handler

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDelegate.swift
+++ b/StayInTouch/StayInTouch/App/AppDelegate.swift
@@ -45,7 +45,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             return
         }
 
-        DeepLinkRouter.shared.handleNotification(userInfo: userInfo)
+        // Only forward known fields to prevent untrusted data propagation
+        let sanitized: [AnyHashable: Any] = [
+            "type": userInfo["type"] as? String ?? "",
+            "personId": userInfo["personId"] as? String ?? "",
+            "category": userInfo["category"] as? String ?? ""
+        ]
+        DeepLinkRouter.shared.handleNotification(userInfo: sanitized)
         completionHandler()
     }
 


### PR DESCRIPTION
## Summary

- Build a sanitized dictionary with only known fields (`type`, `personId`, `category`) before passing notification `userInfo` to `DeepLinkRouter`
- Prevents future code from accidentally consuming untrusted fields from the raw notification payload
- Deep link navigation continues to work identically — `DeepLinkRouter.handleNotification` only reads `type` and `personId`

Closes #109