### PR TITLE
Add design system tokens for UX redesign (#171)

### DIFF
--- a/StayInTouch/StayInTouch/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/StayInTouch/StayInTouch/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,33 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4F",
+          "green" : "0x6B",
+          "red" : "0x3D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4F",
+          "green" : "0x6B",
+          "red" : "0x3D"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -39,6 +39,73 @@ enum DS {
         // Dividers
         static let separator = Color(.separator)
 
+        // MARK: Adaptive Surfaces (light/dark)
+
+        static let pageBg = adaptive(light: "FFFFFF", dark: "111111")
+        static let surfaceElevated = adaptive(light: "F2F2F7", dark: "1C1C1E")
+        static let surfaceSecondary = adaptive(light: "E5E5EA", dark: "2C2C2E")
+        static let surfaceTertiary = adaptive(light: "D1D1D6", dark: "3C3C3E")
+
+        // MARK: Adaptive Borders
+
+        static let borderSubtle = adaptiveColor(
+            light: UIColor.separator,
+            dark: UIColor.white.withAlphaComponent(0.05)
+        )
+        static let borderMedium = adaptiveColor(
+            light: UIColor.separator,
+            dark: UIColor.white.withAlphaComponent(0.10)
+        )
+
+        // MARK: Adaptive Text
+
+        static let textFaint = Color(hex: "6B7280")
+        static let textMuted = Color(hex: "9CA3AF")
+
+        // MARK: Summary Card Colors
+
+        static let overdueCardBackground = adaptive(light: "FEF2F2", dark: "1C1C1E")
+        static let overdueCardBorder = adaptiveColor(
+            light: UIColor(Color(hex: "FEE2E2")),
+            dark: UIColor.white.withAlphaComponent(0.05)
+        )
+        static let dueSoonCardBackground = adaptive(light: "FFFBEB", dark: "1C1C1E")
+        static let dueSoonCardBorder = adaptiveColor(
+            light: UIColor(Color(hex: "FDE68A")),
+            dark: UIColor.white.withAlphaComponent(0.05)
+        )
+        static let allGoodCardBackground = adaptive(light: "ECFDF5", dark: "1C1C1E")
+        static let allGoodCardBorder = adaptiveColor(
+            light: UIColor(Color(hex: "A7F3D0")),
+            dark: UIColor.white.withAlphaComponent(0.05)
+        )
+
+        // MARK: Action Buttons
+
+        static let actionButtonBackground = adaptive(light: "2D3339", dark: "2C2C2E")
+        static let actionButtonPressed = adaptive(light: "1F252B", dark: "3C3C3E")
+        static let actionButtonIconBg = Color.white.opacity(0.1)
+
+        // MARK: Notes Card
+
+        static let notesBackground = adaptiveColor(
+            light: UIColor(Color(hex: "FEFCE8").opacity(0.5)),
+            dark: UIColor(Color(hex: "2C2C2E"))
+        )
+        static let notesBorder = adaptiveColor(
+            light: UIColor(Color(hex: "FEF08A")),
+            dark: UIColor.white.withAlphaComponent(0.05)
+        )
+
+        // MARK: Sheet Overlay
+
+        static let sheetOverlay = adaptiveColor(
+            light: UIColor.black.withAlphaComponent(0.4),
+            dark: UIColor.black.withAlphaComponent(0.6)
+        )
+
+        // MARK: Status Helpers
+
         static func statusColor(for status: ContactStatus) -> Color {
             switch status {
             case .overdue: return statusOverdue
@@ -56,6 +123,58 @@ enum DS {
             case .unknown: return "8E8E93"
             }
         }
+
+        // MARK: Adaptive Helpers
+
+        /// Creates a Color that adapts between light and dark mode using hex strings.
+        private static func adaptive(light: String, dark: String) -> Color {
+            Color(UIColor { trait in
+                trait.userInterfaceStyle == .dark
+                    ? UIColor(Color(hex: dark))
+                    : UIColor(Color(hex: light))
+            })
+        }
+
+        /// Creates a Color that adapts between light and dark mode using UIColors directly.
+        private static func adaptiveColor(light: UIColor, dark: UIColor) -> Color {
+            Color(UIColor { trait in
+                trait.userInterfaceStyle == .dark ? dark : light
+            })
+        }
+
+        // MARK: Theme-Aware Avatar Colors
+
+        /// Returns muted background and text colors for avatars based on color scheme.
+        /// Light mode: stored hex as background, white text.
+        /// Dark mode: muted variants per dark mode addendum spec.
+        static func avatarColors(for hex: String, scheme: ColorScheme) -> (background: Color, text: Color) {
+            guard scheme == .dark else {
+                return (Color(hex: hex), .white)
+            }
+
+            let normalized = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted).uppercased()
+            switch normalized {
+            case "6BCB77":  // Green
+                return (Color(hex: "2D5040"), Color(hex: "4ADE80"))
+            case "4ECDC4":  // Teal
+                return (Color(hex: "0D3D3D"), Color(hex: "5EEAD4"))
+            case "FF6B6B":  // Red / Orange-ish
+                return (Color(hex: "3D2010"), Color(hex: "FDBA74"))
+            case "F38181":  // Pink-Red
+                return (Color(hex: "3D2010"), Color(hex: "FDBA74"))
+            case "AA96DA":  // Purple
+                return (Color(hex: "2D1B4E"), Color(hex: "D8B4FE"))
+            case "FFD93D":  // Yellow / Amber
+                return (Color(hex: "3D2E10"), Color(hex: "FCD34D"))
+            case "95E1D3":  // Mint
+                return (Color(hex: "0D3D3D"), Color(hex: "5EEAD4"))
+            case "FCBAD3":  // Light Pink
+                return (Color(hex: "2D1B4E"), Color(hex: "D8B4FE"))
+            default:
+                // Accent green fallback
+                return (Color(hex: "3D6B4F"), .white)
+            }
+        }
     }
 
     // MARK: - Typography
@@ -69,6 +188,16 @@ enum DS {
         static let metadata = Font.subheadline
         static let caption = Font.caption
         static let captionBold = Font.caption.weight(.medium)
+
+        // New tokens for UX redesign (#171)
+        static let summaryNumber = Font.system(size: 28, weight: .bold)
+        static let summaryLabel = Font.system(size: 11, weight: .bold)
+        static let sectionHeaderMono = Font.system(size: 11, weight: .bold, design: .monospaced)
+        static let tabLabel = Font.system(size: 10, weight: .bold)
+        static let sheetHeroName = Font.system(size: 24, weight: .bold)
+        static let timelineTitle = Font.system(size: 14, weight: .bold)
+        static let timelineMono = Font.system(size: 12, weight: .regular, design: .monospaced)
+        static let timelineNotes = Font.system(size: 14, weight: .regular)
     }
 
     // MARK: - Spacing
@@ -90,6 +219,9 @@ enum DS {
         static let sm: CGFloat = 6
         static let md: CGFloat = 10
         static let lg: CGFloat = 16
+        static let xl: CGFloat = 20
+        static let xxl: CGFloat = 32
+        static let full: CGFloat = 999
     }
 
     // MARK: - Touch Method Icons


### PR DESCRIPTION
## Summary
- Set `AccentColor.colorset` to `#3D6B4F` (forest green) for both light and dark appearances
- Add adaptive color tokens using `UIColor { traitCollection in }` pattern for automatic light/dark switching:
  - Surface tokens (`pageBg`, `surfaceElevated`, `surfaceSecondary`, `surfaceTertiary`)
  - Border tokens (`borderSubtle`, `borderMedium`)
  - Summary card backgrounds/borders (overdue, dueSoon, allGood)
  - Action button colors, notes card colors, sheet overlay
  - Text tokens (`textFaint`, `textMuted`)
- Add typography tokens: `summaryNumber`, `summaryLabel`, `sectionHeaderMono`, `tabLabel`, `sheetHeroName`, `timelineTitle`, `timelineMono`, `timelineNotes`
- Add radius tokens: `xl` (20), `xxl` (32), `full` (999)
- Add `avatarColors(for:scheme:)` for theme-aware avatar color mapping per dark mode addendum

## Test plan
- [x] Build succeeds: `xcodebuild build-for-testing -scheme StayInTouch -destination 'platform=iOS Simulator,name=iPhone 16'`
- [ ] All new tokens accessible via `DS.Colors.*`, `DS.Typography.*`, `DS.Radius.*`
- [ ] No existing functionality broken (all additions, no modifications to existing tokens)
- [ ] AccentColor visible in asset catalog with correct hex values

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)