### PR TITLE
feat: move Core Data store to App Group container (#60 infra)

### DIFF
--- a/StayInTouch/StayInTouch.xcodeproj/project.pbxproj
+++ b/StayInTouch/StayInTouch.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				StayInTouch.entitlements,
 			);
 			target = A28171DA2F313E65003719BC /* StayInTouch */;
 		};
@@ -440,6 +441,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StayInTouch/StayInTouch.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = AFG8NJ774P;
@@ -460,6 +463,7 @@
 				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -471,6 +475,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StayInTouch/StayInTouch.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = AFG8NJ774P;
@@ -491,6 +497,7 @@
 				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
@@ -10,6 +10,36 @@ import CoreData
 final class CoreDataStack: ObservableObject {
     static let shared = CoreDataStack()
 
+    /// Set once the app has successfully opened the persistent store at the
+    /// App Group location. If this is `true` on a subsequent launch but the
+    /// App Group container is unavailable (e.g. entitlement regression), we
+    /// hard-fail rather than silently opening an empty default-location store
+    /// and appearing to have lost the user's data.
+    static let hasMigratedToAppGroupKey = "hasMigratedToAppGroup"
+
+    /// Decides what to do when the App Group container may or may not be
+    /// available. Pure function — extracted for unit testing.
+    enum StoreURLResolution: Equatable {
+        case useGroupURL(URL)
+        case fallbackToDefault
+        case hardFail(String)
+    }
+
+    static func resolveStoreURL(
+        groupStoreURL: URL?,
+        hasPreviouslyMigrated: Bool
+    ) -> StoreURLResolution {
+        if let groupStoreURL {
+            return .useGroupURL(groupStoreURL)
+        }
+        if hasPreviouslyMigrated {
+            return .hardFail(
+                "App Group container is unavailable, but this install has previously migrated to it. Refusing to silently open an empty default-location store. Check entitlements."
+            )
+        }
+        return .fallbackToDefault
+    }
+
     let container: NSPersistentContainer
     private let shouldSeedDefaults: Bool
     private(set) var loadError: Error?
@@ -30,38 +60,73 @@ final class CoreDataStack: ObservableObject {
 
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
-        } else if let groupStoreURL = AppGroup.coreDataStoreURL {
-            if let legacyURL = CoreDataStoreMigrator.legacyStoreURL() {
-                do {
-                    let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
-                        legacyURL: legacyURL,
-                        targetURL: groupStoreURL
-                    )
-                    if migrated {
-                        AppLogger.logInfo(
-                            "Migrated Core Data store from legacy default location to App Group container",
-                            category: AppLogger.coreData
-                        )
-                    }
-                } catch {
-                    AppLogger.logError(
-                        error,
-                        category: AppLogger.coreData,
-                        context: "CoreDataStack.storeMigration"
-                    )
-                }
-            }
-            container.persistentStoreDescriptions.first?.url = groupStoreURL
         } else {
-            AppLogger.logWarning(
-                "App Group container unavailable; falling back to default store location",
-                category: AppLogger.coreData
+            let resolution = Self.resolveStoreURL(
+                groupStoreURL: AppGroup.coreDataStoreURL,
+                hasPreviouslyMigrated: UserDefaults.standard.bool(forKey: Self.hasMigratedToAppGroupKey)
             )
+
+            switch resolution {
+            case .useGroupURL(let groupStoreURL):
+                if let legacyURL = CoreDataStoreMigrator.legacyStoreURL() {
+                    do {
+                        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+                            legacyURL: legacyURL,
+                            targetURL: groupStoreURL
+                        )
+                        if migrated {
+                            AppLogger.logInfo(
+                                "Migrated Core Data store from legacy default location to App Group container",
+                                category: AppLogger.coreData
+                            )
+                        }
+                    } catch {
+                        AppLogger.logError(
+                            error,
+                            category: AppLogger.coreData,
+                            context: "CoreDataStack.storeMigration"
+                        )
+                        self.loadError = error
+                        self.isLoaded = false
+                        self.migrationFailed = true
+                        NotificationCenter.default.post(name: .coreDataMigrationFailed, object: error)
+                        return
+                    }
+                }
+                container.persistentStoreDescriptions.first?.url = groupStoreURL
+
+            case .hardFail(let message):
+                let error = NSError(
+                    domain: "CoreDataStack",
+                    code: -1001,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                )
+                AppLogger.logError(
+                    error,
+                    category: AppLogger.coreData,
+                    context: "CoreDataStack.appGroupUnavailableAfterMigration"
+                )
+                self.loadError = error
+                self.isLoaded = false
+                self.migrationFailed = true
+                NotificationCenter.default.post(name: .coreDataMigrationFailed, object: error)
+                return
+
+            case .fallbackToDefault:
+                AppLogger.logWarning(
+                    "App Group container unavailable; falling back to default store location",
+                    category: AppLogger.coreData
+                )
+            }
         }
 
         let description = container.persistentStoreDescriptions.first
         description?.shouldMigrateStoreAutomatically = true
         description?.shouldInferMappingModelAutomatically = true
