### PR TITLE
[#228] Audit and update TelemetryDeck events after refactors

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -192,6 +192,7 @@ final class SettingsViewModel: ObservableObject {
     }
 
     func resetAllFrequencies() async {
+        AnalyticsService.track("freshStart.confirmed")
         let now = Date()
         let backgroundContext = CoreDataStack.shared.newBackgroundContext()
         await backgroundContext.perform {
@@ -218,7 +219,11 @@ final class SettingsViewModel: ObservableObject {
     // MARK: - Data Export (delegates to DataExportService)
 
     func exportContacts() -> URL? {
-        exportService.exportContacts()
+        let url = exportService.exportContacts()
+        if url != nil {
+            AnalyticsService.track("data.exported")
+        }
+        return url
     }
 
     // MARK: - Data Import (delegates to DataImportService)
@@ -229,6 +234,7 @@ final class SettingsViewModel: ObservableObject {
 
     func executeImport(_ preview: ImportPreview) async -> ImportResult {
         let result = await importService.executeImport(preview)
+        AnalyticsService.track("data.imported", parameters: ["count": "\(result.importedPeople.count)"])
         load()
         NotificationCenter.default.post(name: .personDidChange, object: nil)
         return result

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -35,7 +35,7 @@ struct HomeView: View {
         }
         .onChange(of: viewModel.selectedGroupId) { _, newValue in
             if newValue != nil {
-                AnalyticsService.track("filter.applied", parameters: ["type": "frequency"])
+                AnalyticsService.track("filter.applied", parameters: ["type": "group"])
             }
             withAnimation(.easeInOut(duration: 0.25)) {
                 viewModel.applyFilters()
@@ -43,7 +43,7 @@ struct HomeView: View {
         }
         .onChange(of: viewModel.selectedTagId) { _, newValue in
             if newValue != nil {
-                AnalyticsService.track("filter.applied", parameters: ["type": "group"])
+                AnalyticsService.track("filter.applied", parameters: ["type": "tag"])
             }
             withAnimation(.easeInOut(duration: 0.25)) {
                 viewModel.applyFilters()


### PR DESCRIPTION
## Summary
Full audit of TelemetryDeck signals. Fixed incorrect parameters and added missing signals for features added since initial analytics integration.

### Fixes
- **Swapped filter parameters**: `selectedGroupId` was tracking as `"frequency"`, `selectedTagId` as `"group"` — corrected to `"group"` and `"tag"` respectively

### New signals
- `freshStart.confirmed` — tracks when user confirms the Fresh Start reset (PR #227)
- `data.exported` — tracks successful JSON data exports
- `data.imported` (with `count` param) — tracks file imports with number of people imported

### Audit results (23 existing signals verified)
- All event names match current screen/flow names
- No references to deleted screens or deprecated "Stay in Touch" name
- No signals need removal — all correspond to active features

## Test plan
- [x] Build succeeds
- [x] All 273 unit tests pass
- [ ] Verify Fresh Start signal fires in TelemetryDeck dashboard
- [ ] Verify export/import signals fire correctly

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)