### PR TITLE
[#278] Display nickname in contact detail and list views

### DIFF
--- a/StayInTouch/StayInTouch/Domain/Entities/Person.swift
+++ b/StayInTouch/StayInTouch/Domain/Entities/Person.swift
@@ -45,4 +45,16 @@ struct Person: Identifiable, Equatable, Hashable {
     var createdAt: Date
     var modifiedAt: Date
     var sortOrder: Int
+
+    /// Nickname to display in UI. Returns nil when the stored nickname is
+    /// absent, empty/whitespace, or equals `displayName` (trimmed, case-insensitive)
+    /// so contacts whose Contacts-app nickname echoes their first name don't
+    /// render a duplicate.
+    var displayNickname: String? {
+        guard let raw = nickname?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty,
+              raw.caseInsensitiveCompare(displayName.trimmingCharacters(in: .whitespacesAndNewlines)) != .orderedSame
+        else { return nil }
+        return raw
+    }
 }

--- a/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
@@ -29,10 +29,10 @@ struct ContactCard: View {
 
             VStack(alignment: .leading, spacing: DS.Spacing.xxs) {
                 HStack(spacing: DS.Spacing.xs) {
-                    Text(person.displayName)
+                    nameText
                         .font(DS.Typography.contactCardName)
-                        .foregroundStyle(DS.Colors.primaryText)
                         .lineLimit(1)
+                        .truncationMode(.tail)
                     if person.birthday?.isToday == true {
                         Image(systemName: "gift.fill")
                             .font(.caption)
@@ -69,6 +69,18 @@ struct ContactCard: View {
         .contentShape(Rectangle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
+    }
+
+    // MARK: - Name
+
+    private var nameText: Text {
+        let base = Text(person.displayName)
+            .foregroundColor(DS.Colors.primaryText)
+        if let nickname = person.displayNickname {
+            return base + Text(" (\(nickname))")
+                .foregroundColor(Color(.secondaryLabel))
+        }
+        return base
     }
 
     // MARK: - Metadata Row
@@ -118,7 +130,12 @@ struct ContactCard: View {
     // MARK: - Accessibility
 
     private var accessibilityDescription: String {
-        var parts: [String] = ["Contact \(person.displayName)"]
+        var parts: [String] = []
+        if let nickname = person.displayNickname {
+            parts.append("Contact \(person.displayName), also known as \(nickname)")
+        } else {
+            parts.append("Contact \(person.displayName)")
+        }
 
         if person.birthday?.isToday == true {
             parts.append("birthday today")

--- a/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/ContactCard.swift
@@ -75,10 +75,10 @@ struct ContactCard: View {
 
     private var nameText: Text {
         let base = Text(person.displayName)
-            .foregroundColor(DS.Colors.primaryText)
+            .foregroundStyle(DS.Colors.primaryText)
         if let nickname = person.displayNickname {
             return base + Text(" (\(nickname))")
-                .foregroundColor(Color(.secondaryLabel))
+                .foregroundStyle(Color(.secondaryLabel))
         }
         return base
     }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonHeroSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonHeroSection.swift
@@ -45,6 +45,14 @@ struct PersonHeroSection: View {
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
 
+            if let nickname = viewModel.person.displayNickname {
+                Text("\u{2018}\(nickname)\u{2019}")
+                    .font(DS.Typography.contactCardMeta)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .multilineTextAlignment(.center)
+                    .accessibilityLabel("Nickname \(nickname)")
+            }
+
             Text(statusLabel())
                 .font(DS.Typography.detailStatusLine)
                 .foregroundStyle(statusLineColor)

--- a/StayInTouch/StayInTouchTests/PersonTests.swift
+++ b/StayInTouch/StayInTouchTests/PersonTests.swift
@@ -1,0 +1,81 @@
+//
+//  PersonTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+final class PersonTests: XCTestCase {
+
+    // MARK: - displayNickname
+
+    func testDisplayNicknameNilWhenNicknameIsNil() {
+        let person = makePerson(displayName: "Robert Smith", nickname: nil)
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameNilWhenNicknameIsEmpty() {
+        let person = makePerson(displayName: "Robert Smith", nickname: "")
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameNilWhenNicknameIsWhitespaceOnly() {
+        let person = makePerson(displayName: "Robert Smith", nickname: "   \n\t ")
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameNilWhenEqualToDisplayNameExactly() {
+        let person = makePerson(displayName: "Robert", nickname: "Robert")
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameNilWhenEqualToDisplayNameCaseInsensitive() {
+        let person = makePerson(displayName: "Robert", nickname: "ROBERT")
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameNilWhenEqualToDisplayNameAfterTrim() {
+        let person = makePerson(displayName: "Robert", nickname: "  Robert  ")
+        XCTAssertNil(person.displayNickname)
+    }
+
+    func testDisplayNicknameReturnsTrimmedValueWhenDifferent() {
+        let person = makePerson(displayName: "Robert Smith", nickname: "  Bobby  ")
+        XCTAssertEqual(person.displayNickname, "Bobby")
+    }
+
+    // MARK: - Helpers
+
+    private func makePerson(displayName: String, nickname: String?) -> Person {
+        let now = Date()
+        return Person(
+            id: UUID(),
+            cnIdentifier: nil,
+            displayName: displayName,
+            nickname: nickname,
+            initials: String(displayName.prefix(1)),
+            avatarColor: "#FF6B6B",
+            cadenceId: UUID(),
+            groupIds: [],
+            lastTouchAt: nil,
+            lastTouchMethod: nil,
+            lastTouchNotes: nil,
+            nextTouchNotes: nil,
+            isPaused: false,
+            isTracked: true,
+            notificationsMuted: false,
+            customBreachTime: nil,
+            snoozedUntil: nil,
+            customDueDate: nil,
+            birthday: nil,
+            birthdayNotificationsEnabled: true,
+            contactUnavailable: false,
+            isDemoData: false,
+            cadenceAddedAt: nil,
+            createdAt: now,
+            modifiedAt: now,
+            sortOrder: 0
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Person.displayNickname` computed property — returns the stored nickname only when non-empty and not a case-insensitive match of `displayName` (trimmed), so existing contacts whose Contacts-app nickname echoes their first name stay visually unchanged.
- `ContactCard` renders the nickname inline as `Name (Nickname)`, single line, secondary color, so list rows don't grow in height.
- `PersonHeroSection` renders the nickname on a secondary line as `'Nickname'` (typographic curly quotes) below the hero name, centered, secondary color.
- Accessibility descriptions include "also known as <nickname>" (list) and "Nickname <nickname>" (detail).

Closes the visual half of the nickname work — #275 (PR #277) added nickname search; #278 makes the matched field visible so users aren't confused about why a contact appeared in their results.

## Test plan
- [x] 7 new unit tests cover the `displayNickname` dedupe logic (nil/empty/whitespace/case-insensitive/trim/different-value)
- [x] Full suite passes (`xcode_test`, iPhone 17 Pro / iOS 26.3.1)
- [x] Build clean, 0 new warnings
- [ ] Manual: contact with nickname set in iOS Contacts shows `(Nickname)` on Home + Contacts rows, and `'Nickname'` below the name on detail
- [ ] Manual: contact without nickname (or nickname == displayName) renders identical to before
- [ ] Manual: VoiceOver reads "also known as" / "Nickname" lines

Closes #278