### PR TITLE
[#237] Fix concurrency and redundant modifier warnings

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
@@ -88,9 +88,9 @@ final class HomeViewModel: ObservableObject {
         let byId = Dictionary(uniqueKeysWithValues: summaries.map { ($0.identifier, $0) })
 
         let backgroundContext = CoreDataStack.shared.newBackgroundContext()
-        let repo = CoreDataPersonRepository(context: backgroundContext)
 
         await backgroundContext.perform {
+            let repo = CoreDataPersonRepository(context: backgroundContext)
             let people = repo.fetchTracked(includePaused: true)
             var updated: [Person] = []
             for person in people {

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -19,7 +19,7 @@ final class PersonDetailViewModel: ObservableObject {
     @Published private(set) var email: String?
     @Published private(set) var phoneNumbers: [ContactsFetcher.LabeledValue] = []
     @Published private(set) var emailAddresses: [ContactsFetcher.LabeledValue] = []
-    @Published internal(set) var contactBirthday: Birthday?
+    @Published var contactBirthday: Birthday?
     @Published var quickActionMessage: String?
     @Published var showPhonePicker = false
     @Published var showEmailPicker = false


### PR DESCRIPTION
## Summary
- **HomeViewModel**: Moved `CoreDataPersonRepository` creation inside `backgroundContext.perform` to eliminate non-Sendable capture in `@Sendable` closure (Swift 6 prep)
- **PersonDetailViewModel**: Removed redundant `internal(set)` modifier on `contactBirthday` — property remains settable (needed by tests)

## Changes
- `HomeViewModel.swift:91-93`: `let repo = ...` moved from outside to inside the `perform` block
- `PersonDetailViewModel.swift:22`: `@Published internal(set) var` → `@Published var`

## Test plan
- [x] Build succeeds with zero warnings in HomeViewModel and PersonDetailViewModel
- [x] All 273 unit tests pass (including birthday tests that set `contactBirthday` externally)

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)