### PR TITLE
Fix import dedup bugs: .limited auth, Dictionary crash, main thread (#162)

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -225,7 +225,13 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
-    func parseImportFile(url: URL) -> ImportPreview? {
+    private static func touchEventDedupKey(personId: UUID, date: Date, method: TouchMethod, notes: String?, calendar: Calendar) -> String {
+        let dayKey = Int(calendar.startOfDay(for: date).timeIntervalSince1970)
+        let notesKey = (notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(personId)-\(dayKey)-\(method.rawValue)-\(notesKey)"
+    }
+
+    func parseImportFile(url: URL) async -> ImportPreview? {
         guard url.startAccessingSecurityScopedResource() else { return nil }
         defer { url.stopAccessingSecurityScopedResource() }
 
@@ -309,15 +315,26 @@ final class SettingsViewModel: ObservableObject {
 
         // CN-based dedup: build lookup of tracked people by their CNContact identifier
         let existingByCNId: [String: Person] = Dictionary(
-            uniqueKeysWithValues: allExistingPeople.compactMap { p in
+            allExistingPeople.compactMap { p in
                 guard let cn = p.cnIdentifier else { return nil }
                 return (cn, p)
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
 
         // Fetch device address book contacts: normalized name → [cnIdentifier]
-        var deviceContactsByName: [String: [String]] = [:]
-        if CNContactStore.authorizationStatus(for: .contacts) == .authorized {
+        // Run on background thread to avoid blocking main thread for large contact lists
+        let hasContactsAccess: Bool = {
+            switch CNContactStore.authorizationStatus(for: .contacts) {
+            case .authorized, .limited: return true
+            default: return false
+            }
+        }()
+        let deviceContactsByName: [String: [String]] = await Task.detached {
+            guard hasContactsAccess else {
+                return [:]
+            }
+            var result: [String: [String]] = [:]
             let store = CNContactStore()
             let keys: [CNKeyDescriptor] = [
                 CNContactIdentifierKey as CNKeyDescriptor,
@@ -330,9 +347,10 @@ final class SettingsViewModel: ObservableObject {
                     ?? contact.organizationName
                 let normalized = name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !normalized.isEmpty else { return }
-                deviceContactsByName[normalized, default: []].append(contact.identifier)
+                result[normalized, default: []].append(contact.identifier)
             }
-        }
+            return result
+        }.value
 
         // Name-only fallback for contacts not in address book
         let existingTrackedByName = Dictionary(
@@ -397,9 +415,7 @@ final class SettingsViewModel: ObservableObject {
             guard existingById[actualPersonId] != nil else { continue }
             let existing = touchEventRepository.fetchAll(for: actualPersonId)
             for e in existing {
-                let dayKey = Int(calendar.startOfDay(for: e.at).timeIntervalSince1970)
-                let notesKey = (e.notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                existingEventKeys.insert("\(actualPersonId)-\(dayKey)-\(e.method.rawValue)-\(notesKey)")
+                existingEventKeys.insert(Self.touchEventDedupKey(personId: actualPersonId, date: e.at, method: e.method, notes: e.notes, calendar: calendar))
             }
         }
 
@@ -409,9 +425,7 @@ final class SettingsViewModel: ObservableObject {
             let actualPersonId = remappedIds[exportPerson.id] ?? exportPerson.id
             for event in events {
                 let method = TouchMethod(rawValue: event.method) ?? .other
-                let dayKey = Int(calendar.startOfDay(for: event.at).timeIntervalSince1970)
-                let notesKey = (event.notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                let key = "\(actualPersonId)-\(dayKey)-\(method.rawValue)-\(notesKey)"
+                let key = Self.touchEventDedupKey(personId: actualPersonId, date: event.at, method: method, notes: event.notes, calendar: calendar)
                 if !existingEventKeys.contains(key) {
                     newTouchEventCount += 1
                     existingEventKeys.insert(key)
@@ -595,9 +609,7 @@ final class SettingsViewModel: ObservableObject {
                 guard let actualPersonId = importedIdMap[exportPerson.id] else { continue }
                 let existing = touchRepo.fetchAll(for: actualPersonId)
                 for e in existing {
-                    let dayKey = Int(calendar.startOfDay(for: e.at).timeIntervalSince1970)
-                    let notesKey = (e.notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                    existingEventKeys.insert("\(actualPersonId)-\(dayKey)-\(e.method.rawValue)-\(notesKey)")
+                    existingEventKeys.insert(SettingsViewModel.touchEventDedupKey(personId: actualPersonId, date: e.at, method: e.method, notes: e.notes, calendar: calendar))
                 }
             }
 
@@ -606,9 +618,7 @@ final class SettingsViewModel: ObservableObject {
                       let actualPersonId = importedIdMap[exportPerson.id] else { continue }
                 for event in events {
                     let method = TouchMethod(rawValue: event.method) ?? .other
-                    let dayKey = Int(calendar.startOfDay(for: event.at).timeIntervalSince1970)
-                    let notesKey = (event.notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                    let key = "\(actualPersonId)-\(dayKey)-\(method.rawValue)-\(notesKey)"
+                    let key = SettingsViewModel.touchEventDedupKey(personId: actualPersonId, date: event.at, method: method, notes: event.notes, calendar: calendar)
 
                     guard !existingEventKeys.contains(key) else { continue }
                     existingEventKeys.insert(key)

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -150,12 +150,14 @@ struct SettingsView: View {
         .fileImporter(isPresented: $showFilePicker, allowedContentTypes: [UTType.json]) { result in
             switch result {
             case .success(let url):
-                if let preview = viewModel.parseImportFile(url: url) {
-                    importPreview = preview
-                    showImportPreview = true
-                } else {
-                    importResultMessage = "Could not read the file. Make sure it is a valid Keep In Touch export."
-                    showImportErrorAlert = true
+                Task {
+                    if let preview = await viewModel.parseImportFile(url: url) {
+                        importPreview = preview
+                        showImportPreview = true
+                    } else {
+                        importResultMessage = "Could not read the file. Make sure it is a valid Keep In Touch export."
+                        showImportErrorAlert = true
+                    }
                 }
             case .failure:
                 importResultMessage = "Could not open the file."

--- a/StayInTouch/StayInTouchTests/SettingsViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/SettingsViewModelTests.swift
@@ -127,7 +127,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testParseImportFileLegacyFormat() throws {
+    func testParseImportFileLegacyFormat() async throws {
         // Create a legacy-format JSON ([ExportPerson] array)
         let legacyPeople = [
             ExportPerson(
@@ -151,7 +151,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("legacy-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         XCTAssertEqual(preview?.newPeople.count, 1)
@@ -161,7 +161,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testParseImportFileNewFormatWithGroups() throws {
+    func testParseImportFileNewFormatWithGroups() async throws {
         let groupId = UUID()
         let tagId = UUID()
         let exportData = ExportData(
@@ -190,7 +190,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("new-format-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         XCTAssertEqual(preview?.newPeople.count, 1)
@@ -202,7 +202,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testImportMergesGroupsByName() throws {
+    func testImportMergesGroupsByName() async throws {
         // Set up existing group "Weekly"
         let existingGroupId = UUID()
         groupRepo.groups = [TestFactory.makeGroup(id: existingGroupId, name: "Weekly")]
@@ -241,7 +241,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("merge-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         // "weekly" matches existing "Weekly" — no new group created
@@ -341,7 +341,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - Import Dedup (Name-Based Fallback)
 
-    func testReimportByNameDoesNotCreateDuplicate() throws {
+    func testReimportByNameDoesNotCreateDuplicate() async throws {
         // Existing tracked person with unique name
         let existingId = UUID()
         personRepo.people = [TestFactory.makePerson(id: existingId, name: "Alice Smith")]
@@ -380,7 +380,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-name-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         // Name-only fallback: single tracked person with name "Alice Smith" → auto-match
@@ -391,7 +391,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testReimportWithDuplicateNamesCreatesNew() throws {
+    func testReimportWithDuplicateNamesCreatesNew() async throws {
         // Two tracked people with the same name
         personRepo.people = [
             TestFactory.makePerson(name: "John Smith"),
@@ -431,7 +431,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-ambiguous-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         // Two tracked "John Smith" and no CN match in test env → classified as new (not ambiguous,
@@ -441,7 +441,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testReimportByUUIDMatchClassifiesAsUpdated() throws {
+    func testReimportByUUIDMatchClassifiesAsUpdated() async throws {
         let existingId = UUID()
         personRepo.people = [TestFactory.makePerson(id: existingId, name: "Bob")]
         sut = SettingsViewModel(
@@ -478,7 +478,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-uuid-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         XCTAssertTrue(preview?.newPeople.isEmpty ?? false)
@@ -489,7 +489,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testReimportDoesNotCountExistingTouchEventsAsNew() throws {
+    func testReimportDoesNotCountExistingTouchEventsAsNew() async throws {
         let personId = UUID()
         let cal = Calendar.current
         let touchDate = cal.date(byAdding: .day, value: -3, to: Date())!
@@ -547,7 +547,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("dedup-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         XCTAssertEqual(preview?.touchEventCount, 1, "File contains 1 total event")
@@ -557,7 +557,7 @@ final class SettingsViewModelTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testImportPreviewIncludesTouchEventCount() throws {
+    func testImportPreviewIncludesTouchEventCount() async throws {
         let exportData = ExportData(
             version: 2,
             exportedAt: Date(),
@@ -587,7 +587,7 @@ final class SettingsViewModelTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("events-count-test.json")
         try data.write(to: url, options: .atomic)
 
-        let preview = sut.parseImportFile(url: url)
+        let preview = await sut.parseImportFile(url: url)
 
         XCTAssertNotNil(preview)
         XCTAssertEqual(preview?.touchEventCount, 2)


### PR DESCRIPTION
## Summary

Fixes four import dedup issues identified in post-hoc code review of PR #161:

- **`.limited` contacts auth excluded from CN dedup** — `parseImportFile()` now accepts both `.authorized` and `.limited`, matching the existing pattern in `matchImportedContacts()`
- **`Dictionary(uniqueKeysWithValues:)` crash** — replaced with `uniquingKeysWith: { first, _ in first }` to handle duplicate `cnIdentifier` after contacts merge/unmerge
- **Synchronous `enumerateContacts` on `@MainActor`** — moved to `Task.detached` to avoid blocking main thread for users with large contact lists
- **Duplicated dedup key construction** — extracted `touchEventDedupKey()` static helper used by both `parseImportFile()` and `executeImport()`

Closes #162

## Test plan

- [x] All existing tests pass (8 import tests updated to async)
- [x] Build succeeds on iOS 17.0+ (`.limited` handled via switch for availability)
- [ ] Manual: Import on device with limited contacts access — verify CN dedup works

🤖 Generated with [Claude Code](https://claude.ai/code)