### PR TITLE
Replace N+1 loop saves with batchSave (#112)

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
@@ -86,17 +86,20 @@ final class ManageGroupsViewModel: ObservableObject {
 
     func movePeople(from group: Group, to defaultGroup: Group) {
         let people = personRepository.fetchByGroup(id: group.id, includePaused: true)
-        for person in people {
+        guard !people.isEmpty else { return }
+        let now = Date()
+        let updatedPeople = people.map { person -> Person in
             var updated = person
             updated.groupId = defaultGroup.id
-            updated.groupAddedAt = Date()
-            updated.modifiedAt = Date()
-            do {
-                try personRepository.save(updated)
-            } catch {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.movePeople")
-                ErrorToastManager.shared.show(.saveFailed("ManageGroups"))
-            }
+            updated.groupAddedAt = now
+            updated.modifiedAt = now
+            return updated
+        }
+        do {
+            try personRepository.batchSave(updatedPeople)
+        } catch {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.movePeople")
+            ErrorToastManager.shared.show(.saveFailed("ManageGroups"))
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageTagsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageTagsViewModel.swift
@@ -67,16 +67,20 @@ final class ManageTagsViewModel: ObservableObject {
 
     func removeTagFromPeople(tagId: UUID) {
         let people = personRepository.fetchTracked(includePaused: true)
+        let now = Date()
+        var updatedPeople: [Person] = []
         for person in people where person.tagIds.contains(tagId) {
             var updated = person
             updated.tagIds = updated.tagIds.filter { $0 != tagId }
-            updated.modifiedAt = Date()
-            do {
-                try personRepository.save(updated)
-            } catch {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageTagsViewModel.removeTagFromPeople")
-                ErrorToastManager.shared.show(.saveFailed("ManageTags"))
-            }
+            updated.modifiedAt = now
+            updatedPeople.append(updated)
+        }
+        guard !updatedPeople.isEmpty else { return }
+        do {
+            try personRepository.batchSave(updatedPeople)
+        } catch {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageTagsViewModel.removeTagFromPeople")
+            ErrorToastManager.shared.show(.saveFailed("ManageTags"))
         }
     }
 }

--- a/StayInTouch/StayInTouchTests/ManageGroupsViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/ManageGroupsViewModelTests.swift
@@ -54,6 +54,20 @@ final class ManageGroupsViewModelTests: XCTestCase {
                        "Group should be removed from repository")
     }
 
+    func testDeleteGroupUsesBatchSave() {
+        let person1 = TestFactory.makePerson(name: "Alice", groupId: customGroup.id)
+        let person2 = TestFactory.makePerson(name: "Bob", groupId: customGroup.id)
+        personRepo.people = [person1, person2]
+
+        sut.delete(group: customGroup)
+
+        XCTAssertEqual(personRepo.batchSaveCallCount, 1,
+                       "Should use single batchSave instead of individual saves")
+        let reassigned = personRepo.savedPersons.filter { $0.groupId == defaultGroup.id }
+        XCTAssertEqual(reassigned.count, 2,
+                       "Both people should be reassigned via batch save")
+    }
+
     func testDeleteGroupWithNoPeopleJustDeletes() {
         personRepo.people = []
 

--- a/StayInTouch/StayInTouchTests/ManageTagsViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/ManageTagsViewModelTests.swift
@@ -56,6 +56,20 @@ final class ManageTagsViewModelTests: XCTestCase {
                        "Tag should be removed from repository")
     }
 
+    func testDeleteTagUsesBatchSave() {
+        let groupId = UUID()
+        let person1 = TestFactory.makePerson(name: "Alice", groupId: groupId, tagIds: [tag.id])
+        let person2 = TestFactory.makePerson(name: "Bob", groupId: groupId, tagIds: [tag.id])
+        personRepo.people = [person1, person2]
+
+        sut.delete(tag: tag)
+
+        XCTAssertEqual(personRepo.batchSaveCallCount, 1,
+                       "Should use single batchSave instead of individual saves")
+        XCTAssertEqual(personRepo.savedPersons.count, 2,
+                       "Both people should still be updated")
+    }
+
     func testDeleteTagRemovesFromPeopleBeforeDeleting() {
         // Verify order: removeTagFromPeople runs before tagRepository.delete
         // After delete, tag should be gone AND people should be cleaned

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
@@ -41,7 +41,9 @@ final class MockPersonRepository: PersonRepository {
             people.append(person)
         }
     }
+    var batchSaveCallCount = 0
     func batchSave(_ persons: [Person]) throws {
+        batchSaveCallCount += 1
         for person in persons {
             try save(person)
         }


### PR DESCRIPTION
## Summary

- Replace N individual `personRepository.save()` calls with single `personRepository.batchSave()` in `ManageTagsViewModel.removeTagFromPeople()` and `ManageGroupsViewModel.movePeople()`
- Deleting a tag used by 50 people now triggers 1 Core Data save instead of 50
- Deleting a group with 20 people now triggers 1 save instead of 20

## What's NOT Changed (and Why)

- **SettingsViewModel toggles** — each is a single user action on a singleton entity; debounce adds async complexity for zero gain
- **PersonDetailViewModel tag add/remove** — each requires a user tap; not rapid-fire

## Test plan

- [x] Build succeeds
- [x] All existing tests pass (no regressions)
- [x] New: `testDeleteTagUsesBatchSave` — verifies `batchSaveCallCount == 1`
- [x] New: `testDeleteGroupUsesBatchSave` — verifies `batchSaveCallCount == 1`

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)