### PR TITLE
Fix #152: use calendar days for date calculations

### DIFF
--- a/StayInTouch/StayInTouch/UseCases/FrequencyCalculator.swift
+++ b/StayInTouch/StayInTouch/UseCases/FrequencyCalculator.swift
@@ -25,7 +25,7 @@ struct FrequencyCalculator {
             return .unknown
         }
 
-        let daysSince = Calendar.current.dateComponents([.day], from: lastTouch, to: referenceDate).day ?? 0
+        let daysSince = calendarDaysBetween(from: lastTouch, to: referenceDate)
         if daysSince >= group.frequencyDays {
             return .overdue
         }
@@ -46,7 +46,7 @@ struct FrequencyCalculator {
             return 0
         }
 
-        let daysSince = Calendar.current.dateComponents([.day], from: lastTouch, to: referenceDate).day ?? 0
+        let daysSince = calendarDaysBetween(from: lastTouch, to: referenceDate)
         return max(0, daysSince - group.frequencyDays)
     }
 
@@ -57,6 +57,11 @@ struct FrequencyCalculator {
 
     func daysSinceLastTouch(for person: Person) -> Int? {
         guard let lastTouch = effectiveLastTouchDate(for: person) else { return nil }
-        return Calendar.current.dateComponents([.day], from: lastTouch, to: referenceDate).day
+        return calendarDaysBetween(from: lastTouch, to: referenceDate)
+    }
+
+    private func calendarDaysBetween(from: Date, to: Date) -> Int {
+        let cal = Calendar.current
+        return cal.dateComponents([.day], from: cal.startOfDay(for: from), to: cal.startOfDay(for: to)).day ?? 0
     }
 }

--- a/StayInTouch/StayInTouchTests/FrequencyCalculatorTests.swift
+++ b/StayInTouch/StayInTouchTests/FrequencyCalculatorTests.swift
@@ -140,4 +140,119 @@ final class FrequencyCalculatorTests: XCTestCase {
         let overdue = FrequencyCalculator(referenceDate: reference).daysOverdue(for: person, in: [group])
         XCTAssertEqual(overdue, 3)
     }
