### PR TITLE
Add VoiceOver accessibility label to TagPill (#144)

### DIFF
--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -170,6 +170,7 @@ struct TagPill: View {
             .padding(.vertical, 2)
             .background(Color(hex: colorHex).opacity(0.12))
             .clipShape(Capsule())
+            .accessibilityLabel("Tag: \(name)")
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `.accessibilityLabel("Tag: \(name)")` to TagPill in DesignSystem.swift
- VoiceOver users can now hear tag names when navigating contact cards
- Last remaining item from the #39 accessibility pass

## Test plan

- [ ] Enable VoiceOver, navigate a contact card with tags — tag names are announced clearly

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)