### PR TITLE
Fix import dedup, denormalized fields, custom due date override

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -303,11 +303,47 @@ final class SettingsViewModel: ObservableObject {
         }
 
         // --- People classification ---
-        // Only match by internal UUID — never trust cnIdentifier from external files
-        let existingById = Dictionary(uniqueKeysWithValues: personRepository.fetchAll().map { ($0.id, $0) })
+        // Never trust cnIdentifier from external files — use address book as trusted intermediary
+        let allExistingPeople = personRepository.fetchAll()
+        let existingById = Dictionary(uniqueKeysWithValues: allExistingPeople.map { ($0.id, $0) })
+
+        // CN-based dedup: build lookup of tracked people by their CNContact identifier
+        let existingByCNId: [String: Person] = Dictionary(
+            uniqueKeysWithValues: allExistingPeople.compactMap { p in
+                guard let cn = p.cnIdentifier else { return nil }
+                return (cn, p)
+            }
+        )
+
+        // Fetch device address book contacts: normalized name → [cnIdentifier]
+        var deviceContactsByName: [String: [String]] = [:]
+        if CNContactStore.authorizationStatus(for: .contacts) == .authorized {
+            let store = CNContactStore()
+            let keys: [CNKeyDescriptor] = [
+                CNContactIdentifierKey as CNKeyDescriptor,
+                CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+                CNContactOrganizationNameKey as CNKeyDescriptor
+            ]
+            let request = CNContactFetchRequest(keysToFetch: keys)
+            try? store.enumerateContacts(with: request) { contact, _ in
+                let name = CNContactFormatter.string(from: contact, style: .fullName)
+                    ?? contact.organizationName
+                let normalized = name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalized.isEmpty else { return }
+                deviceContactsByName[normalized, default: []].append(contact.identifier)
+            }
+        }
+
+        // Name-only fallback for contacts not in address book
+        let existingTrackedByName = Dictionary(
+            grouping: allExistingPeople.filter { $0.isTracked },
+            by: { $0.displayName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
+        )
 
         var newPeople: [ExportPerson] = []
         var updatedPeople: [ExportPerson] = []
+        var remappedIds: [UUID: UUID] = [:]
+        var ambiguousPeople: [(export: ExportPerson, candidates: [Person])] = []
         var skipped = 0
         var touchEventCount = 0
 
@@ -316,11 +352,36 @@ final class SettingsViewModel: ObservableObject {
                 skipped += 1
                 continue
             }
+            let normalizedName = person.displayName.lowercased()
+                .trimmingCharacters(in: .whitespacesAndNewlines)
 
             if existingById[person.id] != nil {
+                // 1. UUID match — same app/DB
                 updatedPeople.append(person)
             } else {
-                newPeople.append(person)
+                // 2. CN match: find device contacts with this name, filter to tracked
+                let cnIds = deviceContactsByName[normalizedName] ?? []
+                let trackedMatches = cnIds.compactMap { existingByCNId[$0] }
+                    .filter { existingById[$0.id] != nil }
+                let uniqueMatches = Dictionary(grouping: trackedMatches, by: { $0.id })
+                    .values.compactMap(\.first)
+
+                if uniqueMatches.count == 1 {
+                    // Single tracked match via address book → auto-match
+                    updatedPeople.append(person)
+                    remappedIds[person.id] = uniqueMatches[0].id
+                } else if uniqueMatches.count > 1 {
+                    // Multiple tracked matches → user must disambiguate
+                    ambiguousPeople.append((export: person, candidates: uniqueMatches))
+                } else if let nameMatches = existingTrackedByName[normalizedName],
+                          nameMatches.count == 1 {
+                    // 3. Name-only fallback (contact not in address book)
+                    updatedPeople.append(person)
+                    remappedIds[person.id] = nameMatches[0].id
+                } else {
+                    // 4. No match → new contact
+                    newPeople.append(person)
+                }
             }
             touchEventCount += person.touchEvents?.count ?? 0
         }