+        description?.setOption(
+            FileProtectionType.completeUntilFirstUserAuthentication.rawValue as NSString,
+            forKey: NSPersistentStoreFileProtectionKey
+        )
 
         container.loadPersistentStores { [weak self] _, error in
             guard let self else { return }
@@ -76,6 +141,9 @@ final class CoreDataStack: ObservableObject {
             }
 
             self.isLoaded = true
+            if !inMemory, AppGroup.coreDataStoreURL != nil {
+                UserDefaults.standard.set(true, forKey: Self.hasMigratedToAppGroupKey)
+            }
             self.seedDefaultsIfNeeded()
         }
 

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
@@ -30,6 +30,33 @@ final class CoreDataStack: ObservableObject {
 
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        } else if let groupStoreURL = AppGroup.coreDataStoreURL {
+            if let legacyURL = CoreDataStoreMigrator.legacyStoreURL() {
+                do {
+                    let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+                        legacyURL: legacyURL,
+                        targetURL: groupStoreURL
+                    )
+                    if migrated {
+                        AppLogger.logInfo(
+                            "Migrated Core Data store from legacy default location to App Group container",
+                            category: AppLogger.coreData
+                        )
+                    }
+                } catch {
+                    AppLogger.logError(
+                        error,
+                        category: AppLogger.coreData,
+                        context: "CoreDataStack.storeMigration"
+                    )
+                }
+            }
+            container.persistentStoreDescriptions.first?.url = groupStoreURL
+        } else {
+            AppLogger.logWarning(
+                "App Group container unavailable; falling back to default store location",
+                category: AppLogger.coreData
+            )
         }
 
         let description = container.persistentStoreDescriptions.first

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
@@ -7,6 +7,17 @@
 
 import CoreData
 
