### PR TITLE
Replace UITabBar.appearance() with SwiftUI toolbar modifier (#204)

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/MainTabView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/MainTabView.swift
@@ -10,13 +10,6 @@ struct MainTabView: View {
     @ObservedObject private var deepLinkRouter = DeepLinkRouter.shared
     @State private var selectedPerson: Person?
 
-    init() {
-        let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        UITabBar.appearance().standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
-    }
-
     var body: some View {
         TabView(selection: $deepLinkRouter.selectedTab) {
             HomeView(viewModel: viewModel, selectPerson: { selectedPerson = $0 })
@@ -45,6 +38,7 @@ struct MainTabView: View {
             .tag(2)
             .accessibilityLabel("Settings tab")
         }
+        .toolbarBackground(.visible, for: .tabBar)
         .tint(DS.Colors.accent)
         .overlay {
             // Dimming lives here so it fades in place instead of


### PR DESCRIPTION
## Summary
- Remove UIKit `init()` that globally mutated `UITabBar.appearance()` on every view reconstruction
- Replace with scoped SwiftUI-native `.toolbarBackground(.visible, for: .tabBar)` modifier (iOS 16+)
- Net -7 lines / +1 line — eliminates UIKit dependency from MainTabView

## Test plan
- [x] Build succeeds (zero errors)
- [x] All 241 unit tests pass
- [x] Tab bar remains opaque with system background in both light and dark mode
- [x] Tab bar appearance is consistent across all three tabs

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)