### PR TITLE
Fix #148: default theme to System instead of Light

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/DefaultDataSeeder.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/DefaultDataSeeder.swift
@@ -88,7 +88,7 @@ final class DefaultDataSeeder {
     private func seedAppSettings() {
         let entity = AppSettingsEntity(context: context)
         entity.id = AppSettings.singletonId
-        entity.theme = Theme.light.rawValue
+        entity.theme = Theme.system.rawValue
         entity.notificationsEnabled = false
         entity.breachTimeOfDay = LocalTime(hour: 18, minute: 0).toJsonString()
         entity.digestEnabled = false

--- a/StayInTouch/StayInTouch/Data/CoreData/Mappings/AppSettingsEntity+Mapping.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Mappings/AppSettingsEntity+Mapping.swift
@@ -11,7 +11,7 @@ extension AppSettingsEntity {
     func toDomain() -> AppSettings {
         AppSettings(
             id: id ?? AppSettings.singletonId,
-            theme: Theme(rawValue: theme ?? Theme.light.rawValue) ?? .light,
+            theme: Theme(rawValue: theme ?? Theme.system.rawValue) ?? .system,
             notificationsEnabled: notificationsEnabled,
             breachTimeOfDay: breachTimeOfDay.flatMap(LocalTime.from(jsonString:)) ?? LocalTime(hour: 18, minute: 0),
             digestEnabled: digestEnabled,


### PR DESCRIPTION
## Summary
- Change default theme from `.light` to `.system` in two locations:
  - `DefaultDataSeeder.swift`: seeds new installs with System theme
  - `AppSettingsEntity+Mapping.swift`: fallback when reading from Core Data uses System
- Existing users who explicitly chose Light are unaffected (their stored preference is preserved)

## Test plan
- [x] All existing tests pass
- [x] No test changes needed — tests use explicit `.light` values for CRUD testing, not default behavior

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)