+enum CoreDataStackError: LocalizedError {
+    case appGroupUnavailableAfterMigration
+
+    var errorDescription: String? {
+        switch self {
+        case .appGroupUnavailableAfterMigration:
+            return "App Group container is unavailable, but this install has previously migrated to it. Refusing to silently open an empty default-location store. Check entitlements."
+        }
+    }
+}
+
 final class CoreDataStack: ObservableObject {
     static let shared = CoreDataStack()
 
@@ -15,14 +26,12 @@ final class CoreDataStack: ObservableObject {
     /// App Group container is unavailable (e.g. entitlement regression), we
     /// hard-fail rather than silently opening an empty default-location store
     /// and appearing to have lost the user's data.
-    static let hasMigratedToAppGroupKey = "hasMigratedToAppGroup"
+    private static let hasMigratedToAppGroupKey = "hasMigratedToAppGroup"
 
-    /// Decides what to do when the App Group container may or may not be
-    /// available. Pure function — extracted for unit testing.
     enum StoreURLResolution: Equatable {
         case useGroupURL(URL)
         case fallbackToDefault
-        case hardFail(String)
+        case hardFail
     }
 
     static func resolveStoreURL(
@@ -33,9 +42,7 @@ final class CoreDataStack: ObservableObject {
             return .useGroupURL(groupStoreURL)
         }
         if hasPreviouslyMigrated {
-            return .hardFail(
-                "App Group container is unavailable, but this install has previously migrated to it. Refusing to silently open an empty default-location store. Check entitlements."
-            )
+            return .hardFail
         }
         return .fallbackToDefault
     }
@@ -57,6 +64,8 @@ final class CoreDataStack: ObservableObject {
     private init(inMemory: Bool = false, shouldSeedDefaults: Bool = true) {
         self.shouldSeedDefaults = shouldSeedDefaults
         container = NSPersistentContainer(name: "StayInTouch")
+
+        var didUseGroupURL = false
 
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
@@ -94,13 +103,10 @@ final class CoreDataStack: ObservableObject {
                     }
                 }
                 container.persistentStoreDescriptions.first?.url = groupStoreURL
+                didUseGroupURL = true
 
-            case .hardFail(let message):
-                let error = NSError(
-                    domain: "CoreDataStack",
-                    code: -1001,
-                    userInfo: [NSLocalizedDescriptionKey: message]
-                )
+            case .hardFail:
+                let error = CoreDataStackError.appGroupUnavailableAfterMigration
                 AppLogger.logError(
                     error,
                     category: AppLogger.coreData,
@@ -141,8 +147,11 @@ final class CoreDataStack: ObservableObject {
             }
 
             self.isLoaded = true
-            if !inMemory, AppGroup.coreDataStoreURL != nil {
-                UserDefaults.standard.set(true, forKey: Self.hasMigratedToAppGroupKey)
+            if didUseGroupURL {
+                let defaults = UserDefaults.standard
+                if !defaults.bool(forKey: Self.hasMigratedToAppGroupKey) {
+                    defaults.set(true, forKey: Self.hasMigratedToAppGroupKey)
+                }
             }
             self.seedDefaultsIfNeeded()
         }

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
@@ -1,0 +1,75 @@
+//
+//  CoreDataStoreMigrator.swift
+//  KeepInTouch
+//
+//  Moves the Core Data store from the app's private default location to the
+//  shared App Group container so the widget extension can read from it.
+//  Runs once per install, before the persistent container is loaded.
+//
+
+import Foundation
+
+enum CoreDataStoreMigrator {
+
+    /// The store filenames Core Data creates for a SQLite persistent store.
+    /// All three must move together or the copy is worthless.
+    static let sqliteSidecarSuffixes = ["", "-shm", "-wal"]
+
+    /// Legacy default location — `NSPersistentContainer(name:)` used this by
+    /// default before the App Group move.
+    static func legacyStoreURL(fileManager: FileManager = .default) -> URL? {
+        guard let libraryURL = try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else { return nil }
+        return libraryURL.appendingPathComponent("StayInTouch.sqlite")
+    }
+
+    /// Migrates the legacy store into the app group container if and only if
+    /// the legacy store exists and the target location does not. Safe to call
+    /// on every launch — it short-circuits when migration is unnecessary.
+    ///
+    /// - Parameters:
+    ///   - legacyURL: the pre-migration store location
+    ///   - targetURL: the app group store location
+    ///   - fileManager: injection point for tests
+    /// - Returns: `true` if files were moved, `false` if nothing to do
+    /// - Throws: if file IO fails mid-migration (partial state is possible;
+    ///   caller should surface this as a migration failure)
+    @discardableResult
+    static func migrateIfNeeded(
+        legacyURL: URL,
+        targetURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        guard fileManager.fileExists(atPath: legacyURL.path) else {
+            return false
+        }
+        guard !fileManager.fileExists(atPath: targetURL.path) else {
+            return false
+        }
+
+        try fileManager.createDirectory(
+            at: targetURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        for suffix in sqliteSidecarSuffixes {
+            let source = URL(fileURLWithPath: legacyURL.path + suffix)
+            let destination = URL(fileURLWithPath: targetURL.path + suffix)
+
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            try fileManager.copyItem(at: source, to: destination)
+        }
+
+        for suffix in sqliteSidecarSuffixes {
+            let source = URL(fileURLWithPath: legacyURL.path + suffix)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            try? fileManager.removeItem(at: source)
+        }
+
+        return true
+    }
+}

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
@@ -6,6 +6,14 @@
 //  shared App Group container so the widget extension can read from it.
 //  Runs once per install, before the persistent container is loaded.
 //
+//  Robustness model:
+//  - A sentinel marker file is created only after every sidecar has been
+//    copied successfully. "Migration complete" == "marker exists".
+//  - If a prior run was killed mid-copy (no throw, no cleanup), the marker
+//    will be absent. On the next launch we detect the partial target, clean
+//    it up, and restart migration from the legacy source.
+//  - Legacy source files are never deleted before the marker lands.
+//
 
 import Foundation
 
@@ -14,6 +22,11 @@ enum CoreDataStoreMigrator {
     /// The store filenames Core Data creates for a SQLite persistent store.
     /// All three must move together or the copy is worthless.
     static let sqliteSidecarSuffixes = ["", "-shm", "-wal"]
+
+    /// Written alongside the target store only after every sidecar has been
+    /// copied. Presence of this file is the single source of truth for
+    /// "migration has fully completed".
+    static let migrationMarkerFilename = ".StayInTouch-migration-complete"
 
     /// Legacy default location — `NSPersistentContainer(name:)` used this by
     /// default before the App Group move.
@@ -27,33 +40,49 @@ enum CoreDataStoreMigrator {
         return libraryURL.appendingPathComponent(AppGroup.coreDataStoreFilename)
     }
 
-    /// Migrates the legacy store into the app group container if and only if
-    /// the legacy store exists and the target location does not. Safe to call
-    /// on every launch — it short-circuits when migration is unnecessary.
+    static func migrationMarkerURL(for targetURL: URL) -> URL {
+        targetURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(migrationMarkerFilename)
+    }
+
+    /// Migrates the legacy store into the app group container if and only if:
+    /// - the legacy store exists, AND
+    /// - the marker file does not yet exist (i.e. no prior successful migration).
     ///
-    /// If the copy phase throws part-way through, any files already copied to
-    /// the target are removed before the error is rethrown, so the next
-    /// launch retries from a clean target rather than opening a partial store.
+    /// If an earlier run was interrupted (process kill, power loss) after
+    /// some sidecars copied but before the marker was written, the partial
+    /// target files are removed before the retry.
+    ///
+    /// If the copy phase throws part-way through, files already copied to
+    /// the target are removed before the error is rethrown, and the marker
+    /// is not written. Legacy files are never touched until after the marker
+    /// is in place.
     ///
     /// - Parameters:
     ///   - legacyURL: the pre-migration store location
     ///   - targetURL: the app group store location
     ///   - fileManager: injection point for tests
-    /// - Returns: `true` if files were moved, `false` if nothing to do
+    /// - Returns: `true` if files were moved on this call, `false` otherwise
     /// - Throws: if file IO fails. Target is cleaned up before the throw so
-    ///   a subsequent call can retry. Legacy files are preserved on throw.
+    ///   a subsequent call can retry cleanly. Legacy files are preserved.
     @discardableResult
     static func migrateIfNeeded(
         legacyURL: URL,
         targetURL: URL,
         fileManager: FileManager = .default
     ) throws -> Bool {
+        let markerURL = migrationMarkerURL(for: targetURL)
+
+        if fileManager.fileExists(atPath: markerURL.path) {
+            return false
+        }
+
         guard fileManager.fileExists(atPath: legacyURL.path) else {
             return false
         }
-        guard !fileManager.fileExists(atPath: targetURL.path) else {
-            return false
-        }
+
+        cleanupTarget(targetURL, fileManager: fileManager)
 
         try fileManager.createDirectory(
             at: targetURL.deletingLastPathComponent(),
@@ -82,6 +111,12 @@ enum CoreDataStoreMigrator {
             throw error
         }
 
+        fileManager.createFile(
+            atPath: markerURL.path,
+            contents: Data(),
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+
         for suffix in sqliteSidecarSuffixes {
             let source = URL(fileURLWithPath: legacyURL.path + suffix)
             guard fileManager.fileExists(atPath: source.path) else { continue }
@@ -96,5 +131,28 @@ enum CoreDataStoreMigrator {
         }
 
         return true
+    }
+
+    /// Removes any orphan target files from a prior incomplete migration.
+    /// Called only when the marker is absent — a fully-migrated target is
+    /// never touched here.
+    private static func cleanupTarget(_ targetURL: URL, fileManager: FileManager) {
+        for suffix in sqliteSidecarSuffixes {
+            let url = URL(fileURLWithPath: targetURL.path + suffix)
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            do {
+                try fileManager.removeItem(at: url)
+                AppLogger.logWarning(
+                    "Cleaned up orphan Core Data file at \(url.path) from a prior incomplete migration",
+                    category: AppLogger.coreData
+                )
+            } catch {
+                AppLogger.logError(
+                    error,
+                    category: AppLogger.coreData,
+                    context: "CoreDataStoreMigrator.cleanupTarget(\(url.lastPathComponent))"
+                )
+            }
+        }
     }
 }

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
@@ -24,20 +24,24 @@ enum CoreDataStoreMigrator {
             appropriateFor: nil,
             create: false
         ) else { return nil }
-        return libraryURL.appendingPathComponent("StayInTouch.sqlite")
+        return libraryURL.appendingPathComponent(AppGroup.coreDataStoreFilename)
     }
 
     /// Migrates the legacy store into the app group container if and only if
     /// the legacy store exists and the target location does not. Safe to call
     /// on every launch — it short-circuits when migration is unnecessary.
     ///
+    /// If the copy phase throws part-way through, any files already copied to
+    /// the target are removed before the error is rethrown, so the next
+    /// launch retries from a clean target rather than opening a partial store.
+    ///
     /// - Parameters:
     ///   - legacyURL: the pre-migration store location
     ///   - targetURL: the app group store location
     ///   - fileManager: injection point for tests
     /// - Returns: `true` if files were moved, `false` if nothing to do
-    /// - Throws: if file IO fails mid-migration (partial state is possible;
-    ///   caller should surface this as a migration failure)
+    /// - Throws: if file IO fails. Target is cleaned up before the throw so
+    ///   a subsequent call can retry. Legacy files are preserved on throw.
     @discardableResult
     static func migrateIfNeeded(
         legacyURL: URL,
@@ -56,18 +60,39 @@ enum CoreDataStoreMigrator {
             withIntermediateDirectories: true
         )
 
-        for suffix in sqliteSidecarSuffixes {
-            let source = URL(fileURLWithPath: legacyURL.path + suffix)
-            let destination = URL(fileURLWithPath: targetURL.path + suffix)
+        var copiedDestinations: [URL] = []
+        do {
+            for suffix in sqliteSidecarSuffixes {
+                let source = URL(fileURLWithPath: legacyURL.path + suffix)
+                let destination = URL(fileURLWithPath: targetURL.path + suffix)
 
-            guard fileManager.fileExists(atPath: source.path) else { continue }
-            try fileManager.copyItem(at: source, to: destination)
+                guard fileManager.fileExists(atPath: source.path) else { continue }
+                try fileManager.copyItem(at: source, to: destination)
+                copiedDestinations.append(destination)
+
+                try? fileManager.setAttributes(
+                    [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                    ofItemAtPath: destination.path
+                )
+            }
+        } catch {
+            for destination in copiedDestinations {
+                try? fileManager.removeItem(at: destination)
+            }
+            throw error
         }
 
         for suffix in sqliteSidecarSuffixes {
             let source = URL(fileURLWithPath: legacyURL.path + suffix)
             guard fileManager.fileExists(atPath: source.path) else { continue }
-            try? fileManager.removeItem(at: source)
+            do {
+                try fileManager.removeItem(at: source)
+            } catch {
+                AppLogger.logWarning(
+                    "Failed to remove legacy Core Data file at \(source.path): \(error.localizedDescription)",
+                    category: AppLogger.coreData
+                )
+            }
         }
 
         return true

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStoreMigrator.swift
@@ -2,34 +2,22 @@
 //  CoreDataStoreMigrator.swift
 //  KeepInTouch
 //
-//  Moves the Core Data store from the app's private default location to the
-//  shared App Group container so the widget extension can read from it.
-//  Runs once per install, before the persistent container is loaded.
-//
-//  Robustness model:
-//  - A sentinel marker file is created only after every sidecar has been
-//    copied successfully. "Migration complete" == "marker exists".
-//  - If a prior run was killed mid-copy (no throw, no cleanup), the marker
-//    will be absent. On the next launch we detect the partial target, clean
-//    it up, and restart migration from the legacy source.
-//  - Legacy source files are never deleted before the marker lands.
+//  Invariants:
+//  - The marker file is written only after every sidecar copy succeeds.
+//  - Legacy source files are never deleted until the marker is in place.
 //
 
 import Foundation
 
 enum CoreDataStoreMigrator {
 
-    /// The store filenames Core Data creates for a SQLite persistent store.
-    /// All three must move together or the copy is worthless.
+    /// SQLite writes data to three files in lockstep — main DB plus `-shm`
+    /// (shared memory) and `-wal` (write-ahead log). All three must move
+    /// together or uncheckpointed writes are lost.
     static let sqliteSidecarSuffixes = ["", "-shm", "-wal"]
 
-    /// Written alongside the target store only after every sidecar has been
-    /// copied. Presence of this file is the single source of truth for
-    /// "migration has fully completed".
-    static let migrationMarkerFilename = ".StayInTouch-migration-complete"
+    private static let migrationMarkerFilename = ".StayInTouch-migration-complete"
 
-    /// Legacy default location — `NSPersistentContainer(name:)` used this by
-    /// default before the App Group move.
     static func legacyStoreURL(fileManager: FileManager = .default) -> URL? {
         guard let libraryURL = try? fileManager.url(
             for: .applicationSupportDirectory,
@@ -46,26 +34,12 @@ enum CoreDataStoreMigrator {
             .appendingPathComponent(migrationMarkerFilename)
     }
 
-    /// Migrates the legacy store into the app group container if and only if:
-    /// - the legacy store exists, AND
-    /// - the marker file does not yet exist (i.e. no prior successful migration).
+    /// Migrates the legacy store into the app group container if and only if
+    /// the marker file does not yet exist and the legacy store is present.
     ///
-    /// If an earlier run was interrupted (process kill, power loss) after
-    /// some sidecars copied but before the marker was written, the partial
-    /// target files are removed before the retry.
-    ///
-    /// If the copy phase throws part-way through, files already copied to
-    /// the target are removed before the error is rethrown, and the marker
-    /// is not written. Legacy files are never touched until after the marker
-    /// is in place.
-    ///
-    /// - Parameters:
-    ///   - legacyURL: the pre-migration store location
-    ///   - targetURL: the app group store location
-    ///   - fileManager: injection point for tests
-    /// - Returns: `true` if files were moved on this call, `false` otherwise
-    /// - Throws: if file IO fails. Target is cleaned up before the throw so
-    ///   a subsequent call can retry cleanly. Legacy files are preserved.
+    /// - Returns: `true` when files were moved on this call.
+    /// - Throws: if the copy phase fails. Files already copied to the target
+    ///   are removed before rethrowing; legacy files are preserved.
     @discardableResult
     static func migrateIfNeeded(
         legacyURL: URL,
@@ -133,7 +107,6 @@ enum CoreDataStoreMigrator {
         return true
     }
 
-    /// Removes any orphan target files from a prior incomplete migration.
     /// Called only when the marker is absent — a fully-migrated target is
     /// never touched here.
     private static func cleanupTarget(_ targetURL: URL, fileManager: FileManager) {

--- a/StayInTouch/StayInTouch/Shared/AppGroup.swift
+++ b/StayInTouch/StayInTouch/Shared/AppGroup.swift
@@ -1,0 +1,23 @@
+//
+//  AppGroup.swift
+//  KeepInTouch
+//
+//  Shared across the app and widget extension. Exposes the App Group
+//  identifier and a helper for resolving the shared container URL.
+//
+
+import Foundation
+
+enum AppGroup {
+    static let identifier = "group.slavins.co.KeepInTouch"
+
+    static var containerURL: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)
+    }
+
+    static let coreDataStoreFilename = "StayInTouch.sqlite"
+
+    static var coreDataStoreURL: URL? {
+        containerURL?.appendingPathComponent(coreDataStoreFilename)
+    }
+}

--- a/StayInTouch/StayInTouch/StayInTouch.entitlements
+++ b/StayInTouch/StayInTouch/StayInTouch.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.slavins.co.KeepInTouch</string>
+	</array>
+</dict>
+</plist>

--- a/StayInTouch/StayInTouchTests/CoreDataMigrationTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataMigrationTests.swift
@@ -72,15 +72,16 @@ final class CoreDataMigrationTests: XCTestCase {
             groupStoreURL: nil,
             hasPreviouslyMigrated: true
         )
+        XCTAssertEqual(resolution, .hardFail)
+    }
 
-        if case .hardFail(let message) = resolution {
-            XCTAssertTrue(
-                message.contains("previously migrated"),
-                "Hard-fail message should reference the prior migration, got: \(message)"
-            )
-        } else {
-            XCTFail("Expected .hardFail resolution when App Group is nil after migration, got \(resolution)")
-        }
+    func test_coreDataStackError_appGroupUnavailableAfterMigration_hasDescriptiveMessage() {
+        let error = CoreDataStackError.appGroupUnavailableAfterMigration
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertTrue(
+            error.errorDescription!.contains("previously migrated"),
+            "Error description should reference prior migration, got: \(error.errorDescription ?? "nil")"
+        )
     }
 
     func testInMemoryStoreCanInsertAndFetch() throws {

--- a/StayInTouch/StayInTouchTests/CoreDataMigrationTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataMigrationTests.swift
@@ -39,6 +39,50 @@ final class CoreDataMigrationTests: XCTestCase {
         XCTAssertTrue(entityNames.contains("AppSettings"))
     }
 
+    // MARK: - resolveStoreURL
+
+    func test_resolveStoreURL_whenGroupURLPresent_usesGroupURL() {
+        let url = URL(fileURLWithPath: "/tmp/group/StayInTouch.sqlite")
+        let resolution = CoreDataStack.resolveStoreURL(
+            groupStoreURL: url,
+            hasPreviouslyMigrated: false
+        )
+        XCTAssertEqual(resolution, .useGroupURL(url))
+    }
+
+    func test_resolveStoreURL_whenGroupURLPresentAndAlreadyMigrated_stillUsesGroupURL() {
+        let url = URL(fileURLWithPath: "/tmp/group/StayInTouch.sqlite")
+        let resolution = CoreDataStack.resolveStoreURL(
+            groupStoreURL: url,
+            hasPreviouslyMigrated: true
+        )
+        XCTAssertEqual(resolution, .useGroupURL(url))
+    }
+
+    func test_resolveStoreURL_whenGroupNilOnFreshInstall_fallsBack() {
+        let resolution = CoreDataStack.resolveStoreURL(
+            groupStoreURL: nil,
+            hasPreviouslyMigrated: false
+        )
+        XCTAssertEqual(resolution, .fallbackToDefault)
+    }
+
+    func test_resolveStoreURL_whenGroupNilAfterPriorMigration_hardFails() {
+        let resolution = CoreDataStack.resolveStoreURL(
+            groupStoreURL: nil,
+            hasPreviouslyMigrated: true
+        )
+
+        if case .hardFail(let message) = resolution {
+            XCTAssertTrue(
+                message.contains("previously migrated"),
+                "Hard-fail message should reference the prior migration, got: \(message)"
+            )
+        } else {
+            XCTFail("Expected .hardFail resolution when App Group is nil after migration, got \(resolution)")
+        }
+    }
+
     func testInMemoryStoreCanInsertAndFetch() throws {
         let stack = CoreDataStack.make(inMemory: true, shouldSeedDefaults: false)
         let context = stack.viewContext

--- a/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
@@ -111,15 +111,17 @@ final class CoreDataStoreMigratorTests: XCTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path + "-wal"))
     }
 
-    // MARK: - Partial recovery
+    // MARK: - Completed migration (marker present)
 
-    func test_migrateIfNeeded_whenTargetAlreadyExists_doesNothing() throws {
+    func test_migrateIfNeeded_whenMarkerExists_doesNothingAndPreservesTarget() throws {
         let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
         let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+        let markerURL = CoreDataStoreMigrator.migrationMarkerURL(for: targetURL)
 
         try fileManager.createDirectory(at: groupDir, withIntermediateDirectories: true)
         try "legacy-data".write(to: legacyURL, atomically: true, encoding: .utf8)
         try "existing-group-data".write(to: targetURL, atomically: true, encoding: .utf8)
+        fileManager.createFile(atPath: markerURL.path, contents: Data())
 
         let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
             legacyURL: legacyURL,
@@ -131,11 +133,97 @@ final class CoreDataStoreMigratorTests: XCTestCase {
         XCTAssertEqual(
             try String(contentsOf: targetURL, encoding: .utf8),
             "existing-group-data",
-            "Existing group store must never be overwritten"
+            "Completed-migration target must never be overwritten"
         )
         XCTAssertTrue(
             fileManager.fileExists(atPath: legacyURL.path),
-            "Legacy files must be preserved when migration is skipped"
+            "Legacy files not in our scope to delete once a prior migration finalized; leave them alone"
+        )
+    }
+
+    // MARK: - Interrupted migration (no marker, partial target)
+
+    func test_migrateIfNeeded_whenTargetHasPartialFilesWithoutMarker_cleansTargetAndRemigrates() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+        let markerURL = CoreDataStoreMigrator.migrationMarkerURL(for: targetURL)
+
+        try fileManager.createDirectory(at: groupDir, withIntermediateDirectories: true)
+        try "truncated-db".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        try "fresh-main".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "fresh-shm".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-shm"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "fresh-wal".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertTrue(migrated)
+        XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "fresh-main")
+        XCTAssertEqual(
+            try String(contentsOf: URL(fileURLWithPath: targetURL.path + "-wal"), encoding: .utf8),
+            "fresh-wal"
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: markerURL.path),
+            "Marker must be written after successful remigration"
+        )
+    }
+
+    // MARK: - Marker lifecycle
+
+    func test_migrateIfNeeded_onSuccessfulMigration_createsMarker() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+        let markerURL = CoreDataStoreMigrator.migrationMarkerURL(for: targetURL)
+
+        try "data".write(to: legacyURL, atomically: true, encoding: .utf8)
+
+        _ = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertTrue(fileManager.fileExists(atPath: markerURL.path))
+    }
+
+    func test_migrateIfNeeded_onCopyThrow_doesNotCreateMarker() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+        let markerURL = CoreDataStoreMigrator.migrationMarkerURL(for: targetURL)
+
+        try "data".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "wal".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let failingFM = FailingFileManager(failCopyToPathContaining: targetURL.path + "-wal")
+
+        XCTAssertThrowsError(
+            try CoreDataStoreMigrator.migrateIfNeeded(
+                legacyURL: legacyURL,
+                targetURL: targetURL,
+                fileManager: failingFM
+            )
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: markerURL.path),
+            "Marker must never be written when the copy phase throws"
         )
     }
 

--- a/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
@@ -1,0 +1,204 @@
+//
+//  CoreDataStoreMigratorTests.swift
+//  KeepInTouchTests
+//
+//  Covers the pre-load migration from the legacy default store location to
+//  the App Group container. This is the critical data-safety path for the
+//  widget infrastructure rollout.
+//
+
+import XCTest
+@testable import StayInTouch
+
+final class CoreDataStoreMigratorTests: XCTestCase {
+
+    private var legacyDir: URL!
+    private var groupDir: URL!
+    private var fileManager: FileManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        fileManager = FileManager.default
+
+        let base = fileManager.temporaryDirectory.appendingPathComponent(
+            "CoreDataStoreMigratorTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        legacyDir = base.appendingPathComponent("legacy", isDirectory: true)
+        groupDir = base.appendingPathComponent("group", isDirectory: true)
+
+        try fileManager.createDirectory(at: legacyDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        let parent = legacyDir.deletingLastPathComponent()
+        try? fileManager.removeItem(at: parent)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Fresh install
+
+    func test_migrateIfNeeded_whenLegacyStoreAbsent_doesNothing() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertFalse(migrated)
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
+    }
+
+    // MARK: - Upgrade path
+
+    func test_migrateIfNeeded_whenLegacyStoreExists_copiesAllSidecarsAndRemovesLegacy() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db-bytes".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "shm-bytes".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-shm"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "wal-bytes".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertTrue(migrated)
+
+        XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "main-db-bytes")
+        XCTAssertEqual(
+            try String(contentsOf: URL(fileURLWithPath: targetURL.path + "-shm"), encoding: .utf8),
+            "shm-bytes"
+        )
+        XCTAssertEqual(
+            try String(contentsOf: URL(fileURLWithPath: targetURL.path + "-wal"), encoding: .utf8),
+            "wal-bytes"
+        )
+
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyURL.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyURL.path + "-shm"))
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyURL.path + "-wal"))
+    }
+
+    func test_migrateIfNeeded_whenLegacyHasOnlyMainFile_copiesOnlyMainFile() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db-bytes".write(to: legacyURL, atomically: true, encoding: .utf8)
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertTrue(migrated)
+        XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path + "-shm"))
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path + "-wal"))
+    }
+
+    // MARK: - Partial recovery
+
+    func test_migrateIfNeeded_whenTargetAlreadyExists_doesNothing() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try fileManager.createDirectory(at: groupDir, withIntermediateDirectories: true)
+        try "legacy-data".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "existing-group-data".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertFalse(migrated)
+        XCTAssertEqual(
+            try String(contentsOf: targetURL, encoding: .utf8),
+            "existing-group-data",
+            "Existing group store must never be overwritten"
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: legacyURL.path),
+            "Legacy files must be preserved when migration is skipped"
+        )
+    }
+
+    // MARK: - Idempotency
+
+    func test_migrateIfNeeded_isIdempotent_onSecondCall() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db-bytes".write(to: legacyURL, atomically: true, encoding: .utf8)
+
+        _ = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        let secondRun = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertFalse(secondRun)
+        XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "main-db-bytes")
+    }
+
+    // MARK: - Directory creation
+
+    func test_migrateIfNeeded_createsTargetDirectoryIfMissing() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db-bytes".write(to: legacyURL, atomically: true, encoding: .utf8)
+        XCTAssertFalse(fileManager.fileExists(atPath: groupDir.path))
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: fileManager
+        )
+
+        XCTAssertTrue(migrated)
+        XCTAssertTrue(fileManager.fileExists(atPath: groupDir.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
+    }
+
+    // MARK: - AppGroup identifier sanity
+
+    func test_appGroupIdentifier_matchesEntitlement() {
+        XCTAssertEqual(AppGroup.identifier, "group.slavins.co.KeepInTouch")
+    }
+
+    func test_appGroupCoreDataStoreURL_appendsCorrectFilename() {
+        guard let containerURL = AppGroup.containerURL,
+              let storeURL = AppGroup.coreDataStoreURL else {
+            return
+        }
+
+        XCTAssertEqual(storeURL.lastPathComponent, "StayInTouch.sqlite")
+        XCTAssertEqual(
+            storeURL.deletingLastPathComponent().path,
+            containerURL.path
+        )
+    }
+}

