### PR TITLE
Restyle notes card, history timeline, and contact settings (#177)

### DIFF
--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -132,7 +132,7 @@ enum DS {
             light: UIColor.white,
             dark: UIColor(Color(hex: "1C1C1E"))
         )
-        static let timelineCircleLatest = Color(hex: "10B981")
+        static let timelineCircleLatest = adaptive(light: "10B981", dark: "10B981")
         static let timelineCircleOther = adaptiveColor(
             light: UIColor.systemGray3,
             dark: UIColor(Color(hex: "4B5563"))
@@ -164,10 +164,6 @@ enum DS {
             light: UIColor.separator,
             dark: UIColor.white.withAlphaComponent(0.05)
         )
-        static let settingsLeftBorder = adaptiveColor(
-            light: UIColor.systemGray5,
-            dark: UIColor.white.withAlphaComponent(0.05)
-        )
         static let settingsRemoveText = adaptiveColor(
             light: UIColor.systemRed,
             dark: UIColor(Color(hex: "F87171"))
@@ -183,6 +179,10 @@ enum DS {
         static let settingsSnoozePillBorder = adaptiveColor(
             light: UIColor.systemGray4,
             dark: UIColor.white.withAlphaComponent(0.15)
+        )
+        static let settingsSnoozeActive = adaptiveColor(
+            light: UIColor.systemPurple,
+            dark: UIColor(Color(hex: "C084FC"))
         )
 
         // MARK: Group Badge
@@ -346,12 +346,11 @@ enum DS {
         static let ctaButton = Font.system(size: 16, weight: .bold)
 
         // Tokens for #177 (notes, timeline, settings)
-        static let notesLabel = Font.system(size: 11, weight: .bold)
-        static let notesBody = Font.system(size: 15)
-        static let settingsHeaderTitle = Font.system(size: 15, weight: .semibold)
-        static let settingsRowLabel = Font.system(size: 15)
-        static let timelineHint = Font.system(size: 12)
-        static let settingsSectionLabel = Font.system(size: 12, weight: .semibold)
+        static let notesLabel = Font.caption2.weight(.bold)
+        static let notesBody = Font.body
+        static let settingsHeaderTitle = Font.body.weight(.semibold)
+        static let settingsRowLabel = Font.body
+        static let settingsSectionLabel = Font.caption.weight(.semibold)
     }
 
     // MARK: - Spacing

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -540,13 +540,14 @@ struct PersonDetailView: View {
         VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             HStack {
                 Text("History")
-                    .font(DS.Typography.sectionHeader)
-                    .foregroundStyle(DS.Colors.secondaryText)
+                    .font(DS.Typography.settingsHeaderTitle)
+                    .foregroundStyle(DS.Colors.settingsTitle)
                 Spacer()
                 if viewModel.touchEvents.count > 3 {
                     Button(showFullHistory ? "Hide" : "See All") {
                         showFullHistory.toggle()
                     }
+                    .font(DS.Typography.caption)
                 }
             }
 
@@ -567,6 +568,11 @@ struct PersonDetailView: View {
                             showEditTouch = event
                         }
                         .contextMenu {
+                            Button {
+                                showEditTouch = event
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
                             Button(role: .destructive) {
                                 showDeleteConfirm = event
                             } label: {
@@ -675,7 +681,7 @@ struct PersonDetailView: View {
 
     private func settingsIcon(_ systemName: String) -> some View {
         Image(systemName: systemName)
-            .font(.system(size: 14))
+            .font(.footnote)
             .foregroundStyle(DS.Colors.settingsChevron)
             .frame(width: 32, height: 32)
             .background(DS.Colors.settingsIconCircle)
@@ -764,7 +770,7 @@ struct PersonDetailView: View {
                 if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
                     Text("Until \(snoozedUntil.formatted(date: .abbreviated, time: .omitted))")
                         .font(DS.Typography.settingsRowLabel)
-                        .foregroundStyle(.purple)
+                        .foregroundStyle(DS.Colors.settingsSnoozeActive)
                     Button("Remove") { viewModel.clearSnooze() }
                         .font(DS.Typography.caption)
                 } else {
@@ -790,12 +796,12 @@ struct PersonDetailView: View {
         .padding(.vertical, DS.Spacing.xs)
     }
 
-    // MARK: Settings Row 4 — Groups
+    // MARK: Settings Row 4 — Tags
 
     private var settingsRowGroupsTags: some View {
         HStack(spacing: DS.Spacing.md) {
             settingsIcon("tag")
-            Text("Groups")
+            Text("Tags")
                 .font(DS.Typography.settingsRowLabel)
                 .foregroundStyle(DS.Colors.settingsItemLabel)
             Spacer()
@@ -920,7 +926,7 @@ struct PersonDetailView: View {
         .frame(minHeight: 48)
     }
 
-    // MARK: Settings Row 10 — Remove Contact
+    // MARK: Settings Row 9 — Remove Contact
 
     private var settingsRowRemoveContact: some View {
         Button { showRemoveConfirm = true } label: {
@@ -1003,22 +1009,6 @@ struct PersonDetailView: View {
         f.dateFormat = "MMM d"
         return f
     }()
-
-    private func frequencySubtext() -> String {
-        guard let group = viewModel.group else { return "" }
-        let calculator = FrequencyCalculator()
-
-        if let dueDate = calculator.effectiveDueDate(for: viewModel.person, in: [group]) {
-            let cal = Calendar.current
-            let remaining = cal.dateComponents([.day], from: cal.startOfDay(for: Date()), to: cal.startOfDay(for: dueDate)).day ?? 0
-            let formatted = Self.dueDateFormatter.string(from: dueDate)
-            if remaining > 0 {
-                return "Connect every \(group.frequencyDays) days \u{00B7} Due \(formatted) \u{00B7} \(remaining)d remaining"
-            }
-            return "Connect every \(group.frequencyDays) days \u{00B7} Was due \(formatted)"
-        }
-        return "Connect every \(group.frequencyDays) days"
-    }
 
     private func snooze(days: Int) {
         let date = Calendar.current.date(byAdding: .day, value: days, to: Date()) ?? Date()

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/TimelineEntryView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/TimelineEntryView.swift
@@ -42,16 +42,27 @@ struct TimelineEntryView: View {
                     Spacer()
                     Text(event.at.formatted(date: .abbreviated, time: .omitted))
                         .font(DS.Typography.timelineMono)
-                        .foregroundStyle(Color(.secondaryLabel))
+                        .foregroundStyle(DS.Colors.secondaryText)
                 }
                 if let notes = event.notes, !notes.isEmpty {
                     Text(notes)
                         .font(DS.Typography.timelineNotes)
-                        .foregroundStyle(Color(.label).opacity(0.7))
+                        .foregroundStyle(DS.Colors.secondaryText)
                 }
             }
             .padding(.bottom, isLast ? 0 : DS.Spacing.lg)
         }
         .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityHint("Tap to edit, press and hold for more options")
+    }
+
+    private var accessibilityDescription: String {
+        let method = event.method.rawValue
+        let date = event.at.formatted(date: .abbreviated, time: .omitted)
+        let timeOfDay = event.timeOfDay.map { ", \($0.rawValue)" } ?? ""
+        let notes = event.notes.map { ", \($0)" } ?? ""
+        return "\(method)\(timeOfDay) on \(date)\(notes)"
     }
 }


### PR DESCRIPTION
## Summary
- **Notes card**: Yellow-tinted background with adaptive border, 2px focus ring when editing, uppercase tracking label, 15px body text with relaxed line spacing
- **History timeline**: Vertical timeline with continuous left border, 16px circle markers (emerald border for latest), long-press context menu for edit/delete, one-time "Tap and hold to edit" hint tracked via `@AppStorage`
- **Contact Settings**: Custom collapsible replacing `DisclosureGroup` — gear icon header with rotating chevron, smooth expand/collapse animation, 10 flat setting rows with consistent 48px min height, left accent border when expanded

### DS tokens added
- 15 new adaptive color tokens (notes, timeline, settings)
- 5 new typography tokens
- Reuses existing `notesBackground`, `notesBorder`, `timelineTitle`, `timelineMono`, `timelineNotes`

### Files changed
- `DesignSystem.swift` — new tokens
- `PersonDetailView.swift` — restyled notes card, timeline, and settings sections
- `TimelineEntryView.swift` — new extracted timeline entry component

Closes #177

## Test plan
- [x] Notes card shows yellow tint background, border visible in both modes
- [x] Focus ring toggles between yellow (light) / gray (dark) when editing notes
- [ ] 500-char limit and auto-save on blur still work
- [x] Timeline shows vertical line with circle markers
- [x] Most recent entry has emerald-500 border, others have gray border
- [x] Long-press on timeline entry shows Edit/Delete context menu
- [ ] "Tap and hold to edit" hint shows once, then disappears permanently
- [x] See All / Hide toggle still works for history
- [x] Contact Settings expands/collapses with smooth animation
- [x] All 10 settings items present and functional
- [ ] Frequency row opens group picker
- [ ] Custom due date row opens date picker / shows Clear
- [ ] Snooze row shows quick buttons or active snooze status
- [ ] Groups & Tags row shows tag pills + Manage button
- [x] Birthday row opens birthday editor
- [x] Notification Time row opens time picker
- [x] Mute Notifications toggle works
- [x] Pause Tracking toggle works (resume shows prompt)
- [x] Remove Contact shows confirmation + undo banner
- [x] Dark mode: all adaptive tokens render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)