### PR TITLE
feat: nickname search and auto-expand sections during search (#274, #275)

### DIFF
--- a/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
+++ b/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
@@ -32,13 +32,15 @@ struct ContactSummary: Identifiable, Equatable {
     let id: String
     let identifier: String
     let displayName: String
+    let nickname: String?
     let initials: String
     let birthday: Birthday?
 
-    init(identifier: String, displayName: String, initials: String, birthday: Birthday? = nil) {
+    init(identifier: String, displayName: String, nickname: String? = nil, initials: String, birthday: Birthday? = nil) {
         self.id = identifier
         self.identifier = identifier
         self.displayName = displayName
+        self.nickname = nickname
         self.initials = initials
         self.birthday = birthday
     }
@@ -92,6 +94,7 @@ enum ContactsFetcher {
         let keys: [CNKeyDescriptor] = [
             CNContactIdentifierKey as CNKeyDescriptor,
             CNContactOrganizationNameKey as CNKeyDescriptor,
+            CNContactNicknameKey as CNKeyDescriptor,
             CNContactBirthdayKey as CNKeyDescriptor,
             formatterKeys
         ]
@@ -104,11 +107,13 @@ enum ContactsFetcher {
             try store.enumerateContacts(with: request) { contact, _ in
                 let displayName = CNContactFormatter.string(from: contact, style: .fullName)
                     ?? contact.organizationName
+                let nickname = contact.nickname.isEmpty ? nil : contact.nickname
                 let initials = InitialsBuilder.initials(for: displayName)
                 let birthday = contact.birthday.flatMap { Birthday.from(dateComponents: $0) }
                 results.append(ContactSummary(
                     identifier: contact.identifier,
                     displayName: displayName,
+                    nickname: nickname,
                     initials: initials,
                     birthday: birthday
                 ))

--- a/StayInTouch/StayInTouch/Data/CoreData/Mappings/PersonEntity+Mapping.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Mappings/PersonEntity+Mapping.swift
@@ -13,6 +13,7 @@ extension PersonEntity {
             id: requiredField(id, entity: "PersonEntity", field: "id", fallback: UUID()),
             cnIdentifier: cnIdentifier,
             displayName: requiredField(displayName, entity: "PersonEntity", field: "displayName", fallback: ""),
+            nickname: nickname,
             initials: requiredField(initials, entity: "PersonEntity", field: "initials", fallback: ""),
             avatarColor: requiredField(avatarColor, entity: "PersonEntity", field: "avatarColor", fallback: ""),
             cadenceId: requiredField(groupId, entity: "PersonEntity", field: "groupId", fallback: UUID()),
@@ -42,6 +43,7 @@ extension PersonEntity {
         id = person.id
         cnIdentifier = person.cnIdentifier
         displayName = person.displayName
+        nickname = person.nickname
         initials = person.initials
         avatarColor = person.avatarColor
         groupId = person.cadenceId

--- a/StayInTouch/StayInTouch/Domain/Entities/Person.swift
+++ b/StayInTouch/StayInTouch/Domain/Entities/Person.swift
@@ -15,6 +15,7 @@ struct Person: Identifiable, Equatable, Hashable {
     let id: UUID
     var cnIdentifier: String?
     var displayName: String
+    var nickname: String?
     var initials: String
     var avatarColor: String
 

--- a/StayInTouch/StayInTouch/StayInTouch.xcdatamodeld/.xccurrentversion
+++ b/StayInTouch/StayInTouch/StayInTouch.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>StayInTouch_v7.xcdatamodel</string>
+	<string>StayInTouch_v8.xcdatamodel</string>
 </dict>
 </plist>

--- a/StayInTouch/StayInTouch/StayInTouch.xcdatamodeld/StayInTouch_v8.xcdatamodel/contents
+++ b/StayInTouch/StayInTouch/StayInTouch.xcdatamodeld/StayInTouch_v8.xcdatamodel/contents
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
+    <entity name="Person" representedClassName="PersonEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="cnIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="displayName" optional="NO" attributeType="String"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
+        <attribute name="initials" optional="NO" attributeType="String"/>
+        <attribute name="avatarColor" optional="NO" attributeType="String"/>
+        <attribute name="groupId" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="tagIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
+        <attribute name="lastTouchAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastTouchMethod" optional="YES" attributeType="String"/>
+        <attribute name="lastTouchNotes" optional="YES" attributeType="String"/>
+        <attribute name="nextTouchNotes" optional="YES" attributeType="String"/>
+        <attribute name="isPaused" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isTracked" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="notificationsMuted" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="customBreachTime" optional="YES" attributeType="String"/>
+        <attribute name="snoozedUntil" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customDueDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="birthday" optional="YES" attributeType="String"/>
+        <attribute name="birthdayNotificationsEnabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="groupAddedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="contactUnavailable" optional="NO" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isDemoData" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Group" representedClassName="GroupEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="NO" attributeType="String"/>
+        <attribute name="frequencyDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES" renamingIdentifier="slaDays"/>
+        <attribute name="warningDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="colorHex" optional="YES" attributeType="String"/>
+        <attribute name="isDefault" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Tag" representedClassName="TagEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="NO" attributeType="String"/>
+        <attribute name="colorHex" optional="NO" attributeType="String"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="TouchEvent" representedClassName="TouchEventEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="personId" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="at" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="method" optional="NO" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="timeOfDay" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="AppSettings" representedClassName="AppSettingsEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="theme" optional="NO" attributeType="String"/>
+        <attribute name="notificationsEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="breachTimeOfDay" optional="NO" attributeType="String"/>
+        <attribute name="digestEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="digestDay" optional="NO" attributeType="String"/>
+        <attribute name="digestTime" optional="NO" attributeType="String"/>
+        <attribute name="notificationGrouping" optional="YES" attributeType="String"/>
+        <attribute name="badgeCountShowDueSoon" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="dueSoonWindowDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="demoModeEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="analyticsEnabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="lastContactsSyncAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="onboardingCompleted" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="appVersion" optional="NO" attributeType="String"/>
+        <attribute name="hideContactNamesInNotifications" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="birthdayNotificationsEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="birthdayNotificationTime" optional="YES" attributeType="String"/>
+        <attribute name="birthdayIgnoreSnoozePause" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Person" positionX="-252" positionY="-108" width="128" height="44"/>
+        <element name="Group" positionX="-36" positionY="-108" width="128" height="44"/>
+        <element name="Tag" positionX="180" positionY="-108" width="128" height="44"/>
+        <element name="TouchEvent" positionX="-144" positionY="54" width="128" height="44"/>
+        <element name="AppSettings" positionX="72" positionY="54" width="128" height="44"/>
+    </elements>
+</model>

--- a/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
@@ -145,11 +145,12 @@ final class HomeViewModel: ObservableObject {
             if searchLower.isEmpty { return true }
 
             let nameMatch = person.displayName.lowercased().contains(searchLower)
+            let nicknameMatch = person.nickname?.lowercased().contains(searchLower) ?? false
             let groupMatch = person.groupIds
                 .compactMap { groupNameById[$0] }
                 .contains { $0.contains(searchLower) }
 
-            return nameMatch || groupMatch
+            return nameMatch || nicknameMatch || groupMatch
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
@@ -22,7 +22,8 @@ struct ContactsListView: View {
             }
         }
         return people.filter {
-            $0.displayName.lowercased().contains(query)
+            $0.displayName.lowercased().contains(query) ||
+            ($0.nickname?.lowercased().contains(query) ?? false)
         }.sorted {
             $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
         }

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
     var selectPerson: (Person) -> Void
     @StateObject private var settingsViewModel = SettingsViewModel()
     @State private var collapsedSections: Set<String> = ["all-good"]
+    @State private var savedCollapsedSections: Set<String>?
     @State private var showNewContactsPicker = false
     @State private var showNoNewContactsAlert = false
     @State private var showLimitedAccessAlert = false
@@ -47,6 +48,20 @@ struct HomeView: View {
             }
             withAnimation(.easeInOut(duration: 0.25)) {
                 viewModel.applyFilters()
+            }
+        }
+        .onChange(of: viewModel.searchText) { _, newValue in
+            let isSearching = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if isSearching && savedCollapsedSections == nil {
+                savedCollapsedSections = collapsedSections
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    collapsedSections = []
+                }
+            } else if !isSearching, let saved = savedCollapsedSections {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    collapsedSections = saved
+                }
+                savedCollapsedSections = nil
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .personDidChange)) { _ in

--- a/StayInTouch/StayInTouch/UseCases/ContactImportService.swift
+++ b/StayInTouch/StayInTouch/UseCases/ContactImportService.swift
@@ -95,6 +95,7 @@ struct ContactImportService {
                     id: personId,
                     cnIdentifier: summary.identifier,
                     displayName: summary.displayName,
+                    nickname: summary.nickname,
                     initials: summary.initials,
                     avatarColor: AvatarColors.randomHex(),
                     cadenceId: cadenceId,

--- a/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
+++ b/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
@@ -31,8 +31,9 @@ enum ContactsSyncService {
                 var updated = person
 
                 if let summary = byId[cnId] {
-                    // Contact still exists — sync name and clear unavailable flag
+                    // Contact still exists — sync name, nickname and clear unavailable flag
                     updated.displayName = summary.displayName
+                    updated.nickname = summary.nickname
                     updated.initials = summary.initials
                     if updated.contactUnavailable {
                         updated.contactUnavailable = false

--- a/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
@@ -80,11 +80,90 @@ final class HomeViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.first?.displayName, "A")
     }
 
-    private func makePerson(name: String, cadenceId: UUID, groupIds: [UUID]) -> Person {
+    // MARK: - Nickname Search Tests (#275)
+
+    func testFilterMatchesNickname() {
+        let cadenceId = UUID()
+        let people = [
+            makePerson(name: "Robert Johnson", nickname: "Bobby", cadenceId: cadenceId, groupIds: []),
+            makePerson(name: "Alice Smith", cadenceId: cadenceId, groupIds: [])
+        ]
+
+        let filtered = HomeViewModel.filterPeople(
+            people: people,
+            cadences: [makeCadence(id: cadenceId)],
+            groups: [],
+            selectedCadenceId: nil,
+            selectedGroupId: nil,
+            searchText: "Bobby"
+        )
+
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertEqual(filtered.first?.displayName, "Robert Johnson")
+    }
+
+    func testFilterDoesNotMatchWhenNicknameIsNil() {
+        let cadenceId = UUID()
+        let people = [
+            makePerson(name: "Robert Johnson", cadenceId: cadenceId, groupIds: [])
+        ]
+
+        let filtered = HomeViewModel.filterPeople(
+            people: people,
+            cadences: [makeCadence(id: cadenceId)],
+            groups: [],
+            selectedCadenceId: nil,
+            selectedGroupId: nil,
+            searchText: "Bobby"
+        )
+
+        XCTAssertEqual(filtered.count, 0)
+    }
+
+    func testFilterDoesNotMatchEmptyNickname() {
+        let cadenceId = UUID()
+        let people = [
+            makePerson(name: "Robert Johnson", nickname: "", cadenceId: cadenceId, groupIds: [])
+        ]
+
+        let filtered = HomeViewModel.filterPeople(
+            people: people,
+            cadences: [makeCadence(id: cadenceId)],
+            groups: [],
+            selectedCadenceId: nil,
+            selectedGroupId: nil,
+            searchText: "Bobby"
+        )
+
+        XCTAssertEqual(filtered.count, 0)
+    }
+
+    func testFilterMatchesDisplayNameWhenNicknameAlsoPresent() {
+        let cadenceId = UUID()
+        let people = [
+            makePerson(name: "Robert Johnson", nickname: "Bobby", cadenceId: cadenceId, groupIds: [])
+        ]
+
+        let filtered = HomeViewModel.filterPeople(
+            people: people,
+            cadences: [makeCadence(id: cadenceId)],
+            groups: [],
+            selectedCadenceId: nil,
+            selectedGroupId: nil,
+            searchText: "Robert"
+        )
+
+        XCTAssertEqual(filtered.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makePerson(name: String, nickname: String? = nil, cadenceId: UUID, groupIds: [UUID]) -> Person {
         Person(
             id: UUID(),
             cnIdentifier: nil,
             displayName: name,
+            nickname: nickname,
             initials: String(name.prefix(2)),
             avatarColor: "#FF6B6B",
             cadenceId: cadenceId,

--- a/StayInTouch/StayInTouchTests/PersonEntityMappingTests.swift
+++ b/StayInTouch/StayInTouchTests/PersonEntityMappingTests.swift
@@ -50,6 +50,53 @@ final class PersonEntityMappingTests: XCTestCase {
         XCTAssertEqual(domain.displayName, "", "toDomain should fall back to empty string when displayName is nil")
     }
 
+    // MARK: - Nickname round-trip (#275)
+
+    func testNicknameRoundTrips() {
+        let entity = PersonEntity(context: context)
+        entity.id = UUID()
+        entity.displayName = "Robert"
+        entity.nickname = "Bobby"
+        entity.initials = "RJ"
+        entity.avatarColor = "#FF0000"
+        entity.groupId = UUID()
+        entity.isPaused = false
+        entity.isTracked = true
+        entity.notificationsMuted = false
+        entity.contactUnavailable = false
+        entity.sortOrder = 0
+        entity.createdAt = Date()
+        entity.modifiedAt = Date()
+
+        let domain = entity.toDomain()
+        XCTAssertEqual(domain.nickname, "Bobby")
+
+        // Round-trip back
+        let entity2 = PersonEntity(context: context)
+        entity2.apply(domain)
+        XCTAssertEqual(entity2.nickname, "Bobby")
+    }
+
+    func testNilNicknameRoundTrips() {
+        let entity = PersonEntity(context: context)
+        entity.id = UUID()
+        entity.displayName = "Alice"
+        entity.nickname = nil
+        entity.initials = "AS"
+        entity.avatarColor = "#0000FF"
+        entity.groupId = UUID()
+        entity.isPaused = false
+        entity.isTracked = true
+        entity.notificationsMuted = false
+        entity.contactUnavailable = false
+        entity.sortOrder = 0
+        entity.createdAt = Date()
+        entity.modifiedAt = Date()
+
+        let domain = entity.toDomain()
+        XCTAssertNil(domain.nickname)
+    }
+
     func testNilGroupIdFallsBackToNewUUID() {
         let entity = PersonEntity(context: context)
         entity.id = UUID()


### PR DESCRIPTION
## Summary
- **#275 Nickname search**: Adds `nickname` field to Person entity (Core Data v8 migration), fetches `CNContactNicknameKey` from iOS Contacts, and includes nickname matching in search filters on both Home and Contacts tabs
- **#274 Auto-expand on search**: When search text is active on the Home tab, all collapsed status sections (Overdue, Due Soon, All Good) auto-expand to reveal matching contacts. Previous collapse state is restored when search is cleared
- 6 new unit tests for nickname filtering and entity mapping round-trip. 341 total tests passing

## Test plan
- [x] 341 unit tests pass locally (0 failures)
- [x] Import a contact with a nickname set in iOS Contacts, search for the nickname on both tabs
- [x] On Home tab: collapse All Good, search for a contact in that section, verify it becomes visible
- [x] Clear search, verify All Good re-collapses to previous state

Closes #274
Closes #275