--- a/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
@@ -183,6 +183,114 @@ final class CoreDataStoreMigratorTests: XCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: targetURL.path))
     }
 
+    // MARK: - Partial-copy failure cleanup
+
+    func test_migrateIfNeeded_whenCopyThrowsMidLoop_removesPartialTargetFilesAndPreservesLegacy() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "shm".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-shm"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "wal".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let failingFM = FailingFileManager(
+            failCopyToPathContaining: targetURL.path + "-wal"
+        )
+
+        XCTAssertThrowsError(
+            try CoreDataStoreMigrator.migrateIfNeeded(
+                legacyURL: legacyURL,
+                targetURL: targetURL,
+                fileManager: failingFM
+            )
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: targetURL.path),
+            "Partial main .sqlite must be cleaned up after throw"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: targetURL.path + "-shm"),
+            "Partial -shm must be cleaned up after throw"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: targetURL.path + "-wal"),
+            "Partial -wal must never exist if its copy threw"
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: legacyURL.path),
+            "Legacy main .sqlite must be preserved when migration throws"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: legacyURL.path + "-shm"),
+            "Legacy -shm must be preserved when migration throws"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: legacyURL.path + "-wal"),
+            "Legacy -wal must be preserved when migration throws"
+        )
+    }
+
+    func test_migrateIfNeeded_afterCopyThrowRecovery_succeedsOnRetryWithRealFileManager() throws {
+        let legacyURL = legacyDir.appendingPathComponent("StayInTouch.sqlite")
+        let targetURL = groupDir.appendingPathComponent("StayInTouch.sqlite")
+
+        try "main-db".write(to: legacyURL, atomically: true, encoding: .utf8)
+        try "wal".write(
+            to: URL(fileURLWithPath: legacyURL.path + "-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let failingFM = FailingFileManager(
+            failCopyToPathContaining: targetURL.path + "-wal"
+        )
+        XCTAssertThrowsError(
+            try CoreDataStoreMigrator.migrateIfNeeded(
+                legacyURL: legacyURL,
+                targetURL: targetURL,
+                fileManager: failingFM
+            )
+        )
+
+        let migrated = try CoreDataStoreMigrator.migrateIfNeeded(
+            legacyURL: legacyURL,
+            targetURL: targetURL,
+            fileManager: FileManager.default
+        )
+
+        XCTAssertTrue(migrated)
+        XCTAssertEqual(try String(contentsOf: targetURL, encoding: .utf8), "main-db")
+        XCTAssertEqual(
+            try String(contentsOf: URL(fileURLWithPath: targetURL.path + "-wal"), encoding: .utf8),
+            "wal"
+        )
+    }
+
+    // MARK: - Legacy store URL derivation
+
+    func test_legacyStoreURL_pointsToApplicationSupportStayInTouchSqlite() {
+        guard let legacyURL = CoreDataStoreMigrator.legacyStoreURL() else {
+            XCTFail("legacyStoreURL should return a URL when Application Support exists")
+            return
+        }
+
+        XCTAssertEqual(legacyURL.lastPathComponent, "StayInTouch.sqlite")
+        XCTAssertTrue(
+            legacyURL.path.contains("Application Support"),
+            "Legacy URL should resolve under Application Support, got \(legacyURL.path)"
+        )
+    }
+
     // MARK: - AppGroup identifier sanity
 
     func test_appGroupIdentifier_matchesEntitlement() {
@@ -195,10 +303,33 @@ final class CoreDataStoreMigratorTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(storeURL.lastPathComponent, "StayInTouch.sqlite")
+        XCTAssertEqual(storeURL.lastPathComponent, AppGroup.coreDataStoreFilename)
         XCTAssertEqual(
             storeURL.deletingLastPathComponent().path,
             containerURL.path
         )
+    }
+}
+
+/// Test double that delegates to the real FileManager but throws from
+/// `copyItem(at:to:)` when the destination path contains the configured
+/// substring. Lets us simulate a mid-copy disk failure.
+private final class FailingFileManager: FileManager {
+    private let failCopyToPathContaining: String
+
+    init(failCopyToPathContaining substring: String) {
+        self.failCopyToPathContaining = substring
+        super.init()
+    }
+
+    override func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        if dstURL.path.contains(failCopyToPathContaining) {
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteUnknownError,
+                userInfo: [NSLocalizedDescriptionKey: "Injected failure for \(dstURL.path)"]
+            )
+        }
+        try super.copyItem(at: srcURL, to: dstURL)
     }
 }

