### PR TITLE
[#211] Add integration tests for import-save workflow

### DIFF
--- a/StayInTouch/StayInTouch/UseCases/DataImportService.swift
+++ b/StayInTouch/StayInTouch/UseCases/DataImportService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreData
 import Contacts
 
 struct DataImportService {
@@ -13,6 +14,7 @@ struct DataImportService {
     let groupRepository: GroupRepository
     let tagRepository: TagRepository
     let touchEventRepository: TouchEventRepository
+    var backgroundContextProvider: (() -> NSManagedObjectContext)? = nil
 
     static func touchEventDedupKey(personId: UUID, date: Date, method: TouchMethod, notes: String?, calendar: Calendar) -> String {
         let dayKey = Int(calendar.startOfDay(for: date).timeIntervalSince1970)
@@ -244,7 +246,7 @@ struct DataImportService {
     func executeImport(_ preview: ImportPreview) async -> ImportResult {
         var importedNewPeople: [(id: UUID, displayName: String)] = []
 
-        let backgroundContext = CoreDataStack.shared.newBackgroundContext()
+        let backgroundContext = backgroundContextProvider?() ?? CoreDataStack.shared.newBackgroundContext()
         await backgroundContext.perform {
             let peopleRepo = CoreDataPersonRepository(context: backgroundContext)
             let touchRepo = CoreDataTouchEventRepository(context: backgroundContext)

--- a/StayInTouch/StayInTouchTests/DataImportServiceIntegrationTests.swift
+++ b/StayInTouch/StayInTouchTests/DataImportServiceIntegrationTests.swift
@@ -1,0 +1,459 @@
+//
+//  DataImportServiceIntegrationTests.swift
+//  KeepInTouchTests
+//
+//  Integration tests for the import pipeline using real CoreData repositories.
+//
+
+import CoreData
+import XCTest
+@testable import StayInTouch
+
+final class DataImportServiceIntegrationTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    private var personRepo: CoreDataPersonRepository!
+    private var groupRepo: CoreDataGroupRepository!
+    private var tagRepo: CoreDataTagRepository!
+    private var touchRepo: CoreDataTouchEventRepository!
+    private var sut: DataImportService!
+
+    override func setUp() {
+        super.setUp()
+        let stack = CoreDataTestStack()
+        context = stack.container.newBackgroundContext()
+        personRepo = CoreDataPersonRepository(context: context)
+        groupRepo = CoreDataGroupRepository(context: context)
+        tagRepo = CoreDataTagRepository(context: context)
+        touchRepo = CoreDataTouchEventRepository(context: context)
+        sut = DataImportService(
+            personRepository: personRepo,
+            groupRepository: groupRepo,
+            tagRepository: tagRepo,
+            touchEventRepository: touchRepo,
+            backgroundContextProvider: { [unowned self] in self.context }
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        touchRepo = nil
+        tagRepo = nil
+        groupRepo = nil
+        personRepo = nil
+        context = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func writeExportJSON(_ exportData: ExportData) throws -> URL {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("import-test-\(UUID().uuidString).json")
+        try data.write(to: url, options: .atomic)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func writeRawJSON(_ string: String) throws -> URL {
+        let data = Data(string.utf8)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("import-test-\(UUID().uuidString).json")
+        try data.write(to: url, options: .atomic)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    @discardableResult
+    private func seedDefaultGroup(id: UUID = UUID(), name: String = "Weekly") throws -> Group {
+        let group = TestFactory.makeGroup(id: id, name: name, frequencyDays: 7, isDefault: true)
+        try groupRepo.save(group)
+        return group
+    }
+
+    private func makeExportPerson(
+        id: UUID = UUID(),
+        name: String,
+        groupId: UUID?,
+        tagIds: [UUID] = [],
+        lastTouchAt: Date? = nil,
+        isPaused: Bool = false,
+        touchEvents: [ExportTouchEvent]? = nil
+    ) -> ExportPerson {
+        let now = Date()
+        return ExportPerson(
+            id: id,
+            displayName: name,
+            groupId: groupId,
+            groupName: nil,
+            tagIds: tagIds,
+            tagNames: [],
+            lastTouchAt: lastTouchAt,
+            isPaused: isPaused,
+            createdAt: now,
+            modifiedAt: now,
+            touchEvents: touchEvents,
+            birthday: nil
+        )
+    }
+
+    private func makeExportEvent(
+        at date: Date,
+        method: TouchMethod = .call,
+        notes: String? = nil
+    ) -> ExportTouchEvent {
+        ExportTouchEvent(id: UUID(), at: date, method: method.rawValue, notes: notes)
+    }
+
+    // MARK: - Test 1: Happy Path
+
+    func testHappyPath_importsAllEntities() async throws {
+        try seedDefaultGroup()
+
+        let groupA = UUID()
+        let groupB = UUID()
+        let tagId = UUID()
+        let now = Date()
+
+        let events1 = [
+            makeExportEvent(at: now.addingTimeInterval(-86400 * 3), method: .call, notes: "Caught up"),
+            makeExportEvent(at: now.addingTimeInterval(-86400 * 1), method: .text)
+        ]
+        let events2 = [
+            makeExportEvent(at: now.addingTimeInterval(-86400 * 5), method: .email)
+        ]
+        let events3 = [
+            makeExportEvent(at: now.addingTimeInterval(-86400 * 2), method: .irl),
+            makeExportEvent(at: now.addingTimeInterval(-86400 * 7), method: .call)
+        ]
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: now,
+            groups: [
+                ExportGroup(id: groupA, name: "Close Friends", frequencyDays: 3, warningDays: 1, colorHex: "#FF0000", sortOrder: 0, isDefault: false),
+                ExportGroup(id: groupB, name: "Monthly", frequencyDays: 30, warningDays: 5, colorHex: nil, sortOrder: 1, isDefault: false)
+            ],
+            tags: [
+                ExportTag(id: tagId, name: "Family", colorHex: "#00FF00", sortOrder: 0)
+            ],
+            people: [
+                makeExportPerson(name: "Alice", groupId: groupA, tagIds: [tagId], touchEvents: events1),
+                makeExportPerson(name: "Bob", groupId: groupB, touchEvents: events2),
+                makeExportPerson(name: "Carol", groupId: groupA, touchEvents: events3)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let preview = await sut.parseImportFile(url: url)
+        let previewValue = try XCTUnwrap(preview)
+
+        XCTAssertEqual(previewValue.newPeople.count, 3)
+        XCTAssertEqual(previewValue.newGroups.count, 2)
+        XCTAssertEqual(previewValue.newTags.count, 1)
+        XCTAssertEqual(previewValue.newTouchEventCount, 5)
+
+        let result = await sut.executeImport(previewValue)
+
+        XCTAssertEqual(result.totalPeople, 3)
+        XCTAssertEqual(result.groupsCreated, 2)
+        XCTAssertEqual(result.tagsCreated, 1)
+
+        // Verify persistence via real repos
+        let allPeople = personRepo.fetchAll()
+        XCTAssertEqual(allPeople.count, 3, "All 3 people should be persisted")
+
+        let allGroups = groupRepo.fetchAll()
+        XCTAssertEqual(allGroups.count, 3, "Default + 2 imported groups")
+        XCTAssertTrue(allGroups.contains(where: { $0.name == "Close Friends" }))
+        XCTAssertTrue(allGroups.contains(where: { $0.name == "Monthly" }))
+
+        let allTags = tagRepo.fetchAll()
+        XCTAssertEqual(allTags.count, 1)
+        XCTAssertEqual(allTags.first?.name, "Family")
+
+        // Verify touch events total
+        var totalEvents = 0
+        for person in allPeople {
+            totalEvents += touchRepo.fetchAll(for: person.id).count
+        }
+        XCTAssertEqual(totalEvents, 5, "All 5 touch events should be persisted")
+    }
+
+    // MARK: - Test 2: UUID Duplicate
+
+    func testDuplicateUUID_updatesNotDuplicates() async throws {
+        let groupId = try seedDefaultGroup().id
+        let personId = UUID()
+        let existingPerson = TestFactory.makePerson(id: personId, name: "Alice", groupId: groupId)
+        try personRepo.save(existingPerson)
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(id: personId, name: "Alice Updated", groupId: groupId)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        XCTAssertEqual(preview.updatedPeople.count, 1, "Should classify as updated")
+        XCTAssertTrue(preview.newPeople.isEmpty, "Should not be new")
+
+        _ = await sut.executeImport(preview)
+
+        let allPeople = personRepo.fetchAll()
+        XCTAssertEqual(allPeople.count, 1, "Should update, not duplicate")
+
+        let updated = try XCTUnwrap(personRepo.fetch(id: personId))
+        XCTAssertEqual(updated.displayName, "Alice Updated")
+    }
+
+    // MARK: - Test 3: Name-Only Match
+
+    func testNameOnlyMatch_updatesExistingPerson() async throws {
+        let groupId = try seedDefaultGroup().id
+        let existingId = UUID()
+        let existingPerson = TestFactory.makePerson(id: existingId, name: "Sarah Chen", groupId: groupId)
+        try personRepo.save(existingPerson)
+
+        // Different UUID, same name
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(id: UUID(), name: "Sarah Chen", groupId: groupId)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        XCTAssertEqual(preview.updatedPeople.count, 1, "Name-only match should classify as updated")
+        XCTAssertTrue(preview.newPeople.isEmpty)
+        XCTAssertNotNil(preview.remappedIds.values.first, "Should remap to existing person")
+
+        _ = await sut.executeImport(preview)
+
+        XCTAssertEqual(personRepo.fetchAll().count, 1, "Should not create duplicate")
+    }
+
+    // MARK: - Test 4: Touch Event Dedup
+
+    func testTouchEventDedup_skipsExistingEvents() async throws {
+        let groupId = try seedDefaultGroup().id
+        let personId = UUID()
+        let person = TestFactory.makePerson(id: personId, name: "Dave", groupId: groupId)
+        try personRepo.save(person)
+
+        let threeDaysAgo = Calendar.current.startOfDay(for: Date()).addingTimeInterval(-86400 * 3 + 3600)
+        let fiveDaysAgo = Calendar.current.startOfDay(for: Date()).addingTimeInterval(-86400 * 5 + 3600)
+        let oneDayAgo = Calendar.current.startOfDay(for: Date()).addingTimeInterval(-86400 * 1 + 3600)
+
+        // Seed existing events
+        try touchRepo.save(TestFactory.makeTouchEvent(personId: personId, at: threeDaysAgo, method: .call, notes: "Hi"))
+        try touchRepo.save(TestFactory.makeTouchEvent(personId: personId, at: fiveDaysAgo, method: .text, notes: nil))
+
+        XCTAssertEqual(touchRepo.fetchAll(for: personId).count, 2)
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(
+                    id: personId,
+                    name: "Dave",
+                    groupId: groupId,
+                    touchEvents: [
+                        makeExportEvent(at: threeDaysAgo, method: .call, notes: "Hi"),   // duplicate
+                        makeExportEvent(at: fiveDaysAgo, method: .text, notes: nil),     // duplicate
+                        makeExportEvent(at: oneDayAgo, method: .email, notes: "New")     // genuinely new
+                    ]
+                )
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        XCTAssertEqual(preview.newTouchEventCount, 1, "Only the email event should be new")
+
+        _ = await sut.executeImport(preview)
+
+        let allEvents = touchRepo.fetchAll(for: personId)
+        XCTAssertEqual(allEvents.count, 3, "2 existing + 1 new = 3 total")
+    }
+
+    // MARK: - Test 5: Malformed JSON
+
+    func testMalformedJSON_returnsNilPreview() async throws {
+        let url = try writeRawJSON("this is not json at all {{{")
+
+        let preview = await sut.parseImportFile(url: url)
+
+        XCTAssertNil(preview, "Malformed JSON should return nil")
+        XCTAssertTrue(personRepo.fetchAll().isEmpty, "No data should be persisted")
+        XCTAssertEqual(groupRepo.fetchAll().count, 0)
+    }
+
+    // MARK: - Test 6: Missing Required Fields
+
+    func testMissingRequiredFields_returnsNilPreview() async throws {
+        // Valid JSON but not a valid ExportData or [ExportPerson]
+        let url = try writeRawJSON("""
+        {"version": 2, "someRandomField": "value"}
+        """)
+
+        let preview = await sut.parseImportFile(url: url)
+
+        XCTAssertNil(preview, "Invalid structure should return nil")
+    }
+
+    // MARK: - Test 7: Ambiguous Names
+
+    func testAmbiguousNames_createsNewPerson() async throws {
+        let groupId = try seedDefaultGroup().id
+
+        // Two tracked people with the same name
+        try personRepo.save(TestFactory.makePerson(name: "John Smith", groupId: groupId))
+        try personRepo.save(TestFactory.makePerson(name: "John Smith", groupId: groupId))
+
+        XCTAssertEqual(personRepo.fetchAll().count, 2)
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(name: "John Smith", groupId: groupId)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        // Without CN access, multiple name matches → falls through to new person
+        XCTAssertEqual(preview.newPeople.count, 1, "Ambiguous name should create new person")
+        XCTAssertTrue(preview.updatedPeople.isEmpty)
+
+        _ = await sut.executeImport(preview)
+
+        XCTAssertEqual(personRepo.fetchAll().count, 3, "2 original + 1 new")
+    }
+
+    // MARK: - Test 8: Group Merging
+
+    func testGroupMerging_deduplicatesByName() async throws {
+        let defaultGroup = try seedDefaultGroup(name: "Weekly")
+
+        let exportGroupId = UUID()
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [
+                ExportGroup(id: exportGroupId, name: "weekly", frequencyDays: 7, warningDays: 2, colorHex: nil, sortOrder: 0, isDefault: false)
+            ],
+            tags: [],
+            people: [
+                makeExportPerson(name: "Eve", groupId: exportGroupId)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        XCTAssertTrue(preview.newGroups.isEmpty, "Group should merge by name (case-insensitive)")
+        XCTAssertEqual(preview.groupIdMap[exportGroupId], defaultGroup.id, "Should map to existing group")
+
+        _ = await sut.executeImport(preview)
+
+        XCTAssertEqual(groupRepo.fetchAll().count, 1, "No duplicate group")
+
+        let importedPerson = personRepo.fetchAll().first
+        XCTAssertEqual(importedPerson?.groupId, defaultGroup.id, "Person should be assigned to existing group")
+    }
+
+    // MARK: - Test 9: Denormalized Fields
+
+    func testDenormalizedFields_updatedFromImportedEvents() async throws {
+        try seedDefaultGroup()
+
+        let fiveDaysAgo = Date().addingTimeInterval(-86400 * 5)
+        let oneDayAgo = Date().addingTimeInterval(-86400 * 1)
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(
+                    name: "Fiona",
+                    groupId: nil,
+                    touchEvents: [
+                        makeExportEvent(at: fiveDaysAgo, method: .call),
+                        makeExportEvent(at: oneDayAgo, method: .email, notes: "Latest")
+                    ]
+                )
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+        _ = await sut.executeImport(preview)
+
+        let person = try XCTUnwrap(personRepo.fetchAll().first)
+
+        // lastTouchAt should reflect the most recent event
+        XCTAssertNotNil(person.lastTouchAt)
+        if let lastTouch = person.lastTouchAt {
+            let daysBetween = Calendar.current.dateComponents([.day], from: lastTouch, to: oneDayAgo).day ?? 99
+            XCTAssertEqual(daysBetween, 0, "lastTouchAt should match the most recent imported event")
+        }
+        XCTAssertEqual(person.lastTouchMethod, .email, "lastTouchMethod should match most recent event")
+        XCTAssertEqual(person.lastTouchNotes, "Latest")
+    }
+
+    // MARK: - Test 10: Empty Display Name
+
+    func testEmptyDisplayName_skipped() async throws {
+        try seedDefaultGroup()
+
+        let exportData = ExportData(
+            version: 2,
+            exportedAt: Date(),
+            groups: [],
+            tags: [],
+            people: [
+                makeExportPerson(name: "   ", groupId: nil),   // whitespace-only
+                makeExportPerson(name: "Valid Person", groupId: nil)
+            ]
+        )
+
+        let url = try writeExportJSON(exportData)
+        let previewOpt = await sut.parseImportFile(url: url)
+        let preview = try XCTUnwrap(previewOpt)
+
+        XCTAssertEqual(preview.skippedCount, 1, "Whitespace name should be skipped")
+        XCTAssertEqual(preview.newPeople.count, 1, "Only valid person should be included")
+        XCTAssertEqual(preview.newPeople.first?.displayName, "Valid Person")
+    }
+}


### PR DESCRIPTION
## Summary

- Added `backgroundContextProvider` to `DataImportService` enabling integration testing with in-memory CoreData (nil default preserves existing behavior)
- 10 new integration tests exercise the full parse-to-persist import pipeline using real CoreData repositories backed by `CoreDataTestStack`

## Tests

| # | Test | Coverage |
|---|------|----------|
| 1 | Happy path | 3 people, 2 groups, 1 tag, 5 touch events all persisted |
| 2 | UUID duplicate | Re-import same UUID updates, doesn't duplicate |
| 3 | Name-only match | Different UUID, same name → classified as updated |
| 4 | Touch event dedup | Overlapping events skipped, new ones added |
| 5 | Malformed JSON | Returns nil, no data persisted |
| 6 | Missing fields | Invalid structure returns nil |
| 7 | Ambiguous names | Multiple name matches → new person created |
| 8 | Group merging | Case-insensitive name dedup, person assigned to existing |
| 9 | Denormalized fields | lastTouchAt/Method updated from imported events |
| 10 | Empty display name | Whitespace-only names skipped |

## Test plan

- [x] All 10 new integration tests pass
- [x] All 187 tests pass (0 regressions)
- [x] Main target builds with zero errors
- [x] No changes to SettingsViewModel or other call sites

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)