+
+    // MARK: - Calendar Day Boundary Tests (#152)
+
+    func testDaysSinceLastTouchUsesCalendarDaysNotHours() {
+        // Touch at 11 PM yesterday, check at 8 AM today → should be 1 day, not 0
+        let cal = Calendar.current
+        let todayAt8AM = cal.date(bySettingHour: 8, minute: 0, second: 0, of: Date())!
+        let yesterdayAt11PM = cal.date(byAdding: .hour, value: -9, to: todayAt8AM)!
+
+        let groupId = UUID()
+        let person = Person(
+            id: UUID(),
+            cnIdentifier: nil,
+            displayName: "Eve",
+            initials: "E",
+            avatarColor: "#FF6B6B",
+            groupId: groupId,
+            tagIds: [],
+            lastTouchAt: yesterdayAt11PM,
+            lastTouchMethod: nil,
+            lastTouchNotes: nil,
+            nextTouchNotes: nil,
+            isPaused: false,
+            isTracked: true,
+            notificationsMuted: false,
+            customBreachTime: nil,
+            snoozedUntil: nil,
+            birthday: nil,
+            contactUnavailable: false,
+            isDemoData: false,
+            groupAddedAt: nil,
+            createdAt: Date(),
+            modifiedAt: Date(),
+            sortOrder: 0
+        )
+
+        let days = FrequencyCalculator(referenceDate: todayAt8AM).daysSinceLastTouch(for: person)
+        XCTAssertEqual(days, 1, "Touch yesterday at 11 PM should count as 1 calendar day ago, not 0")
+    }
+
+    func testDaysSinceLastTouchSameCalendarDayIsZero() {
+        // Touch at 1 AM, check at 11 PM same day → should be 0
+        let cal = Calendar.current
+        let todayAt1AM = cal.date(bySettingHour: 1, minute: 0, second: 0, of: Date())!
+        let todayAt11PM = cal.date(bySettingHour: 23, minute: 0, second: 0, of: Date())!
+
+        let groupId = UUID()
+        let person = Person(
+            id: UUID(),
+            cnIdentifier: nil,
+            displayName: "Sam",
+            initials: "S",
+            avatarColor: "#FF6B6B",
+            groupId: groupId,
+            tagIds: [],
+            lastTouchAt: todayAt1AM,
+            lastTouchMethod: nil,
+            lastTouchNotes: nil,
+            nextTouchNotes: nil,
+            isPaused: false,
+            isTracked: true,
+            notificationsMuted: false,
+            customBreachTime: nil,
+            snoozedUntil: nil,
+            birthday: nil,
+            contactUnavailable: false,
+            isDemoData: false,
+            groupAddedAt: nil,
+            createdAt: Date(),
+            modifiedAt: Date(),
+            sortOrder: 0
+        )
+
+        let days = FrequencyCalculator(referenceDate: todayAt11PM).daysSinceLastTouch(for: person)
+        XCTAssertEqual(days, 0, "Touch earlier same calendar day should count as 0 days ago")
+    }
+
+    func testStatusUsesCalendarDaysForOverdueCheck() {
+        // Touch at 11 PM, 7 days later at 8 AM → only ~6.4 24-hour periods
+        // but 7 calendar days → should be overdue for a 7-day frequency
+        let cal = Calendar.current
+        let touchDate = cal.date(bySettingHour: 23, minute: 0, second: 0, of: Date())!
+        let referenceDate = cal.date(byAdding: .day, value: 7, to: cal.date(bySettingHour: 8, minute: 0, second: 0, of: Date())!)!
+
+        let groupId = UUID()
+        let person = Person(
+            id: UUID(),
+            cnIdentifier: nil,
+            displayName: "Alex",
+            initials: "A",
+            avatarColor: "#FF6B6B",
+            groupId: groupId,
+            tagIds: [],
+            lastTouchAt: touchDate,
+            lastTouchMethod: nil,
+            lastTouchNotes: nil,
+            nextTouchNotes: nil,
+            isPaused: false,
+            isTracked: true,
+            notificationsMuted: false,
+            customBreachTime: nil,
+            snoozedUntil: nil,
+            birthday: nil,
+            contactUnavailable: false,
+            isDemoData: false,
+            groupAddedAt: nil,
+            createdAt: Date(),
+            modifiedAt: Date(),
+            sortOrder: 0
+        )
+        let group = Group(id: groupId, name: "Weekly", frequencyDays: 7, warningDays: 2, colorHex: nil, isDefault: true, sortOrder: 0, createdAt: Date(), modifiedAt: Date())
+
+        let status = FrequencyCalculator(referenceDate: referenceDate).status(for: person, in: [group])
+        XCTAssertEqual(status, .overdue, "7 calendar days should trigger overdue even if fewer than 7×24 hours elapsed")
+    }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,10 +1,18 @@
 # TODO - Stay in Touch iOS App
 
 **Project Status:** v0.2.2 (Build 8) — Pre-release Beta
-**Last Updated:** March 1, 2026
+**Last Updated:** March 2, 2026
 
 > **TestFlight Status:** Code blockers resolved. Manual submission steps remain — see `tasks/testflight-guide.md`.
 > When creating PRs, confirm TestFlight readiness is not regressed (deployment target 17.0, PrivacyInfo.xcprivacy present, UIBackgroundModes declared, build number incremented).
+
+---
+
+## Completed — Session 2026-03-02 (Issue #152: Date Calculation Bug)
+
+- [x] **#152** Fix "Today" shown for contacts touched yesterday — normalize to calendar days instead of 24-hour periods
+- [x] FrequencyCalculator: `daysSinceLastTouch()`, `status()`, `daysOverdue()` all use `startOfDay` normalization
+- [x] 3 new edge-case tests for calendar-day boundary scenarios, all pass
 
 ---
 


### PR DESCRIPTION
## Summary
- Normalize dates to start-of-day in `FrequencyCalculator` before computing day differences
- Fixes bug where contacts touched yesterday late evening showed "Today" instead of "1d ago"
- Affects `daysSinceLastTouch()`, `status()`, and `daysOverdue()` — all three now use a shared `calendarDaysBetween()` helper
- 3 new edge-case tests covering the yesterday/today boundary scenario

## Test plan
- [x] All existing tests pass (7/7 FrequencyCalculator tests)
- [x] New test: touch at 11 PM yesterday, check at 8 AM today → returns 1 day
- [x] New test: touch at 1 AM, check at 11 PM same day → returns 0 days
- [x] New test: 7 calendar days with late-evening touch → correctly triggers overdue status

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)