### PR TITLE
Reorganize Settings view into 6 logical sections (#147)

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -350,7 +350,7 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .padding(.leading, 16)
+                .padding(.leading, DS.Spacing.lg)
             }
 
             Toggle(isOn: Binding(
@@ -372,7 +372,7 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .padding(.leading, 16)
+                .padding(.leading, DS.Spacing.lg)
 
                 Button {
                     showDigestTimePicker = true
@@ -384,7 +384,7 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .padding(.leading, 16)
+                .padding(.leading, DS.Spacing.lg)
             }
 
             Picker("Reminder Grouping", selection: Binding(
@@ -448,7 +448,11 @@ struct SettingsView: View {
                 Text("Your relationship data never leaves your phone. Anonymous usage statistics help us improve the app.")
                 VStack(spacing: DS.Spacing.sm) {
                     Text("Keep In Touch \(appVersion)")
+                        .font(DS.Typography.caption)
+                        .foregroundStyle(DS.Colors.secondaryText)
                     Text("Privacy-first personal CRM")
+                        .font(DS.Typography.caption)
+                        .foregroundStyle(DS.Colors.secondaryText)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.top, DS.Spacing.sm)


### PR DESCRIPTION
## Summary
- Restructures Settings from 8 confusing sections into 6 intuitive ones: **Appearance**, **People**, **Notifications**, **Data**, **About**, **Danger Zone**
- Groups people-related settings together (Frequencies, Groups, Paused Contacts, Add from Contacts)
- Nests conditional notification settings under their parent toggles with leading indentation
- Isolates Fresh Start in a visually distinct "Danger Zone" section with red header
- Collapses Privacy + Advanced + About into a single "About" section

## Test plan
- [ ] Build succeeds with zero errors
- [ ] All existing unit + UI tests pass
- [ ] Settings screen shows 6 sections in correct order
- [ ] "People" section contains Manage Frequencies, Manage Groups, Paused Contacts, Add from Contacts
- [ ] Notification conditional rows (Reminder Time, Digest Day/Time) appear indented under their parent toggles
- [ ] "Data" section shows only Export and Import
- [ ] "About" section shows analytics toggle, advanced link, privacy footer, and version
- [ ] "Danger Zone" shows Fresh Start with red header
- [ ] All navigation links still navigate to correct destinations
- [ ] All toggles and pickers still function correctly

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)