### PR TITLE
#104: Clean up temporary export files after sharing

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -51,7 +51,9 @@ struct SettingsView: View {
         .listStyle(.insetGrouped)
         .navigationTitle("Settings")
         .sheet(item: $shareItem) { item in
-            ShareSheet(items: [item.url])
+            ShareSheet(items: [item.url]) {
+                try? FileManager.default.removeItem(at: item.url)
+            }
         }
         .sheet(isPresented: $showBreachTimePicker) {
             timePickerSheet(

--- a/StayInTouch/StayInTouch/Utilities/Views/ShareSheet.swift
+++ b/StayInTouch/StayInTouch/Utilities/Views/ShareSheet.swift
@@ -10,9 +10,14 @@ import UIKit
 
 struct ShareSheet: UIViewControllerRepresentable {
     let items: [Any]
+    var onComplete: (() -> Void)?
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: items, applicationActivities: nil)
+        let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        controller.completionWithItemsHandler = { _, _, _, _ in
+            onComplete?()
+        }
+        return controller
     }
 
     func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}


### PR DESCRIPTION
## Summary

- Add `onComplete` callback to `ShareSheet` using `UIActivityViewController.completionWithItemsHandler`
- `SettingsView` passes a cleanup closure that deletes the temp export JSON file after the share sheet is dismissed
- Prevents accumulation of unencrypted contact data files in the temp directory

## Changes
- `ShareSheet.swift` — added optional `onComplete` closure, wired to `completionWithItemsHandler`
- `SettingsView.swift` — pass `FileManager.removeItem` cleanup closure when presenting share sheet

Closes #104