--- a/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
+++ b/StayInTouch/StayInTouchTests/CoreDataStoreMigratorTests.swift
@@ -385,11 +385,11 @@ final class CoreDataStoreMigratorTests: XCTestCase {
         XCTAssertEqual(AppGroup.identifier, "group.slavins.co.KeepInTouch")
     }
 
-    func test_appGroupCoreDataStoreURL_appendsCorrectFilename() {
-        guard let containerURL = AppGroup.containerURL,
-              let storeURL = AppGroup.coreDataStoreURL else {
-            return
-        }
+    func test_appGroupCoreDataStoreURL_appendsCorrectFilename() throws {
+        try XCTSkipIf(AppGroup.containerURL == nil, "No App Group entitlement in test host")
+
+        let containerURL = AppGroup.containerURL!
+        let storeURL = AppGroup.coreDataStoreURL!
 
         XCTAssertEqual(storeURL.lastPathComponent, AppGroup.coreDataStoreFilename)
         XCTAssertEqual(
@@ -399,9 +399,6 @@ final class CoreDataStoreMigratorTests: XCTestCase {
     }
 }
 
-/// Test double that delegates to the real FileManager but throws from
-/// `copyItem(at:to:)` when the destination path contains the configured
-/// substring. Lets us simulate a mid-copy disk failure.
 private final class FailingFileManager: FileManager {
     private let failCopyToPathContaining: String
 


### PR DESCRIPTION
## Summary

Infrastructure preparation for iOS widget support ([#60](https://github.com/slavins-co/keep-in-touch/issues/60)). Moves the Core Data store into the `group.slavins.co.KeepInTouch` App Group container so the upcoming widget extension can read from it. Migrates any pre-existing data from the legacy default-location store on first launch.

Split out from the widget feature PR intentionally — this change has real data-loss blast radius and deserves isolated review and rollback ability. No widget target or user-visible change ships here; PR 2 will add the widget itself.

## What changes

- `AppGroup.swift` — identifier + `containerURL` helpers, shared with the future widget target
- `StayInTouch.entitlements` — adds `com.apple.security.application-groups` with `group.slavins.co.KeepInTouch`
- `CoreDataStack` — prefers the App Group store URL; falls back to the default location with a warning log if the container is unavailable (defensive)
- `CoreDataStoreMigrator` — one-time pre-`loadPersistentStores` copy of `.sqlite` + `-shm` + `-wal` from the legacy default location; deletes the legacy files after a successful copy; short-circuits on subsequent launches
- `project.pbxproj` — adds `CODE_SIGN_ENTITLEMENTS` to Debug + Release configs and excludes `StayInTouch.entitlements` from the synchronized-folder membership set

## Manual migration verification (completed)

Verified on simulator before this PR was opened:
- [x] Contact status (SLA + group) and touch history identical between main build and feature-branch build
- [x] Touch history log preserved across the switch
- [x] App settings (theme, onboarding state) preserved across the switch
- [x] New touch logged on the feature build persists after force-quit

## Automated coverage

`CoreDataStoreMigratorTests` — 8 new tests:
- Fresh install (no legacy store)
- Full upgrade path (copies all three sidecar files, removes legacy)
- Partial legacy (only main `.sqlite` present)
- Target already exists (never overwrite; preserve legacy)
- Idempotency (second call is a no-op)
- Target directory creation when missing
- `AppGroup.identifier` matches the entitlement
- `AppGroup.coreDataStoreURL` appends the correct filename

Full suite: 349 tests pass, 0 failures.

## Test plan

- [x] `xcodebuild ... build` succeeds
- [x] `xcodebuild ... test` — all tests green (349 passed)
- [x] CodeSign step applies entitlements (`--entitlements ... .xcent` visible in build log)
- [x] Manual upgrade-with-data test (see above)
- [ ] `/code-review`
- [ ] `/security-review`

## Follow-up

- PR 2 ([#60](https://github.com/slavins-co/keep-in-touch/issues/60)) — widget target, deep link router, timeline provider, small + medium views, `LogTouchIntent`, reload hooks
- [#279](https://github.com/slavins-co/keep-in-touch/issues/279) — Lock Screen + StandBy accessory widgets (post-PR 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)