### PR TITLE
[#206] Decompose PersonDetailView into child views

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonConversationContextCard.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonConversationContextCard.swift
@@ -1,0 +1,63 @@
+//
+//  PersonConversationContextCard.swift
+//  KeepInTouch
+//
+
+import SwiftUI
+
+struct PersonConversationContextCard: View {
+    @ObservedObject var viewModel: PersonDetailViewModel
+
+    @State private var nextTouchNotesText: String = ""
+    @FocusState private var isNextTouchNotesFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+            Text("NOTES FOR NEXT TIME")
+                .font(DS.Typography.notesLabel)
+                .textCase(.uppercase)
+                .tracking(1.5)
+                .foregroundStyle(Color(.secondaryLabel))
+
+            TextField("What to talk about...",
+                      text: $nextTouchNotesText,
+                      prompt: Text("What to talk about...").foregroundColor(DS.Colors.notesPlaceholder),
+                      axis: .vertical)
+                .font(DS.Typography.notesBody)
+                .foregroundStyle(DS.Colors.notesText)
+                .lineSpacing(4)
+                .lineLimit(3...6)
+                .focused($isNextTouchNotesFocused)
+                .onChange(of: nextTouchNotesText) { _, newValue in
+                    if newValue.count > 500 { nextTouchNotesText = String(newValue.prefix(500)) }
+                }
+                .toolbar {
+                    ToolbarItemGroup(placement: .keyboard) {
+                        Spacer()
+                        Button("Done") {
+                            isNextTouchNotesFocused = false
+                        }
+                    }
+                }
+                .onChange(of: isNextTouchNotesFocused) { _, focused in
+                    if !focused {
+                        viewModel.saveNextTouchNotes(nextTouchNotesText)
+                    }
+                }
+        }
+        .padding(DS.Spacing.lg)
+        .background(DS.Colors.notesBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: DS.Radius.lg)
+                .stroke(
+                    isNextTouchNotesFocused ? DS.Colors.notesFocusRing : DS.Colors.notesBorder,
+                    lineWidth: isNextTouchNotesFocused ? 2 : 1
+                )
+        )
+        .padding(.vertical, DS.Spacing.md)
+        .onAppear {
+            nextTouchNotesText = viewModel.person.nextTouchNotes ?? ""
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
@@ -1,0 +1,63 @@
+//
+//  PersonDetailModal.swift
+//  KeepInTouch
+//
+
+import Foundation
+
+// MARK: - Sheet presentations
+
+enum PersonDetailSheet: Identifiable {
+    case logTouch
+    case editTouch(TouchEvent)
+    case changeGroup
+    case manageTags
+    case resumeDatePicker
+    case reminderTimePicker
+    case snoozeDatePicker
+    case customDueDatePicker
+    case birthdayEditor
+
+    var id: String {
+        switch self {
+        case .logTouch: return "logTouch"
+        case .editTouch(let t): return "editTouch-\(t.id)"
+        case .changeGroup: return "changeGroup"
+        case .manageTags: return "manageTags"
+        case .resumeDatePicker: return "resumeDatePicker"
+        case .reminderTimePicker: return "reminderTimePicker"
+        case .snoozeDatePicker: return "snoozeDatePicker"
+        case .customDueDatePicker: return "customDueDatePicker"
+        case .birthdayEditor: return "birthdayEditor"
+        }
+    }
+}
+
+// MARK: - Alert presentations
+
+enum PersonDetailAlert: Identifiable {
+    case resumePrompt
+    case deleteConfirm(TouchEvent)
+    case removeConfirm
+
+    var id: String {
+        switch self {
+        case .resumePrompt: return "resumePrompt"
+        case .deleteConfirm(let t): return "deleteConfirm-\(t.id)"
+        case .removeConfirm: return "removeConfirm"
+        }
+    }
+}
+
+// MARK: - Settings actions
+
+enum PersonSettingsAction {
+    case changeGroup
+    case manageTags
+    case resumePrompt
+    case removeConfirm
+    case reminderTimePicker
+    case snoozeDatePicker(initialDate: Date)
+    case customDueDatePicker(initialDate: Date)
+    case birthdayEditor
+}

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -14,31 +14,28 @@ struct PersonDetailView: View {
 
     @StateObject private var viewModel: PersonDetailViewModel
 
-    @State private var showLogTouch = false
-    @State private var showEditTouch: TouchEvent?
-    @State private var showChangeGroup = false
-    @State private var showManageTags = false
+    // Modal state (replaces 12 individual booleans/optionals)
+    @State private var activeSheet: PersonDetailSheet?
+    @State private var activeAlert: PersonDetailAlert?
+
+    // Inline toggles
     @State private var showFullHistory = false
-    @State private var showResumePrompt = false
-    @State private var showDatePicker = false
-    @State private var pickedResumeDate = Date()
-    @State private var showDeleteConfirm: TouchEvent?
-    @State private var showRemoveConfirm = false
-    @State private var showReminderTimePicker = false
-    @State private var workingReminderTime = Date()
-    @State private var showSnoozeDatePicker = false
-    @State private var pickedSnoozeDate = Date()
-    @State private var showCustomDueDatePicker = false
-    @State private var pickedCustomDueDate = Date()
-    @State private var nextTouchNotesText: String = ""
     @State private var settingsExpanded = false
+
+    // Date picker working values
+    @State private var pickedResumeDate = Date()
+    @State private var workingReminderTime = Date()
+    @State private var pickedSnoozeDate = Date()
+    @State private var pickedCustomDueDate = Date()
+
+    // Quick action undo state
     @State private var pendingQuickActionMethod: TouchMethod?
     @State private var pendingQuickActionTouch: TouchEvent?
     @State private var showQuickActionUndo = false
+
+    // Remove undo state
     @State private var showRemoveUndo = false
     @State private var pendingRemoveTask: Task<Void, Never>?
-    @State private var showBirthdayEditor = false
-    @FocusState private var isNextTouchNotesFocused: Bool
 
     init(person: Person) {
         _viewModel = StateObject(wrappedValue: PersonDetailViewModel(person: person))
@@ -48,34 +45,42 @@ struct PersonDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 // TIER 1: Hero Zone
-                header
-                    .padding(.bottom, DS.Spacing.lg)
+                PersonHeroSection(
+                    viewModel: viewModel,
+                    onBirthdayEdit: { activeSheet = .birthdayEditor },
+                    onResumePrompt: { activeAlert = .resumePrompt },
+                    onRemoveConfirm: { activeAlert = .removeConfirm }
+                )
 
-                if viewModel.person.contactUnavailable {
-                    unavailableContactBanner
-                }
-
-                if viewModel.person.isPaused {
-                    pausedBanner
-                }
-
-                reachOutButtons
-                    .opacity(viewModel.person.contactUnavailable ? 0.4 : 1.0)
-                    .disabled(viewModel.person.contactUnavailable)
+                PersonQuickActionsBar(
+                    viewModel: viewModel,
+                    onQuickAction: { open($0) }
+                )
+                .opacity(viewModel.person.contactUnavailable ? 0.4 : 1.0)
+                .disabled(viewModel.person.contactUnavailable)
 
                 SubtleDivider()
 
                 // TIER 2: Context Zone
-                conversationContextCard
+                PersonConversationContextCard(viewModel: viewModel)
 
                 SubtleDivider()
 
-                historyCard
+                PersonTouchHistorySection(
+                    viewModel: viewModel,
+                    showFullHistory: $showFullHistory,
+                    onEditTouch: { activeSheet = .editTouch($0) },
+                    onDeleteTouch: { activeAlert = .deleteConfirm($0) }
+                )
 
                 SubtleDivider()
 
                 // TIER 3: Settings Zone
-                detailsAndSettings
+                PersonSettingsSection(
+                    viewModel: viewModel,
+                    settingsExpanded: $settingsExpanded,
+                    onAction: { handleSettingsAction($0) }
+                )
             }
             .padding(.horizontal, DS.Spacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -83,175 +88,20 @@ struct PersonDetailView: View {
         .safeAreaInset(edge: .bottom) {
             fixedBottomCTA
         }
-        .sheet(isPresented: $showLogTouch) {
-            LogTouchModal { method, notes, date, timeOfDay in
-                viewModel.logTouch(method: method, notes: notes, date: date, timeOfDay: timeOfDay)
-                showLogTouch = false
-            }
+        .sheet(item: $activeSheet) { sheet in
+            sheetContent(for: sheet)
         }
-        .sheet(item: $showEditTouch) { touch in
-            EditTouchModal(touch: touch, onSave: { method, notes, timeOfDay in
-                viewModel.updateTouch(touch, method: method, notes: notes, timeOfDay: timeOfDay)
-                showEditTouch = nil
-            }, onDelete: {
-                viewModel.deleteTouch(touch)
-                showEditTouch = nil
-            })
-        }
-        .sheet(isPresented: $showChangeGroup) {
-            GroupPickerSheet(
-                groups: viewModel.groups,
-                selectedId: viewModel.person.groupId,
-                onSelect: { viewModel.changeGroup(to: $0) }
-            )
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: $showManageTags) {
-            TagManagerSheet(
-                tags: viewModel.tags,
-                selectedIds: Set(viewModel.person.tagIds),
-                onAdd: { viewModel.addTag($0) },
-                onRemove: { viewModel.removeTag($0) }
-            )
-            .presentationDetents([.medium])
-        }
-        .alert("Resume tracking?", isPresented: $showResumePrompt) {
-            Button("Today") {
-                viewModel.resumeAndUpdateLastTouch(date: Date())
-            }
-            Button("Pick Date") {
-                pickedResumeDate = Date()
-                showDatePicker = true
-            }
-            Button("Skip") {
-                viewModel.resumeAndUpdateLastTouch(date: nil)
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("When did you last connect?")
-        }
-        .alert("Delete connection?", isPresented: Binding(
-            get: { showDeleteConfirm != nil },
-            set: { if !$0 { showDeleteConfirm = nil } }
-        )) {
-            Button("Delete", role: .destructive) {
-                if let touch = showDeleteConfirm {
-                    Haptics.medium()
-                    viewModel.deleteTouch(touch)
-                }
-                showDeleteConfirm = nil
-            }
-            Button("Cancel", role: .cancel) { showDeleteConfirm = nil }
-        } message: {
-            Text("This can't be undone.")
-        }
-        .alert("Remove contact?", isPresented: $showRemoveConfirm) {
-            Button("Remove", role: .destructive) {
-                startPendingRemove()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will remove them from Keep In Touch.")
-        }
-        .sheet(isPresented: $showDatePicker) {
-            NavigationStack {
-                DatePicker("Last connection", selection: $pickedResumeDate, displayedComponents: .date)
-                    .datePickerStyle(.graphical)
-                    .padding()
-                    .navigationTitle("Last Connection")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Save") {
-                                viewModel.resumeAndUpdateLastTouch(date: pickedResumeDate)
-                                showDatePicker = false
-                            }
-                        }
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button("Cancel") { showDatePicker = false }
-                        }
-                    }
-            }
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: $showReminderTimePicker) {
-            NavigationStack {
-                DatePicker("Reminder Time", selection: $workingReminderTime, displayedComponents: .hourAndMinute)
-                    .datePickerStyle(.wheel)
-                    .labelsHidden()
-                    .navigationTitle("Reminder Time")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button("Cancel") { showReminderTimePicker = false }
-                        }
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Save") {
-                                viewModel.setCustomBreachTime(LocalTime.from(date: workingReminderTime))
-                                showReminderTimePicker = false
-                            }
-                        }
-                    }
-                    .onAppear {
-                        workingReminderTime = reminderTimeDate()
-                    }
-            }
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: $showSnoozeDatePicker) {
-            NavigationStack {
-                DatePicker("Snooze until", selection: $pickedSnoozeDate, in: Date()..., displayedComponents: .date)
-                    .datePickerStyle(.graphical)
-                    .padding()
-                    .navigationTitle("Snooze Until")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button("Cancel") { showSnoozeDatePicker = false }
-                        }
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Save") {
-                                viewModel.snooze(until: pickedSnoozeDate)
-                                showSnoozeDatePicker = false
-                            }
-                        }
-                    }
-            }
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: $showCustomDueDatePicker) {
-            NavigationStack {
-                DatePicker("Due by", selection: $pickedCustomDueDate, in: Date()..., displayedComponents: .date)
-                    .datePickerStyle(.graphical)
-                    .padding()
-                    .navigationTitle("Due Date")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button("Cancel") { showCustomDueDatePicker = false }
-                        }
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Save") {
-                                viewModel.setCustomDueDate(pickedCustomDueDate)
-                                showCustomDueDatePicker = false
-                            }
-                        }
-                    }
-            }
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: $showBirthdayEditor) {
-            BirthdayEditorSheet(
-                birthday: viewModel.displayBirthday,
-                onSave: { birthday in
-                    viewModel.setBirthday(birthday)
-                    showBirthdayEditor = false
-                },
-                onClear: {
-                    viewModel.setBirthday(nil)
-                    showBirthdayEditor = false
-                }
-            )
+        .alert(
+            alertTitle,
+            isPresented: Binding(
+                get: { activeAlert != nil },
+                set: { if !$0 { activeAlert = nil } }
+            ),
+            presenting: activeAlert
+        ) { alert in
+            alertActions(for: alert)
+        } message: { alert in
+            alertMessage(for: alert)
         }
         .confirmationDialog("Choose a number", isPresented: $viewModel.showPhonePicker) {
             ForEach(viewModel.phoneNumbers) { phone in
@@ -327,166 +177,13 @@ struct PersonDetailView: View {
         }
     }
 
-    // MARK: - Tier 1: Hero Zone
-
-    private var personTags: [Tag] {
-        viewModel.tags.filter { viewModel.person.tagIds.contains($0.id) }
-    }
-
-    private var header: some View {
-        VStack(alignment: .center, spacing: DS.Spacing.sm) {
-            ContactPhotoView(
-                cnIdentifier: viewModel.person.cnIdentifier,
-                displayName: viewModel.person.displayName,
-                avatarColor: viewModel.person.avatarColor,
-                size: 96
-            )
-            .overlay(Circle().stroke(DS.Colors.heroAvatarRing, lineWidth: 4))
-            .shadow(color: .black.opacity(0.10), radius: 8, y: 6)
-
-            Text(viewModel.person.displayName)
-                .font(DS.Typography.sheetHeroName)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-
-            Text(statusLabel())
-                .font(DS.Typography.detailStatusLine)
-                .foregroundStyle(statusLineColor)
-                .multilineTextAlignment(.center)
-
-            if let birthday = viewModel.displayBirthday {
-                Button {
-                    showBirthdayEditor = true
-                } label: {
-                    HStack(spacing: DS.Spacing.xs) {
-                        Image(systemName: "gift.fill")
-                            .font(.caption)
-                        Text(birthday.formatted)
-                            .font(DS.Typography.contactCardMeta)
-                    }
-                    .foregroundStyle(Color(.secondaryLabel))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Birthday \(birthday.formatted), tap to edit")
-            }
-
-            if !personTags.isEmpty {
-                HStack(spacing: DS.Spacing.sm) {
-                    ForEach(personTags.prefix(3), id: \.id) { tag in
-                        TagPill(tag: tag)
-                    }
-                    if personTags.count > 3 {
-                        Text("+\(personTags.count - 3)")
-                            .font(DS.Typography.caption)
-                            .foregroundStyle(DS.Colors.secondaryText)
-                    }
-                }
-            }
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var unavailableContactBanner: some View {
-        HStack(spacing: DS.Spacing.sm) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.white)
-            VStack(alignment: .leading, spacing: DS.Spacing.xs) {
-                Text("Contact unavailable")
-                    .font(DS.Typography.metadata.weight(.semibold))
-                    .foregroundStyle(.white)
-                Text("This contact may have been deleted or merged.")
-                    .font(DS.Typography.caption)
-                    .foregroundStyle(.white.opacity(0.8))
-            }
-            Spacer()
-            Button("Remove") { showRemoveConfirm = true }
-                .font(DS.Typography.caption.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, DS.Spacing.sm)
-                .padding(.vertical, DS.Spacing.xs)
-                .background(.white.opacity(0.2))
-                .clipShape(Capsule())
-        }
-        .padding(DS.Spacing.md)
-        .background(DS.Colors.statusDueSoon)
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
-        .padding(.bottom, DS.Spacing.md)
-    }
-
-    private var pausedBanner: some View {
-        HStack {
-            Text("Tracking paused")
-                .font(DS.Typography.metadata)
-            Spacer()
-            Button("Resume") { showResumePrompt = true }
-                .buttonStyle(.borderedProminent)
-        }
-        .padding(DS.Spacing.md)
-        .background(DS.Colors.statusUnknown.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
-        .padding(.bottom, DS.Spacing.md)
-    }
-
-    private var hasPhone: Bool {
-        viewModel.phone != nil || !viewModel.phoneNumbers.isEmpty
-    }
-
-    private var hasEmail: Bool {
-        viewModel.email != nil || !viewModel.emailAddresses.isEmpty
-    }
-
-    private var reachOutButtons: some View {
-        VStack(spacing: DS.Spacing.sm) {
-            HStack(spacing: DS.Spacing.sm) {
-                actionCard(icon: "message.fill", label: "Message", enabled: hasPhone) { open(.message) }
-                actionCard(icon: "phone.fill", label: "Call", enabled: hasPhone) { open(.call) }
-                actionCard(icon: "envelope.fill", label: "Email", enabled: hasEmail) { open(.email) }
-            }
-
-            if let message = viewModel.quickActionMessage {
-                Text(message)
-                    .font(DS.Typography.metadata)
-                    .foregroundStyle(DS.Colors.secondaryText)
-            }
-        }
-        .padding(.vertical, DS.Spacing.md)
-    }
-
-    private func actionCard(icon: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: DS.Spacing.sm) {
-                Image(systemName: icon)
-                    .font(.title2)
-                    .foregroundStyle(.white)
-                    .frame(width: 36, height: 36)
-                    .background(DS.Colors.actionButtonIconCircleOpacity)
-                    .clipShape(Circle())
-                Text(label)
-                    .font(DS.Typography.contactCardMeta)
-                    .foregroundStyle(.white)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(minHeight: 80)
-            .background(DS.Colors.actionButtonBackground)
-            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.lg))
-            .overlay(
-                RoundedRectangle(cornerRadius: DS.Radius.lg)
-                    .stroke(DS.Colors.actionButtonBorder, lineWidth: 1)
-            )
-            .shadow(color: DS.Colors.actionButtonShadow, radius: 6, y: 2)
-        }
-        .buttonStyle(ActionCardButtonStyle())
-        .accessibilityLabel(enabled ? label : "\(label), unavailable")
-        .accessibilityHint(enabled ? "\(label)s this contact" : "No \(label == "Email" ? "email address" : "phone number") on file")
-        .disabled(!enabled)
-        .opacity(!enabled && !viewModel.person.contactUnavailable ? 0.5 : 1.0)
-    }
+    // MARK: - Fixed Bottom CTA
 
     private var fixedBottomCTA: some View {
         VStack(spacing: 0) {
             DS.Colors.borderMedium.frame(height: 1)
             Button {
-                showLogTouch = true
+                activeSheet = .logTouch
             } label: {
                 Text("Log Connection")
                     .font(DS.Typography.ctaButton)
@@ -505,541 +202,137 @@ struct PersonDetailView: View {
         .background(DS.Colors.ctaContainerBg)
     }
 
-    // MARK: - Tier 2: Context Zone
+    // MARK: - Sheet Content
 
-    private var conversationContextCard: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
-            Text("NOTES FOR NEXT TIME")
-                .font(DS.Typography.notesLabel)
-                .textCase(.uppercase)
-                .tracking(1.5)
-                .foregroundStyle(Color(.secondaryLabel))
-
-            TextField("What to talk about...",
-                      text: $nextTouchNotesText,
-                      prompt: Text("What to talk about...").foregroundColor(DS.Colors.notesPlaceholder),
-                      axis: .vertical)
-                .font(DS.Typography.notesBody)
-                .foregroundStyle(DS.Colors.notesText)
-                .lineSpacing(4)
-                .lineLimit(3...6)
-                .focused($isNextTouchNotesFocused)
-                .onChange(of: nextTouchNotesText) { _, newValue in
-                    if newValue.count > 500 { nextTouchNotesText = String(newValue.prefix(500)) }
-                }
-                .toolbar {
-                    ToolbarItemGroup(placement: .keyboard) {
-                        Spacer()
-                        Button("Done") {
-                            isNextTouchNotesFocused = false
-                        }
-                    }
-                }
-                .onChange(of: isNextTouchNotesFocused) { _, focused in
-                    if !focused {
-                        viewModel.saveNextTouchNotes(nextTouchNotesText)
-                    }
-                }
-        }
-        .padding(DS.Spacing.lg)
-        .background(DS.Colors.notesBackground)
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: DS.Radius.lg)
-                .stroke(
-                    isNextTouchNotesFocused ? DS.Colors.notesFocusRing : DS.Colors.notesBorder,
-                    lineWidth: isNextTouchNotesFocused ? 2 : 1
-                )
-        )
-        .padding(.vertical, DS.Spacing.md)
-        .onAppear {
-            nextTouchNotesText = viewModel.person.nextTouchNotes ?? ""
+    @ViewBuilder
+    private func sheetContent(for sheet: PersonDetailSheet) -> some View {
+        switch sheet {
+        case .logTouch:
+            LogTouchModal { method, notes, date, timeOfDay in
+                viewModel.logTouch(method: method, notes: notes, date: date, timeOfDay: timeOfDay); activeSheet = nil
+            }
+        case .editTouch(let touch):
+            EditTouchModal(touch: touch, onSave: { method, notes, timeOfDay in
+                viewModel.updateTouch(touch, method: method, notes: notes, timeOfDay: timeOfDay); activeSheet = nil
+            }, onDelete: { viewModel.deleteTouch(touch); activeSheet = nil })
+        case .changeGroup:
+            GroupPickerSheet(groups: viewModel.groups, selectedId: viewModel.person.groupId,
+                             onSelect: { viewModel.changeGroup(to: $0) }).presentationDetents([.medium])
+        case .manageTags:
+            TagManagerSheet(tags: viewModel.tags, selectedIds: Set(viewModel.person.tagIds),
+                            onAdd: { viewModel.addTag($0) }, onRemove: { viewModel.removeTag($0) }).presentationDetents([.medium])
+        case .resumeDatePicker:
+            datePickerSheet("Last Connection", selection: $pickedResumeDate) { viewModel.resumeAndUpdateLastTouch(date: pickedResumeDate) }
+        case .reminderTimePicker:
+            datePickerSheet("Reminder Time", selection: $workingReminderTime, components: .hourAndMinute, useWheel: true) {
+                viewModel.setCustomBreachTime(LocalTime.from(date: workingReminderTime))
+            }.onAppear { workingReminderTime = reminderTimeDate() }
+        case .snoozeDatePicker:
+            datePickerSheet("Snooze Until", selection: $pickedSnoozeDate, minDate: Date()) { viewModel.snooze(until: pickedSnoozeDate) }
+        case .customDueDatePicker:
+            datePickerSheet("Due Date", selection: $pickedCustomDueDate, minDate: Date()) { viewModel.setCustomDueDate(pickedCustomDueDate) }
+        case .birthdayEditor:
+            BirthdayEditorSheet(birthday: viewModel.displayBirthday,
+                                onSave: { viewModel.setBirthday($0); activeSheet = nil },
+                                onClear: { viewModel.setBirthday(nil); activeSheet = nil })
         }
     }
 
-    private var historyCard: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
-            HStack {
-                Text("History")
-                    .font(DS.Typography.settingsHeaderTitle)
-                    .foregroundStyle(DS.Colors.settingsTitle)
-                Spacer()
-                if viewModel.touchEvents.count > 3 {
-                    Button(showFullHistory ? "Hide" : "See All") {
-                        showFullHistory.toggle()
-                    }
-                    .font(DS.Typography.caption)
-                    .accessibilityLabel(showFullHistory ? "Hide full history" : "See all \(viewModel.touchEvents.count) connections")
-                }
-            }
+    // MARK: - Alert Content
 
-            if viewModel.touchEvents.isEmpty {
-                Text("No connections yet")
-                    .font(DS.Typography.metadata)
-                    .foregroundStyle(DS.Colors.tertiaryText)
-            } else {
-                let events = showFullHistory ? viewModel.touchEvents : Array(viewModel.touchEvents.prefix(3))
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(events.enumerated()), id: \.element.id) { index, event in
-                        TimelineEntryView(
-                            event: event,
-                            isLatest: index == 0,
-                            isLast: index == events.count - 1
-                        )
-                        .onTapGesture {
-                            showEditTouch = event
-                        }
-                        .contextMenu {
-                            Button {
-                                showEditTouch = event
-                            } label: {
-                                Label("Edit", systemImage: "pencil")
-                            }
-                            Button(role: .destructive) {
-                                showDeleteConfirm = event
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .padding(.vertical, DS.Spacing.md)
-    }
-
-    // MARK: - Tier 3: Settings Zone
-
-    private var detailsAndSettings: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Collapsible header
-            Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    settingsExpanded.toggle()
-                }
-            } label: {
-                HStack(spacing: DS.Spacing.sm) {
-                    Image(systemName: "gearshape.fill")
-                        .foregroundStyle(DS.Colors.settingsGearIcon)
-                    Text("Contact Settings")
-                        .font(DS.Typography.settingsHeaderTitle)
-                        .foregroundStyle(DS.Colors.settingsTitle)
-                    Spacer()
-                    Image(systemName: "chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(DS.Colors.settingsChevron)
-                        .rotationEffect(.degrees(settingsExpanded ? 0 : -90))
-                        .animation(.easeInOut(duration: 0.25), value: settingsExpanded)
-                }
-                .padding(.vertical, DS.Spacing.md)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Contact Settings")
-            .accessibilityHint(settingsExpanded ? "Collapses settings" : "Expands settings")
-
-            if settingsExpanded {
-                settingsContent
-                    .transition(.opacity.combined(with: .slide))
-            }
-        }
-        .padding(.vertical, DS.Spacing.md)
-    }
-
-    private var settingsContent: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.lg) {
-            // No heading — Frequency & Reminder Date
-            settingsCard {
-                settingsRowFrequency
-                settingsDivider
-                settingsRowCustomDueDate
-            }
-
-            // DETAILS
-            settingsSectionHeader("DETAILS")
-            settingsCard {
-                settingsRowBirthday
-                settingsDivider
-                settingsRowGroupsTags
-            }
-
-            // TRACKING & NOTIFICATIONS
-            settingsSectionHeader("TRACKING & NOTIFICATIONS")
-            settingsCard {
-                settingsRowNotificationTime
-                settingsDivider
-                settingsRowSnooze
-                settingsDivider
-                settingsRowMuteNotifications
-                settingsDivider
-                settingsRowPauseTracking
-            }
-
-            // Remove Contact (standalone)
-            settingsRowRemoveContact
+    private var alertTitle: String {
+        switch activeAlert {
+        case .resumePrompt: return "Resume tracking?"
+        case .deleteConfirm: return "Delete connection?"
+        case .removeConfirm: return "Remove contact?"
+        case .none: return ""
         }
     }
 
-    private var settingsDivider: some View {
-        Rectangle()
-            .fill(DS.Colors.settingsSeparator)
-            .frame(height: 0.5)
-    }
-
-    private func settingsSectionHeader(_ title: String) -> some View {
-        Text(title)
-            .font(DS.Typography.settingsSectionLabel)
-            .foregroundStyle(DS.Colors.settingsItemLabel)
-            .textCase(.uppercase)
-            .tracking(0.5)
-    }
-
-    private func settingsCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            content()
+    @ViewBuilder
+    private func alertActions(for alert: PersonDetailAlert) -> some View {
+        switch alert {
+        case .resumePrompt:
+            Button("Today") { viewModel.resumeAndUpdateLastTouch(date: Date()) }
+            Button("Pick Date") { pickedResumeDate = Date(); activeSheet = .resumeDatePicker }
+            Button("Skip") { viewModel.resumeAndUpdateLastTouch(date: nil) }
+            Button("Cancel", role: .cancel) {}
+        case .deleteConfirm(let touch):
+            Button("Delete", role: .destructive) { Haptics.medium(); viewModel.deleteTouch(touch) }
+            Button("Cancel", role: .cancel) {}
+        case .removeConfirm:
+            Button("Remove", role: .destructive) { startPendingRemove() }
+            Button("Cancel", role: .cancel) {}
         }
-        .padding(.horizontal, DS.Spacing.lg)
-        .background(DS.Colors.settingsCardBg)
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
     }
 
-    private func settingsIcon(_ systemName: String) -> some View {
-        Image(systemName: systemName)
-            .font(.footnote)
-            .foregroundStyle(DS.Colors.settingsChevron)
-            .frame(width: 32, height: 32)
-            .background(DS.Colors.settingsIconCircle)
-            .clipShape(Circle())
-    }
-
-    private func snoozePill(_ title: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(DS.Typography.caption)
-                .padding(.horizontal, DS.Spacing.md)
-                .padding(.vertical, DS.Spacing.xs)
-                .overlay(
-                    Capsule()
-                        .stroke(DS.Colors.settingsSnoozePillBorder, lineWidth: 1)
-                )
+    private func alertMessage(for alert: PersonDetailAlert) -> Text {
+        switch alert {
+        case .resumePrompt: return Text("When did you last connect?")
+        case .deleteConfirm: return Text("This can't be undone.")
+        case .removeConfirm: return Text("This will remove them from Keep In Touch.")
         }
-        .buttonStyle(.plain)
     }
 
-    // MARK: Settings Row 1 — Frequency
+    // MARK: - Settings Action Handler
 
-    private var settingsRowFrequency: some View {
-        Button { showChangeGroup = true } label: {
-            HStack {
-                Text("Frequency")
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemLabel)
-                Spacer()
-                Text(viewModel.group?.name ?? "Not set")
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemValue)
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(DS.Colors.settingsChevron)
-            }
-            .frame(minHeight: 48)
-            .contentShape(Rectangle())
+    private func handleSettingsAction(_ action: PersonSettingsAction) {
+        switch action {
+        case .changeGroup: activeSheet = .changeGroup
+        case .manageTags: activeSheet = .manageTags
+        case .resumePrompt: activeAlert = .resumePrompt
+        case .removeConfirm: activeAlert = .removeConfirm
+        case .reminderTimePicker: activeSheet = .reminderTimePicker
+        case .snoozeDatePicker(let d): pickedSnoozeDate = d; activeSheet = .snoozeDatePicker
+        case .customDueDatePicker(let d): pickedCustomDueDate = d; activeSheet = .customDueDatePicker
+        case .birthdayEditor: activeSheet = .birthdayEditor
         }
-        .buttonStyle(.plain)
     }
 
-    // MARK: Settings Row 2 — Set A Reminder Date
+    // MARK: - Date Picker Sheet Helper
 
-    private var settingsRowCustomDueDate: some View {
-        HStack {
-            Text("Set A Reminder Date")
-                .font(DS.Typography.settingsRowLabel)
-                .foregroundStyle(DS.Colors.settingsItemLabel)
-            Spacer()
-            if let customDue = viewModel.person.customDueDate {
-                Text(customDue.formatted(date: .abbreviated, time: .omitted))
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemValue)
-                Button("Clear") { viewModel.clearCustomDueDate() }
-                    .font(DS.Typography.caption)
-            } else {
-                Button {
-                    pickedCustomDueDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
-                    showCustomDueDatePicker = true
-                } label: {
-                    HStack(spacing: DS.Spacing.xs) {
-                        Text("Not set")
-                            .font(DS.Typography.settingsRowLabel)
-                            .foregroundStyle(DS.Colors.settingsItemValue)
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(DS.Colors.settingsChevron)
-                    }
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .frame(minHeight: 48)
-    }
-
-    // MARK: Settings Row 3 — Snooze
-
-    private var settingsRowSnooze: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
-            HStack {
-                Text("Snooze")
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemLabel)
-                Spacer()
-                if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
-                    Text("Until \(snoozedUntil.formatted(date: .abbreviated, time: .omitted))")
-                        .font(DS.Typography.settingsRowLabel)
-                        .foregroundStyle(DS.Colors.settingsSnoozeActive)
-                    Button("Remove") { viewModel.clearSnooze() }
-                        .font(DS.Typography.caption)
+    private func datePickerSheet(
+        _ title: String,
+        selection: Binding<Date>,
+        components: DatePickerComponents = .date,
+        useWheel: Bool = false,
+        minDate: Date? = nil,
+        onSave: @escaping () -> Void
+    ) -> some View {
+        NavigationStack {
+            SwiftUI.Group {
+                if useWheel {
+                    DatePicker(title, selection: selection, displayedComponents: components)
+                        .datePickerStyle(.wheel)
+                        .labelsHidden()
+                } else if let minDate {
+                    DatePicker(title, selection: selection, in: minDate..., displayedComponents: components)
+                        .datePickerStyle(.graphical)
+                        .padding()
                 } else {
-                    Text("Not snoozed")
-                        .font(DS.Typography.settingsRowLabel)
-                        .foregroundStyle(DS.Colors.settingsItemValue)
+                    DatePicker(title, selection: selection, displayedComponents: components)
+                        .datePickerStyle(.graphical)
+                        .padding()
                 }
             }
-
-            if !(viewModel.person.snoozedUntil.map { $0 > Date() } ?? false) {
-                HStack(spacing: DS.Spacing.sm) {
-                    snoozePill("3d") { snooze(days: 3) }
-                    snoozePill("7d") { snooze(days: 7) }
-                    snoozePill("14d") { snooze(days: 14) }
-                    snoozePill("Pick date") {
-                        pickedSnoozeDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
-                        showSnoozeDatePicker = true
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { activeSheet = nil }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        onSave()
+                        activeSheet = nil
                     }
                 }
             }
         }
-        .frame(minHeight: 48)
-        .padding(.vertical, DS.Spacing.xs)
+        .presentationDetents([.medium])
     }
 
-    // MARK: Settings Row 4 — Tags
-
-    private var settingsRowGroupsTags: some View {
-        HStack(spacing: DS.Spacing.md) {
-            settingsIcon("person.2")
-            Text("Groups")
-                .font(DS.Typography.settingsRowLabel)
-                .foregroundStyle(DS.Colors.settingsItemLabel)
-            Spacer()
-            VStack(alignment: .trailing, spacing: DS.Spacing.xs) {
-                if !personTags.isEmpty {
-                    HStack(spacing: DS.Spacing.xs) {
-                        ForEach(personTags.prefix(2), id: \.id) { tag in
-                            TagPill(tag: tag)
-                        }
-                        if personTags.count > 2 {
-                            Text("+\(personTags.count - 2)")
-                                .font(DS.Typography.caption)
-                                .foregroundStyle(DS.Colors.secondaryText)
-                        }
-                    }
-                }
-                Button {
-                    showManageTags = true
-                } label: {
-                    HStack(spacing: DS.Spacing.xs) {
-                        Text("Manage")
-                            .font(DS.Typography.caption)
-                        Image(systemName: "chevron.right")
-                            .font(.caption2)
-                            .foregroundStyle(DS.Colors.settingsChevron)
-                    }
-                }
-            }
-        }
-        .frame(minHeight: 48)
-    }
-
-    // MARK: Settings Row 5 — Birthday
-
-    private var settingsRowBirthday: some View {
-        Button { showBirthdayEditor = true } label: {
-            HStack(spacing: DS.Spacing.md) {
-                settingsIcon("birthday.cake")
-                Text("Birthday")
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemLabel)
-                Spacer()
-                Text(viewModel.displayBirthday?.formatted ?? "Add")
-                    .font(DS.Typography.settingsRowLabel)
-                    .foregroundStyle(DS.Colors.settingsItemValue)
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(DS.Colors.settingsChevron)
-            }
-            .frame(minHeight: 48)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: Settings Row 6 — Notification Time
-
-    private var settingsRowNotificationTime: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
-            Button {
-                showReminderTimePicker = true
-            } label: {
-                HStack {
-                    Text("Custom Notification Time")
-                        .font(DS.Typography.settingsRowLabel)
-                        .foregroundStyle(DS.Colors.settingsItemLabel)
-                    Spacer()
-                    Text(reminderTimeLabel())
-                        .font(DS.Typography.settingsRowLabel)
-                        .foregroundStyle(DS.Colors.settingsItemValue)
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(DS.Colors.settingsChevron)
-                }
-                .frame(minHeight: 48)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if viewModel.person.customBreachTime != nil {
-                Button("Restore defaults") {
-                    viewModel.restoreNotificationDefaults()
-                }
-                .font(DS.Typography.caption)
-                .foregroundStyle(DS.Colors.secondaryText)
-                .padding(.bottom, DS.Spacing.xs)
-            }
-        }
-    }
-
-    // MARK: Settings Row 7 — Mute Notifications
-
-    private var settingsRowMuteNotifications: some View {
-        Toggle(isOn: Binding(
-            get: { viewModel.person.notificationsMuted },
-            set: { viewModel.setNotificationsMuted($0) }
-        )) {
-            Text("Mute Notifications")
-                .font(DS.Typography.settingsRowLabel)
-                .foregroundStyle(DS.Colors.settingsItemLabel)
-        }
-        .frame(minHeight: 48)
-    }
-
-    // MARK: Settings Row 8 — Pause Tracking
-
-    private var settingsRowPauseTracking: some View {
-        Toggle(isOn: Binding(
-            get: { viewModel.person.isPaused },
-            set: { newValue in
-                if newValue {
-                    viewModel.togglePause()
-                } else {
-                    showResumePrompt = true
-                }
-            }
-        )) {
-            Text("Pause Tracking")
-                .font(DS.Typography.settingsRowLabel)
-                .foregroundStyle(DS.Colors.settingsItemLabel)
-        }
-        .frame(minHeight: 48)
-    }
-
-    // MARK: Settings Row 9 — Remove Contact
-
-    private var settingsRowRemoveContact: some View {
-        Button { showRemoveConfirm = true } label: {
-            Text("Remove Contact")
-                .font(DS.Typography.settingsRowLabel)
-                .foregroundStyle(DS.Colors.settingsRemoveText)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .frame(minHeight: 48)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Remove \(viewModel.person.displayName)")
-        .accessibilityHint("Confirms removal")
-    }
-
-    // MARK: - Computed Properties
-
-    private var currentStatus: ContactStatus {
-        guard let group = viewModel.group else { return .onTrack }
-        return FrequencyCalculator().status(for: viewModel.person, in: [group])
-    }
-
-    private var daysOverdue: Int {
-        guard let group = viewModel.group else { return 0 }
-        return FrequencyCalculator().daysOverdue(for: viewModel.person, in: [group])
-    }
-
-    private var daysUntilDue: Int {
-        guard let group = viewModel.group else { return 0 }
-        let calculator = FrequencyCalculator()
-        guard let dueDate = calculator.effectiveDueDate(for: viewModel.person, in: [group]) else { return 0 }
-        let cal = Calendar.current
-        return max(0, cal.dateComponents([.day], from: cal.startOfDay(for: Date()), to: cal.startOfDay(for: dueDate)).day ?? 0)
-    }
-
-    // MARK: - Helper Functions
-
-    private func statusLabel() -> String {
-        let groupName = viewModel.group?.name ?? "Frequency"
-
-        // Check paused state first
-        if viewModel.person.isPaused {
-            return "\(groupName) \u{00B7} Paused"
-        }
-
-        // Check snoozed state
-        if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
-            let formatted = Self.dueDateFormatter.string(from: snoozedUntil)
-            return "\(groupName) \u{00B7} Snoozed until \(formatted)"
-        }
-
-        switch currentStatus {
-        case .onTrack:
-            return "\(groupName) \u{00B7} All good"
-        case .dueSoon:
-            let days = daysUntilDue
-            return days > 0 ? "\(groupName) \u{00B7} Due in \(days)d" : "\(groupName) \u{00B7} Check in soon"
-        case .overdue:
-            let days = daysOverdue
-            if days >= 14 {
-                let weeks = days / 7
-                return "\(groupName) \u{00B7} Overdue by \(weeks) week\(weeks == 1 ? "" : "s")"
-            }
-            return "\(groupName) \u{00B7} Overdue by \(days) day\(days == 1 ? "" : "s")"
-        case .unknown:
-            return "\(groupName) \u{00B7} No connections yet"
-        }
-    }
-
-    private var statusLineColor: Color {
-        if viewModel.person.isPaused {
-            return DS.Colors.textMuted
-        }
-        if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
-            return DS.Colors.textMuted
-        }
-        return DS.Colors.statusColor(for: currentStatus)
-    }
-
-    private static let dueDateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        return f
-    }()
-
-    private func snooze(days: Int) {
-        let date = Calendar.current.date(byAdding: .day, value: days, to: Date()) ?? Date()
-        viewModel.snooze(until: date)
-    }
+    // MARK: - Quick Actions
 
     private func open(_ action: QuickActionType) {
         guard let url = viewModel.openAction(type: action) else { return }
@@ -1057,32 +350,14 @@ struct PersonDetailView: View {
     }
 
     private func quickActionUndoBanner(method: TouchMethod) -> some View {
-        HStack(spacing: DS.Spacing.sm) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.white)
-            Text("Logged \(method.rawValue.lowercased()). Didn't connect?")
-                .font(DS.Typography.metadata)
-                .foregroundStyle(.white)
-            Spacer()
-            Button("Undo") {
-                Haptics.light()
-                if let touch = pendingQuickActionTouch {
-                    viewModel.deleteTouch(touch)
-                }
-                dismissQuickActionUndo()
-            }
-            .font(DS.Typography.metadata.weight(.semibold))
-            .foregroundStyle(.white)
-            .padding(.horizontal, DS.Spacing.sm)
-            .padding(.vertical, DS.Spacing.xs)
-            .background(.white.opacity(0.2))
-            .clipShape(Capsule())
+        undoBanner(
+            icon: "checkmark.circle.fill",
+            text: "Logged \(method.rawValue.lowercased()). Didn't connect?",
+            color: DS.Colors.statusAllGood
+        ) {
+            if let touch = pendingQuickActionTouch { viewModel.deleteTouch(touch) }
+            dismissQuickActionUndo()
         }
-        .padding(DS.Spacing.md)
-        .background(DS.Colors.statusAllGood)
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
-        .padding(.horizontal, DS.Spacing.lg)
-        .padding(.top, DS.Spacing.sm)
     }
 
     private func dismissQuickActionUndo() {
@@ -1091,27 +366,29 @@ struct PersonDetailView: View {
         pendingQuickActionTouch = nil
     }
 
+    // MARK: - Remove Undo
+
     private var removeUndoBanner: some View {
+        undoBanner(icon: "trash.fill", text: "Contact removed", color: DS.Colors.destructive) {
+            cancelPendingRemove()
+        }
+    }
+
+    private func undoBanner(icon: String, text: String, color: Color, onUndo: @escaping () -> Void) -> some View {
         HStack(spacing: DS.Spacing.sm) {
-            Image(systemName: "trash.fill")
-                .foregroundStyle(.white)
-            Text("Contact removed")
-                .font(DS.Typography.metadata)
-                .foregroundStyle(.white)
+            Image(systemName: icon).foregroundStyle(.white)
+            Text(text).font(DS.Typography.metadata).foregroundStyle(.white)
             Spacer()
-            Button("Undo") {
-                Haptics.light()
-                cancelPendingRemove()
-            }
-            .font(DS.Typography.metadata.weight(.semibold))
-            .foregroundStyle(.white)
-            .padding(.horizontal, DS.Spacing.sm)
-            .padding(.vertical, DS.Spacing.xs)
-            .background(.white.opacity(0.2))
-            .clipShape(Capsule())
+            Button("Undo") { Haptics.light(); onUndo() }
+                .font(DS.Typography.metadata.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, DS.Spacing.sm)
+                .padding(.vertical, DS.Spacing.xs)
+                .background(.white.opacity(0.2))
+                .clipShape(Capsule())
         }
         .padding(DS.Spacing.md)
-        .background(DS.Colors.destructive)
+        .background(color)
         .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
         .padding(.horizontal, DS.Spacing.lg)
         .padding(.top, DS.Spacing.sm)
@@ -1135,15 +412,7 @@ struct PersonDetailView: View {
         showRemoveUndo = false
     }
 
-    private func reminderTimeLabel() -> String {
-        if let custom = viewModel.person.customBreachTime {
-            return custom.formatted
-        }
-        if let settings = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext).fetch() {
-            return settings.breachTimeOfDay.formatted
-        }
-        return "Default"
-    }
+    // MARK: - Helpers
 
     private func reminderTimeDate() -> Date {
         if let custom = viewModel.person.customBreachTime {
@@ -1155,14 +424,3 @@ struct PersonDetailView: View {
         return Date()
     }
 }
-
-// MARK: - Action Card Button Style
-
-private struct ActionCardButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
-    }
-}
-

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonHeroSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonHeroSection.swift
@@ -1,0 +1,196 @@
+//
+//  PersonHeroSection.swift
+//  KeepInTouch
+//
+
+import SwiftUI
+
+struct PersonHeroSection: View {
+    @ObservedObject var viewModel: PersonDetailViewModel
+    var onBirthdayEdit: () -> Void
+    var onResumePrompt: () -> Void
+    var onRemoveConfirm: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.bottom, DS.Spacing.lg)
+
+            if viewModel.person.contactUnavailable {
+                unavailableContactBanner
+            }
+
+            if viewModel.person.isPaused {
+                pausedBanner
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .center, spacing: DS.Spacing.sm) {
+            ContactPhotoView(
+                cnIdentifier: viewModel.person.cnIdentifier,
+                displayName: viewModel.person.displayName,
+                avatarColor: viewModel.person.avatarColor,
+                size: 96
+            )
+            .overlay(Circle().stroke(DS.Colors.heroAvatarRing, lineWidth: 4))
+            .shadow(color: .black.opacity(0.10), radius: 8, y: 6)
+
+            Text(viewModel.person.displayName)
+                .font(DS.Typography.sheetHeroName)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+
+            Text(statusLabel())
+                .font(DS.Typography.detailStatusLine)
+                .foregroundStyle(statusLineColor)
+                .multilineTextAlignment(.center)
+
+            if let birthday = viewModel.displayBirthday {
+                Button {
+                    onBirthdayEdit()
+                } label: {
+                    HStack(spacing: DS.Spacing.xs) {
+                        Image(systemName: "gift.fill")
+                            .font(.caption)
+                        Text(birthday.formatted)
+                            .font(DS.Typography.contactCardMeta)
+                    }
+                    .foregroundStyle(Color(.secondaryLabel))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Birthday \(birthday.formatted), tap to edit")
+            }
+
+            if !personTags.isEmpty {
+                HStack(spacing: DS.Spacing.sm) {
+                    ForEach(personTags.prefix(3), id: \.id) { tag in
+                        TagPill(tag: tag)
+                    }
+                    if personTags.count > 3 {
+                        Text("+\(personTags.count - 3)")
+                            .font(DS.Typography.caption)
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Banners
+
+    private var unavailableContactBanner: some View {
+        HStack(spacing: DS.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.white)
+            VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+                Text("Contact unavailable")
+                    .font(DS.Typography.metadata.weight(.semibold))
+                    .foregroundStyle(.white)
+                Text("This contact may have been deleted or merged.")
+                    .font(DS.Typography.caption)
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+            Spacer()
+            Button("Remove") { onRemoveConfirm() }
+                .font(DS.Typography.caption.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, DS.Spacing.sm)
+                .padding(.vertical, DS.Spacing.xs)
+                .background(.white.opacity(0.2))
+                .clipShape(Capsule())
+        }
+        .padding(DS.Spacing.md)
+        .background(DS.Colors.statusDueSoon)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+        .padding(.bottom, DS.Spacing.md)
+    }
+
+    private var pausedBanner: some View {
+        HStack {
+            Text("Tracking paused")
+                .font(DS.Typography.metadata)
+            Spacer()
+            Button("Resume") { onResumePrompt() }
+                .buttonStyle(.borderedProminent)
+        }
+        .padding(DS.Spacing.md)
+        .background(DS.Colors.statusUnknown.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+        .padding(.bottom, DS.Spacing.md)
+    }
+
+    // MARK: - Computed Properties
+
+    private var personTags: [Tag] {
+        viewModel.tags.filter { viewModel.person.tagIds.contains($0.id) }
+    }
+
+    private var currentStatus: ContactStatus {
+        guard let group = viewModel.group else { return .onTrack }
+        return FrequencyCalculator().status(for: viewModel.person, in: [group])
+    }
+
+    private var daysOverdue: Int {
+        guard let group = viewModel.group else { return 0 }
+        return FrequencyCalculator().daysOverdue(for: viewModel.person, in: [group])
+    }
+
+    private var daysUntilDue: Int {
+        guard let group = viewModel.group else { return 0 }
+        let calculator = FrequencyCalculator()
+        guard let dueDate = calculator.effectiveDueDate(for: viewModel.person, in: [group]) else { return 0 }
+        let cal = Calendar.current
+        return max(0, cal.dateComponents([.day], from: cal.startOfDay(for: Date()), to: cal.startOfDay(for: dueDate)).day ?? 0)
+    }
+
+    private func statusLabel() -> String {
+        let groupName = viewModel.group?.name ?? "Frequency"
+
+        if viewModel.person.isPaused {
+            return "\(groupName) \u{00B7} Paused"
+        }
+
+        if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
+            let formatted = Self.dueDateFormatter.string(from: snoozedUntil)
+            return "\(groupName) \u{00B7} Snoozed until \(formatted)"
+        }
+
+        switch currentStatus {
+        case .onTrack:
+            return "\(groupName) \u{00B7} All good"
+        case .dueSoon:
+            let days = daysUntilDue
+            return days > 0 ? "\(groupName) \u{00B7} Due in \(days)d" : "\(groupName) \u{00B7} Check in soon"
+        case .overdue:
+            let days = daysOverdue
+            if days >= 14 {
+                let weeks = days / 7
+                return "\(groupName) \u{00B7} Overdue by \(weeks) week\(weeks == 1 ? "" : "s")"
+            }
+            return "\(groupName) \u{00B7} Overdue by \(days) day\(days == 1 ? "" : "s")"
+        case .unknown:
+            return "\(groupName) \u{00B7} No connections yet"
+        }
+    }
+
+    private var statusLineColor: Color {
+        if viewModel.person.isPaused {
+            return DS.Colors.textMuted
+        }
+        if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
+            return DS.Colors.textMuted
+        }
+        return DS.Colors.statusColor(for: currentStatus)
+    }
+
+    private static let dueDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+}

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonQuickActionsBar.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonQuickActionsBar.swift
@@ -1,0 +1,78 @@
+//
+//  PersonQuickActionsBar.swift
+//  KeepInTouch
+//
+
+import SwiftUI
+
+struct PersonQuickActionsBar: View {
+    @ObservedObject var viewModel: PersonDetailViewModel
+    var onQuickAction: (QuickActionType) -> Void
+
+    var body: some View {
+        VStack(spacing: DS.Spacing.sm) {
+            HStack(spacing: DS.Spacing.sm) {
+                actionCard(icon: "message.fill", label: "Message", enabled: hasPhone) { onQuickAction(.message) }
+                actionCard(icon: "phone.fill", label: "Call", enabled: hasPhone) { onQuickAction(.call) }
+                actionCard(icon: "envelope.fill", label: "Email", enabled: hasEmail) { onQuickAction(.email) }
+            }
+
+            if let message = viewModel.quickActionMessage {
+                Text(message)
+                    .font(DS.Typography.metadata)
+                    .foregroundStyle(DS.Colors.secondaryText)
+            }
+        }
+        .padding(.vertical, DS.Spacing.md)
+    }
+
+    // MARK: - Private
+
+    private var hasPhone: Bool {
+        viewModel.phone != nil || !viewModel.phoneNumbers.isEmpty
+    }
+
+    private var hasEmail: Bool {
+        viewModel.email != nil || !viewModel.emailAddresses.isEmpty
+    }
+
+    private func actionCard(icon: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: DS.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundStyle(.white)
+                    .frame(width: 36, height: 36)
+                    .background(DS.Colors.actionButtonIconCircleOpacity)
+                    .clipShape(Circle())
+                Text(label)
+                    .font(DS.Typography.contactCardMeta)
+                    .foregroundStyle(.white)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: 80)
+            .background(DS.Colors.actionButtonBackground)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: DS.Radius.lg)
+                    .stroke(DS.Colors.actionButtonBorder, lineWidth: 1)
+            )
+            .shadow(color: DS.Colors.actionButtonShadow, radius: 6, y: 2)
+        }
+        .buttonStyle(ActionCardButtonStyle())
+        .accessibilityLabel(enabled ? label : "\(label), unavailable")
+        .accessibilityHint(enabled ? "\(label)s this contact" : "No \(label == "Email" ? "email address" : "phone number") on file")
+        .disabled(!enabled)
+        .opacity(!enabled && !viewModel.person.contactUnavailable ? 0.5 : 1.0)
+    }
+}
+
+// MARK: - Action Card Button Style
+
+struct ActionCardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -1,0 +1,354 @@
+//
+//  PersonSettingsSection.swift
+//  KeepInTouch
+//
+
+import SwiftUI
+
+struct PersonSettingsSection: View {
+    @ObservedObject var viewModel: PersonDetailViewModel
+    @Binding var settingsExpanded: Bool
+    var onAction: (PersonSettingsAction) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Collapsible header
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    settingsExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: DS.Spacing.sm) {
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(DS.Colors.settingsGearIcon)
+                    Text("Contact Settings")
+                        .font(DS.Typography.settingsHeaderTitle)
+                        .foregroundStyle(DS.Colors.settingsTitle)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(DS.Colors.settingsChevron)
+                        .rotationEffect(.degrees(settingsExpanded ? 0 : -90))
+                        .animation(.easeInOut(duration: 0.25), value: settingsExpanded)
+                }
+                .padding(.vertical, DS.Spacing.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Contact Settings")
+            .accessibilityHint(settingsExpanded ? "Collapses settings" : "Expands settings")
+
+            if settingsExpanded {
+                settingsContent
+                    .transition(.opacity.combined(with: .slide))
+            }
+        }
+        .padding(.vertical, DS.Spacing.md)
+    }
+
+    // MARK: - Settings Content
+
+    private var settingsContent: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.lg) {
+            settingsCard {
+                settingsRowFrequency
+                settingsDivider
+                settingsRowCustomDueDate
+            }
+
+            settingsSectionHeader("DETAILS")
+            settingsCard {
+                settingsRowBirthday
+                settingsDivider
+                settingsRowGroupsTags
+            }
+
+            settingsSectionHeader("TRACKING & NOTIFICATIONS")
+            settingsCard {
+                settingsRowNotificationTime
+                settingsDivider
+                settingsRowSnooze
+                settingsDivider
+                settingsRowMuteNotifications
+                settingsDivider
+                settingsRowPauseTracking
+            }
+
+            settingsRowRemoveContact
+        }
+    }
+
+    // MARK: - Settings Rows
+
+    private var settingsRowFrequency: some View {
+        Button { onAction(.changeGroup) } label: {
+            HStack {
+                Text("Frequency")
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemLabel)
+                Spacer()
+                Text(viewModel.group?.name ?? "Not set")
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemValue)
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(DS.Colors.settingsChevron)
+            }
+            .frame(minHeight: 48)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var settingsRowCustomDueDate: some View {
+        HStack {
+            Text("Set A Reminder Date")
+                .font(DS.Typography.settingsRowLabel)
+                .foregroundStyle(DS.Colors.settingsItemLabel)
+            Spacer()
+            if let customDue = viewModel.person.customDueDate {
+                Text(customDue.formatted(date: .abbreviated, time: .omitted))
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemValue)
+                Button("Clear") { viewModel.clearCustomDueDate() }
+                    .font(DS.Typography.caption)
+            } else {
+                Button {
+                    let initialDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
+                    onAction(.customDueDatePicker(initialDate: initialDate))
+                } label: {
+                    HStack(spacing: DS.Spacing.xs) {
+                        Text("Not set")
+                            .font(DS.Typography.settingsRowLabel)
+                            .foregroundStyle(DS.Colors.settingsItemValue)
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(DS.Colors.settingsChevron)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(minHeight: 48)
+    }
+
+    private var settingsRowSnooze: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+            HStack {
+                Text("Snooze")
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemLabel)
+                Spacer()
+                if let snoozedUntil = viewModel.person.snoozedUntil, snoozedUntil > Date() {
+                    Text("Until \(snoozedUntil.formatted(date: .abbreviated, time: .omitted))")
+                        .font(DS.Typography.settingsRowLabel)
+                        .foregroundStyle(DS.Colors.settingsSnoozeActive)
+                    Button("Remove") { viewModel.clearSnooze() }
+                        .font(DS.Typography.caption)
+                } else {
+                    Text("Not snoozed")
+                        .font(DS.Typography.settingsRowLabel)
+                        .foregroundStyle(DS.Colors.settingsItemValue)
+                }
+            }
+
+            if !(viewModel.person.snoozedUntil.map { $0 > Date() } ?? false) {
+                HStack(spacing: DS.Spacing.sm) {
+                    snoozePill("3d") { snooze(days: 3) }
+                    snoozePill("7d") { snooze(days: 7) }
+                    snoozePill("14d") { snooze(days: 14) }
+                    snoozePill("Pick date") {
+                        let initialDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
+                        onAction(.snoozeDatePicker(initialDate: initialDate))
+                    }
+                }
+            }
+        }
+        .frame(minHeight: 48)
+        .padding(.vertical, DS.Spacing.xs)
+    }
+
+    private var settingsRowBirthday: some View {
+        Button { onAction(.birthdayEditor) } label: {
+            HStack(spacing: DS.Spacing.md) {
+                settingsIcon("birthday.cake")
+                Text("Birthday")
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemLabel)
+                Spacer()
+                Text(viewModel.displayBirthday?.formatted ?? "Add")
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemValue)
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(DS.Colors.settingsChevron)
+            }
+            .frame(minHeight: 48)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var settingsRowGroupsTags: some View {
+        HStack(spacing: DS.Spacing.md) {
+            settingsIcon("person.2")
+            Text("Groups")
+                .font(DS.Typography.settingsRowLabel)
+                .foregroundStyle(DS.Colors.settingsItemLabel)
+            Spacer()
+            VStack(alignment: .trailing, spacing: DS.Spacing.xs) {
+                if !personTags.isEmpty {
+                    HStack(spacing: DS.Spacing.xs) {
+                        ForEach(personTags.prefix(2), id: \.id) { tag in
+                            TagPill(tag: tag)
+                        }
+                        if personTags.count > 2 {
+                            Text("+\(personTags.count - 2)")
+                                .font(DS.Typography.caption)
+                                .foregroundStyle(DS.Colors.secondaryText)
+                        }
+                    }
+                }
+                Button {
+                    onAction(.manageTags)
+                } label: {
+                    HStack(spacing: DS.Spacing.xs) {
+                        Text("Manage")
+                            .font(DS.Typography.caption)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(DS.Colors.settingsChevron)
+                    }
+                }
+            }
+        }
+        .frame(minHeight: 48)
+    }
+
+    private var settingsRowNotificationTime: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            Button {
+                onAction(.reminderTimePicker)
+            } label: {
+                HStack {
+                    Text("Custom Notification Time")
+                        .font(DS.Typography.settingsRowLabel)
+                        .foregroundStyle(DS.Colors.settingsItemLabel)
+                    Spacer()
+                    Text(reminderTimeLabel())
+                        .font(DS.Typography.settingsRowLabel)
+                        .foregroundStyle(DS.Colors.settingsItemValue)
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(DS.Colors.settingsChevron)
+                }
+                .frame(minHeight: 48)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if viewModel.person.customBreachTime != nil {
+                Button("Restore defaults") {
+                    viewModel.restoreNotificationDefaults()
+                }
+                .font(DS.Typography.caption)
+                .foregroundStyle(DS.Colors.secondaryText)
+                .padding(.bottom, DS.Spacing.xs)
+            }
+        }
+    }
+
+    private var settingsRowMuteNotifications: some View {
+        Toggle(isOn: Binding(
+            get: { viewModel.person.notificationsMuted },
+            set: { viewModel.setNotificationsMuted($0) }
+        )) {
+            Text("Mute Notifications")
+                .font(DS.Typography.settingsRowLabel)
+                .foregroundStyle(DS.Colors.settingsItemLabel)
+        }
+        .frame(minHeight: 48)
+    }
+
+    private var settingsRowPauseTracking: some View {
+        Toggle(isOn: Binding(
+            get: { viewModel.person.isPaused },
+            set: { newValue in
+                if newValue {
+                    viewModel.togglePause()
+                } else {
+                    onAction(.resumePrompt)
+                }
+            }
+        )) {
+            Text("Pause Tracking")
+                .font(DS.Typography.settingsRowLabel)
+                .foregroundStyle(DS.Colors.settingsItemLabel)
+        }
+        .frame(minHeight: 48)
+    }
+
+    private var settingsRowRemoveContact: some View {
+        Button { onAction(.removeConfirm) } label: {
+            Text("Remove Contact")
+                .font(DS.Typography.settingsRowLabel)
+                .foregroundStyle(DS.Colors.settingsRemoveText)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(minHeight: 48)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove \(viewModel.person.displayName)")
+        .accessibilityHint("Confirms removal")
+    }
+
+    // MARK: - Helpers
+
+    private var personTags: [Tag] {
+        viewModel.tags.filter { viewModel.person.tagIds.contains($0.id) }
+    }
+
+    private func snooze(days: Int) {
+        let date = Calendar.current.date(byAdding: .day, value: days, to: Date()) ?? Date()
+        viewModel.snooze(until: date)
+    }
+
+    private func reminderTimeLabel() -> String {
+        if let custom = viewModel.person.customBreachTime {
+            return custom.formatted
+        }
+        if let settings = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext).fetch() {
+            return settings.breachTimeOfDay.formatted
+        }
+        return "Default"
+    }
+
+    private var settingsDivider: some View {
+        Rectangle().fill(DS.Colors.settingsSeparator).frame(height: 0.5)
+    }
+
+    private func settingsSectionHeader(_ title: String) -> some View {
+        Text(title).font(DS.Typography.settingsSectionLabel).foregroundStyle(DS.Colors.settingsItemLabel)
+            .textCase(.uppercase).tracking(0.5)
+    }
+
+    private func settingsCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 0) { content() }
+            .padding(.horizontal, DS.Spacing.lg).background(DS.Colors.settingsCardBg)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+    }
+
+    private func settingsIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName).font(.footnote).foregroundStyle(DS.Colors.settingsChevron)
+            .frame(width: 32, height: 32).background(DS.Colors.settingsIconCircle).clipShape(Circle())
+    }
+
+    private func snoozePill(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title).font(DS.Typography.caption)
+                .padding(.horizontal, DS.Spacing.md).padding(.vertical, DS.Spacing.xs)
+                .overlay(Capsule().stroke(DS.Colors.settingsSnoozePillBorder, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonTouchHistorySection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonTouchHistorySection.swift
@@ -1,0 +1,64 @@
+//
+//  PersonTouchHistorySection.swift
+//  KeepInTouch
+//
+
+import SwiftUI
+
+struct PersonTouchHistorySection: View {
+    @ObservedObject var viewModel: PersonDetailViewModel
+    @Binding var showFullHistory: Bool
+    var onEditTouch: (TouchEvent) -> Void
+    var onDeleteTouch: (TouchEvent) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+            HStack {
+                Text("History")
+                    .font(DS.Typography.settingsHeaderTitle)
+                    .foregroundStyle(DS.Colors.settingsTitle)
+                Spacer()
+                if viewModel.touchEvents.count > 3 {
+                    Button(showFullHistory ? "Hide" : "See All") {
+                        showFullHistory.toggle()
+                    }
+                    .font(DS.Typography.caption)
+                    .accessibilityLabel(showFullHistory ? "Hide full history" : "See all \(viewModel.touchEvents.count) connections")
+                }
+            }
+
+            if viewModel.touchEvents.isEmpty {
+                Text("No connections yet")
+                    .font(DS.Typography.metadata)
+                    .foregroundStyle(DS.Colors.tertiaryText)
+            } else {
+                let events = showFullHistory ? viewModel.touchEvents : Array(viewModel.touchEvents.prefix(3))
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(events.enumerated()), id: \.element.id) { index, event in
+                        TimelineEntryView(
+                            event: event,
+                            isLatest: index == 0,
+                            isLast: index == events.count - 1
+                        )
+                        .onTapGesture {
+                            onEditTouch(event)
+                        }
+                        .contextMenu {
+                            Button {
+                                onEditTouch(event)
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+                            Button(role: .destructive) {
+                                onDeleteTouch(event)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.vertical, DS.Spacing.md)
+    }
+}


### PR DESCRIPTION
## Summary

- Extract 6 focused child views from 1,168-line monolithic `PersonDetailView` (64% reduction to 426 lines)
- Consolidate 12 boolean/optional `@State` modal vars into 2 typed enums (`PersonDetailSheet`, `PersonDetailAlert`)
- Add `PersonSettingsAction` enum for clean child-to-parent communication
- **No behavioral or visual changes** — purely structural refactor. `PersonDetailViewModel` unchanged.

### New files
| File | Lines | Purpose |
|------|-------|---------|
| `PersonDetailModal.swift` | 63 | Sheet, alert, and settings action enums |
| `PersonHeroSection.swift` | 196 | Avatar, name, status, birthday, tags, banners |
| `PersonQuickActionsBar.swift` | 78 | Message/Call/Email action cards |
| `PersonConversationContextCard.swift` | 63 | "Notes for Next Time" with self-contained @FocusState |
| `PersonTouchHistorySection.swift` | 64 | Timeline history with See All toggle |
| `PersonSettingsSection.swift` | 354 | Collapsible settings with 9 configurable rows |

### State reduction
23 `@State` vars → 14 vars (12 booleans → 2 enum optionals, 2 vars moved to children)

## Test plan

- [x] `xcodebuild build` — zero errors
- [x] All existing tests pass unmodified
- [x] `git diff HEAD -- PersonDetailViewModel.swift` — no changes
- [x] Manual verification: all modal presentations, settings rows, undo banners work identically

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)