### PR TITLE
Standardize @MainActor usage, remove DispatchQueue.main.async (#113)

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDelegate.swift
+++ b/StayInTouch/StayInTouch/App/AppDelegate.swift
@@ -83,7 +83,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             person.snoozedUntil = nil
             person.modifiedAt = now
             try personRepo.save(person)
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 NotificationCenter.default.post(name: .personDidChange, object: personId)
             }
         } catch {

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -142,9 +142,7 @@ final class SettingsViewModel: ObservableObject {
                 }
             }
         }
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .personDidChange, object: nil)
-        }
+        NotificationCenter.default.post(name: .personDidChange, object: nil)
     }
 
     func sendTestNotification() async {

--- a/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
+++ b/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
@@ -55,7 +55,7 @@ enum ContactsSyncService {
             }
         }
 
-        DispatchQueue.main.async {
+        await MainActor.run {
             NotificationCenter.default.post(name: .contactsDidSync, object: nil)
         }
     }


### PR DESCRIPTION
## Summary

- **SettingsViewModel.swift**: Remove redundant `DispatchQueue.main.async` — class is `@MainActor`, already on main after `await`
- **ContactsSyncService.swift**: Replace `DispatchQueue.main.async` with `await MainActor.run { }` (async context, matches existing pattern in `resetAllFrequencies`)
- **AppDelegate.swift**: Replace `DispatchQueue.main.async` with `Task { @MainActor in }` (sync context, matches existing `DeepLinkRouter` pattern)

Zero `DispatchQueue.main.async` calls remain in the codebase.

## Test plan

- [x] All unit tests pass
- [x] `grep -r "DispatchQueue.main.async"` returns zero results
- [x] Manual: toggle demo mode on/off (exercises SettingsViewModel path)
- [x] Manual: sync contacts (exercises ContactsSyncService path)
- [x] Manual: tap notification action (exercises AppDelegate path)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)