@@ -333,7 +394,9 @@ final class SettingsViewModel: ObservableObject {
             newGroups: newGroups,
             newTags: newTags,
             groupIdMap: groupIdMap,
-            tagIdMap: tagIdMap
+            tagIdMap: tagIdMap,
+            remappedIds: remappedIds,
+            ambiguousPeople: ambiguousPeople
         )
     }
 
@@ -448,9 +511,15 @@ final class SettingsViewModel: ObservableObject {
                 sortOrder += 1
             }
 
-            // 5. Updated people — remap groupId and tagIds
-            for exportPerson in preview.updatedPeople {
-                guard var person = existingById[exportPerson.id] else { continue }
+            // 5. Updated people — use remappedIds for CN/name-matched contacts
+            // Include disambiguated people that the user resolved
+            let allUpdatedPeople: [ExportPerson] = preview.updatedPeople + preview.ambiguousPeople
+                .filter { preview.remappedIds[$0.export.id] != nil }
+                .map(\.export)
+
+            for exportPerson in allUpdatedPeople {
+                let lookupId = preview.remappedIds[exportPerson.id] ?? exportPerson.id
+                guard var person = existingById[lookupId] else { continue }
                 importedIdMap[exportPerson.id] = person.id
 
                 person.displayName = exportPerson.displayName
@@ -477,7 +546,10 @@ final class SettingsViewModel: ObservableObject {
             }
 
             // 6. Touch events — fresh UUIDs, map personId to actual saved IDs
-            let allExported = preview.newPeople + preview.updatedPeople
+            let allExported = preview.newPeople + allUpdatedPeople
+            // Track most recent event per person for denormalized field update
+            var mostRecentEvent: [UUID: ExportTouchEvent] = [:]
+
             for exportPerson in allExported {
                 guard let events = exportPerson.touchEvents,
                       let actualPersonId = importedIdMap[exportPerson.id] else { continue }
@@ -497,6 +569,36 @@ final class SettingsViewModel: ObservableObject {
                         try touchRepo.save(touchEvent)
                     } catch {
                         AppLogger.logError(error, category: AppLogger.viewModel, context: "SettingsViewModel.executeImport.touchEvents")
+                    }
+
+                    // Track most recent event per person
+                    if let current = mostRecentEvent[actualPersonId] {
+                        if event.at > current.at { mostRecentEvent[actualPersonId] = event }
+                    } else {
+                        mostRecentEvent[actualPersonId] = event
+                    }
+                }
+            }
+
+            // 7. Update denormalized fields from imported touch events
+            if !mostRecentEvent.isEmpty {
+                var denormUpdates: [Person] = []
+                for (personId, recentEvent) in mostRecentEvent {
+                    guard var person = peopleRepo.fetch(id: personId) else { continue }
+                    // Only update if imported event is more recent than stored
+                    if person.lastTouchAt == nil || recentEvent.at > (person.lastTouchAt ?? .distantPast) {
+                        person.lastTouchAt = recentEvent.at
+                        person.lastTouchMethod = TouchMethod(rawValue: recentEvent.method)
+                        person.lastTouchNotes = recentEvent.notes
+                        person.modifiedAt = now
+                        denormUpdates.append(person)
+                    }
+                }
+                if !denormUpdates.isEmpty {
+                    do {
+                        try peopleRepo.batchSave(denormUpdates)
+                    } catch {
+                        AppLogger.logError(error, category: AppLogger.viewModel, context: "SettingsViewModel.executeImport.denorm")
                     }
                 }
             }
@@ -842,9 +944,13 @@ struct ImportPreview {
     let newTags: [ExportTag]
     let groupIdMap: [UUID: UUID]
     let tagIdMap: [UUID: UUID]
+    /// Maps export person UUID → existing tracked Person UUID (auto-matched via address book or name)
+    var remappedIds: [UUID: UUID]
+    /// Imported people that matched multiple tracked contacts — user must disambiguate
+    let ambiguousPeople: [(export: ExportPerson, candidates: [Person])]
 
-    var totalPeople: Int { newPeople.count + updatedPeople.count }
-    var isEmpty: Bool { newPeople.isEmpty && updatedPeople.isEmpty && newGroups.isEmpty && newTags.isEmpty }
+    var totalPeople: Int { newPeople.count + updatedPeople.count + ambiguousPeople.count }
+    var isEmpty: Bool { newPeople.isEmpty && updatedPeople.isEmpty && ambiguousPeople.isEmpty && newGroups.isEmpty && newTags.isEmpty }
 }
 
 struct ImportResult {

--- a/StayInTouch/StayInTouch/UI/Views/Settings/ImportPreviewView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/ImportPreviewView.swift
@@ -9,8 +9,25 @@ import SwiftUI
 
 struct ImportPreviewView: View {
     let preview: ImportPreview
-    let onImport: () -> Void
+    let onImport: (ImportPreview) -> Void
     let onCancel: () -> Void
+
+    /// User's disambiguation choices: export person UUID → chosen tracked Person UUID
+    @State private var disambiguationChoices: [UUID: UUID] = [:]
+
+    private var allDisambiguated: Bool {
+        preview.ambiguousPeople.allSatisfy { disambiguationChoices[$0.export.id] != nil }
+    }
+
+    private var resolvedPreview: ImportPreview {
+        var resolved = preview
+        for (exportPerson, _) in preview.ambiguousPeople {
+            if let chosenId = disambiguationChoices[exportPerson.id] {
+                resolved.remappedIds[exportPerson.id] = chosenId
+            }
+        }
+        return resolved
+    }
 
     var body: some View {
         NavigationStack {
@@ -52,11 +69,15 @@ struct ImportPreviewView: View {
                 }
 
                 if !preview.updatedPeople.isEmpty {
-                    Section("Existing Contacts (\(preview.updatedPeople.count))") {
+                    Section("Matched Contacts (\(preview.updatedPeople.count))") {
                         ForEach(preview.updatedPeople, id: \.id) { person in
                             Label(person.displayName, systemImage: "arrow.triangle.2.circlepath")
                         }
                     }
+                }
+
+                if !preview.ambiguousPeople.isEmpty {
+                    disambiguationSection
                 }
             }
             .listStyle(.insetGrouped)
@@ -67,13 +88,15 @@ struct ImportPreviewView: View {
                     Button("Cancel", action: onCancel)
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Import", action: onImport)
+                    Button("Import") { onImport(resolvedPreview) }
                         .bold()
-                        .disabled(preview.isEmpty)
+                        .disabled(preview.isEmpty || !allDisambiguated)
                 }
             }
         }
     }
+
+    // MARK: - Summary
 
     private var summarySection: some View {
         Section {
@@ -85,6 +108,10 @@ struct ImportPreviewView: View {
                 Label("\(preview.updatedPeople.count) existing contact\(preview.updatedPeople.count == 1 ? "" : "s") will be updated", systemImage: "arrow.triangle.2.circlepath.circle.fill")
                     .foregroundStyle(DS.Colors.accent)
             }
+            if !preview.ambiguousPeople.isEmpty {
+                Label("\(preview.ambiguousPeople.count) contact\(preview.ambiguousPeople.count == 1 ? "" : "s") need\(preview.ambiguousPeople.count == 1 ? "s" : "") your selection", systemImage: "questionmark.circle.fill")
+                    .foregroundStyle(DS.Colors.statusDueSoon)
+            }
             if !preview.newGroups.isEmpty {
                 Label("\(preview.newGroups.count) new frequenc\(preview.newGroups.count == 1 ? "y" : "ies") will be created", systemImage: "clock.badge.checkmark.fill")
                     .foregroundStyle(DS.Colors.accent)
@@ -94,7 +121,7 @@ struct ImportPreviewView: View {
                     .foregroundStyle(DS.Colors.accent)
             }
             if preview.touchEventCount > 0 {
-                Label("\(preview.touchEventCount) touch event\(preview.touchEventCount == 1 ? "" : "s") will be imported", systemImage: "hand.tap.fill")
+                Label("\(preview.touchEventCount) activit\(preview.touchEventCount == 1 ? "y" : "ies") will be imported", systemImage: "hand.tap.fill")
                     .foregroundStyle(DS.Colors.statusDueSoon)
             }
             if preview.skippedCount > 0 {
@@ -107,4 +134,66 @@ struct ImportPreviewView: View {
             }
         }
     }
+
+    // MARK: - Disambiguation Helpers
+
+    private var disambiguationSection: some View {
+        let items = preview.ambiguousPeople.map {
+            AmbiguousItem(exportPerson: $0.export, candidates: $0.candidates)
+        }
+        return Section("Select Matching Contact") {
+            Text("The following imported contacts match multiple people you're tracking. Select which contact to update for each.")
+                .font(DS.Typography.caption)
+                .foregroundStyle(DS.Colors.secondaryText)
+
+            ForEach(items) { item in
+                disambiguationRow(item: item)
+            }
+        }
+    }
+
+    private func disambiguationRow(item: AmbiguousItem) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(item.exportPerson.displayName)
+                .font(DS.Typography.contactName)
+
+            Menu {
+                ForEach(item.candidates, id: \.id) { candidate in
+                    Button(candidateLabel(candidate)) {
+                        disambiguationChoices[item.exportPerson.id] = candidate.id
+                    }
+                }
+            } label: {
+                HStack {
+                    if let chosenId = disambiguationChoices[item.exportPerson.id],
+                       let chosen = item.candidates.first(where: { $0.id == chosenId }) {
+                        Text(candidateLabel(chosen))
+                            .foregroundStyle(DS.Colors.primaryText)
+                    } else {
+                        Text("Select a contact...")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(DS.Colors.secondaryText)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func candidateLabel(_ person: Person) -> String {
+        var parts = [person.displayName]
+        if let method = person.lastTouchMethod {
+            parts.append("Last: \(method.rawValue)")
+        }
+        return parts.joined(separator: " \u{2022} ")
+    }
+}
+
+private struct AmbiguousItem: Identifiable {
+    let exportPerson: ExportPerson
+    let candidates: [Person]
+    var id: UUID { exportPerson.id }
 }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -166,11 +166,11 @@ struct SettingsView: View {
             if let preview = importPreview {
                 ImportPreviewView(
                     preview: preview,
-                    onImport: {
+                    onImport: { resolvedPreview in
                         showImportPreview = false
                         Task {
                             isImporting = true
-                            let result = await viewModel.executeImport(preview)
+                            let result = await viewModel.executeImport(resolvedPreview)
 
                             // Attempt contact matching for newly imported people
                             if !result.importedPeople.isEmpty {

--- a/StayInTouch/StayInTouch/UseCases/FrequencyCalculator.swift
+++ b/StayInTouch/StayInTouch/UseCases/FrequencyCalculator.swift
@@ -63,10 +63,11 @@ struct FrequencyCalculator {
 
         let customDue = person.customDueDate.map { cal.startOfDay(for: $0) }
 
+        // Custom due date fully replaces group frequency when set.
+        // It does not combine with group — it IS the due date.
         switch (groupDueDate, customDue) {
-        case let (g?, c?): return min(g, c)
-        case let (g?, nil): return g
-        case let (nil, c?): return c
+        case (_, let c?): return c
+        case (let g?, nil): return g
         case (nil, nil): return nil
         }
     }

--- a/StayInTouch/StayInTouchTests/FrequencyCalculatorTests.swift
+++ b/StayInTouch/StayInTouchTests/FrequencyCalculatorTests.swift
@@ -310,20 +310,20 @@ final class FrequencyCalculatorTests: XCTestCase {
         XCTAssertEqual(status, .dueSoon, "Custom due date tomorrow should override group due date (4 days remaining)")
     }
 
-    func testCustomDueDateLaterThanGroupDoesNotReduceUrgency() {
+    func testCustomDueDateFullyOverridesGroupFrequency() {
         let now = Date()
         let cal = Calendar.current
         let groupId = UUID()
-        // Last touch 8 days ago — already overdue for 7-day group
+        // Last touch 8 days ago — would be overdue for 7-day group
         let lastTouch = cal.date(byAdding: .day, value: -8, to: now)!
-        // Custom due date far in the future
+        // Custom due date far in the future — fully replaces group frequency
         let customDue = cal.date(byAdding: .day, value: 30, to: now)!
 
         let person = TestFactory.makePerson(groupId: groupId, lastTouchAt: lastTouch, customDueDate: customDue)
         let group = Group(id: groupId, name: "Weekly", frequencyDays: 7, warningDays: 2, colorHex: nil, isDefault: true, sortOrder: 0, createdAt: now, modifiedAt: now)
 
         let status = FrequencyCalculator(referenceDate: now).status(for: person, in: [group])
-        XCTAssertEqual(status, .overdue, "Custom due date in the future should not mask group-based overdue status")
+        XCTAssertEqual(status, .onTrack, "Custom due date fully overrides group frequency — 30 days out means on track")
     }
 
     func testNoLastTouchWithCustomDueDateDerivesStatus() {
@@ -365,12 +365,13 @@ final class FrequencyCalculatorTests: XCTestCase {
         XCTAssertEqual(FrequencyCalculator(referenceDate: now).status(for: person, in: [group]), .onTrack)
     }
 
-    func testEffectiveDueDateReturnsMinOfGroupAndCustom() {
+    func testEffectiveDueDateReturnsCustomDateWhenSet() {
         let now = Date()
         let cal = Calendar.current
         let groupId = UUID()
         let lastTouch = cal.date(byAdding: .day, value: -3, to: now)!
-        let customDue = cal.date(byAdding: .day, value: 1, to: now)!
+        // Custom due is later than group due — custom still wins (full override)
+        let customDue = cal.date(byAdding: .day, value: 20, to: now)!
 
         let person = TestFactory.makePerson(groupId: groupId, lastTouchAt: lastTouch, customDueDate: customDue)
         let group = Group(id: groupId, name: "Weekly", frequencyDays: 7, warningDays: 2, colorHex: nil, isDefault: true, sortOrder: 0, createdAt: now, modifiedAt: now)
@@ -378,6 +379,26 @@ final class FrequencyCalculatorTests: XCTestCase {
         let calc = FrequencyCalculator(referenceDate: now)
         let dueDate = calc.effectiveDueDate(for: person, in: [group])
         XCTAssertNotNil(dueDate)
-        XCTAssertEqual(cal.startOfDay(for: dueDate!), cal.startOfDay(for: customDue))
+        XCTAssertEqual(cal.startOfDay(for: dueDate!), cal.startOfDay(for: customDue),
+                        "Custom due date should be returned regardless of group frequency")
+    }
+
+    func testCustomDueDateFullyOverridesFrequencyWhenOverdue() {
+        let now = Date()
+        let cal = Calendar.current
+        let groupId = UUID()
+        // Last touch 14 days ago — way overdue for 7-day group
+        let lastTouch = cal.date(byAdding: .day, value: -14, to: now)!
+        // Custom due date 10 days out — this IS the due date now
+        let customDue = cal.date(byAdding: .day, value: 10, to: now)!
+
+        let person = TestFactory.makePerson(groupId: groupId, lastTouchAt: lastTouch, customDueDate: customDue)
+        let group = Group(id: groupId, name: "Weekly", frequencyDays: 7, warningDays: 2, colorHex: nil, isDefault: true, sortOrder: 0, createdAt: now, modifiedAt: now)
+
+        let calc = FrequencyCalculator(referenceDate: now)
+        XCTAssertEqual(calc.status(for: person, in: [group]), .onTrack,
+                        "Person overdue by frequency but custom due date 10 days out should show on track")
+        XCTAssertEqual(calc.daysOverdue(for: person, in: [group]), 0,
+                        "No days overdue when custom due date is in the future")
     }
 }

--- a/StayInTouch/StayInTouchTests/SettingsViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/SettingsViewModelTests.swift
@@ -338,4 +338,192 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tagsCount, 2)
         XCTAssertEqual(sut.pausedCount, 1)
     }
+
+    // MARK: - Import Dedup (Name-Based Fallback)
+
+    func testReimportByNameDoesNotCreateDuplicate() throws {
+        // Existing tracked person with unique name
+        let existingId = UUID()
+        personRepo.people = [TestFactory.makePerson(id: existingId, name: "Alice Smith")]
+        sut = SettingsViewModel(
+            settingsRepository: settingsRepo,
+            groupRepository: groupRepo,
+            tagRepository: tagRepo,
+            personRepository: personRepo,
+            touchEventRepository: touchEventRepo
+        )
+
+        // Import file has same name but different UUID (simulating re-export/re-import)
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [ExportPerson(
+                id: UUID(), // Different UUID
+                displayName: "Alice Smith",
+                groupId: nil,
+                groupName: nil,
+                tagIds: [],
+                tagNames: [],
+                lastTouchAt: nil,
+                isPaused: false,
+                createdAt: Date(),
+                modifiedAt: Date(),
+                touchEvents: nil,
+                birthday: nil
+            )]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-name-test.json")
+        try data.write(to: url, options: .atomic)
+
+        let preview = sut.parseImportFile(url: url)
+
+        XCTAssertNotNil(preview)
+        // Name-only fallback: single tracked person with name "Alice Smith" → auto-match
+        XCTAssertTrue(preview?.newPeople.isEmpty ?? false, "Should NOT create new person — matched by name")
+        XCTAssertEqual(preview?.updatedPeople.count, 1, "Should classify as updated person")
+        XCTAssertEqual(preview?.remappedIds.values.first, existingId, "Should remap to existing person ID")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testReimportWithDuplicateNamesCreatesNew() throws {
+        // Two tracked people with the same name
+        personRepo.people = [
+            TestFactory.makePerson(name: "John Smith"),
+            TestFactory.makePerson(name: "John Smith")
+        ]
+        sut = SettingsViewModel(
+            settingsRepository: settingsRepo,
+            groupRepository: groupRepo,
+            tagRepository: tagRepo,
+            personRepository: personRepo,
+            touchEventRepository: touchEventRepo
+        )
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [ExportPerson(
+                id: UUID(),
+                displayName: "John Smith",
+                groupId: nil,
+                groupName: nil,
+                tagIds: [],
+                tagNames: [],
+                lastTouchAt: nil,
+                isPaused: false,
+                createdAt: Date(),
+                modifiedAt: Date(),
+                touchEvents: nil,
+                birthday: nil
+            )]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-ambiguous-test.json")
+        try data.write(to: url, options: .atomic)
+
+        let preview = sut.parseImportFile(url: url)
+
+        XCTAssertNotNil(preview)
+        // Two tracked "John Smith" and no CN match in test env → classified as new (not ambiguous,
+        // because CN matching requires contacts access which tests don't have)
+        XCTAssertEqual(preview?.newPeople.count, 1, "Ambiguous name without CN match → new contact")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testReimportByUUIDMatchClassifiesAsUpdated() throws {
+        let existingId = UUID()
+        personRepo.people = [TestFactory.makePerson(id: existingId, name: "Bob")]
+        sut = SettingsViewModel(
+            settingsRepository: settingsRepo,
+            groupRepository: groupRepo,
+            tagRepository: tagRepo,
+            personRepository: personRepo,
+            touchEventRepository: touchEventRepo
+        )
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [ExportPerson(
+                id: existingId, // Same UUID
+                displayName: "Bob",
+                groupId: nil,
+                groupName: nil,
+                tagIds: [],
+                tagNames: [],
+                lastTouchAt: nil,
+                isPaused: false,
+                createdAt: Date(),
+                modifiedAt: Date(),
+                touchEvents: nil,
+                birthday: nil
+            )]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-uuid-test.json")
+        try data.write(to: url, options: .atomic)
+
+        let preview = sut.parseImportFile(url: url)
+
+        XCTAssertNotNil(preview)
+        XCTAssertTrue(preview?.newPeople.isEmpty ?? false)
+        XCTAssertEqual(preview?.updatedPeople.count, 1, "UUID match → updated person")
+        // No remapping needed for UUID match
+        XCTAssertTrue(preview?.remappedIds.isEmpty ?? false)
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testImportPreviewIncludesTouchEventCount() throws {
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [ExportPerson(
+                id: UUID(),
+                displayName: "Eve",
+                groupId: nil,
+                groupName: nil,
+                tagIds: [],
+                tagNames: [],
+                lastTouchAt: Date(),
+                isPaused: false,
+                createdAt: Date(),
+                modifiedAt: Date(),
+                touchEvents: [
+                    ExportTouchEvent(id: UUID(), at: Date(), method: "call", notes: "Caught up"),
+                    ExportTouchEvent(id: UUID(), at: Date(), method: "message", notes: nil)
+                ],
+                birthday: nil
+            )]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("events-count-test.json")
+        try data.write(to: url, options: .atomic)
+
+        let preview = sut.parseImportFile(url: url)
+
+        XCTAssertNotNil(preview)
+        XCTAssertEqual(preview?.touchEventCount, 2)
+
+        try? FileManager.default.removeItem(at: url)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during testing of PR #159 (custom due dates):

- **Custom due date fully overrides group frequency**: Previously used `min(customDueDate, groupDueDate)` — now custom date completely replaces group frequency when set
- **Import dedup via address book matching**: Re-importing the same file no longer creates duplicates. Uses device address book as trusted intermediary (CN match → tracked contact), with name-only fallback and disambiguation picker for ambiguous matches
- **Denormalized fields updated after import**: `lastTouchMethod` and `lastTouchNotes` are now populated from imported touch events (previously hardcoded nil)

Also renames "touch events" to "activities" in the import preview UI.

## Changes

| File | Change |
|------|--------|
| `FrequencyCalculator.swift` | Full override when customDueDate set |
| `SettingsViewModel.swift` | CN/name dedup in parseImportFile, remapped IDs in executeImport, denormalized field update |
| `ImportPreviewView.swift` | Disambiguation picker, "activities" copy, updated onImport signature |
| `SettingsView.swift` | Updated ImportPreviewView call site |
| `FrequencyCalculatorTests.swift` | Updated 2 tests, added 1 new for full override |
| `SettingsViewModelTests.swift` | 4 new import dedup tests |

## Test plan

- [x] All existing tests pass
- [x] New FrequencyCalculator tests verify full override behavior
- [x] New SettingsViewModel tests verify name-based dedup, UUID match, and touch event count
- [ ] Manual: Export contacts with activities → re-import → no duplicates, activities visible
- [ ] Manual: Set custom due date on overdue-by-frequency contact → status shows on track
- [ ] Manual: Import file with ambiguous names → disambiguation picker appears


🤖 Generated with [Claude Code](https://claude.com/claude-code)