### PR TITLE
[#285] Extract brand color tokens into Shared/ for widget reuse

### DIFF
--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
@@ -286,7 +286,7 @@ private struct GroupChip: View {
     let colorHex: String?
 
     var body: some View {
-        let tint = (colorHex.flatMap(Color.init(hex:))) ?? .gray
+        let tint = colorHex.map(Color.init(hex:)) ?? .gray
         Text(name.uppercased())
             .font(.system(size: 10, weight: .semibold))
             .foregroundStyle(tint)
@@ -302,16 +302,11 @@ private struct GroupChip: View {
 struct EmptyStateView: View {
     let hasTrackedPeople: Bool
 
-    /// Hero accent green from the main app's DesignSystem
-    /// (`DS.Colors.heroAccentGreen`, `#3D6B4F`). Mirrored as a literal
-    /// here because the widget doesn't import the app's design system.
-    private static let heroAccentGreen = Color(hex: "3D6B4F") ?? .green
-
     var body: some View {
         VStack(spacing: 8) {
             Image(systemName: hasTrackedPeople ? "hand.wave.fill" : "person.crop.circle.badge.plus")
                 .font(.title)
-                .foregroundStyle(hasTrackedPeople ? Self.heroAccentGreen : .secondary)
+                .foregroundStyle(hasTrackedPeople ? BrandColors.heroAccentGreen : .secondary)
             Text(hasTrackedPeople ? "You've reached out to everyone.\nWay to go!" : "Add someone to track")
                 .font(.caption)
                 .fontWeight(.medium)

--- a/StayInTouch/KeepInTouchWidget/WidgetAvatarView.swift
+++ b/StayInTouch/KeepInTouchWidget/WidgetAvatarView.swift
@@ -29,7 +29,7 @@ struct WidgetAvatarView: View {
 
     var body: some View {
         Circle()
-            .fill(Color(hex: colorHex) ?? .gray)
+            .fill(Color(hex: colorHex))
             .frame(width: diameter, height: diameter)
             .overlay(
                 Text(initials)
@@ -41,18 +41,5 @@ struct WidgetAvatarView: View {
                     .stroke(statusRingColor ?? .clear, lineWidth: 2)
                     .padding(-3)
             )
-    }
-}
-
-extension Color {
-    init?(hex: String) {
-        let cleaned = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
-        guard cleaned.count == 6, let value = UInt32(cleaned, radix: 16) else {
-            return nil
-        }
-        let r = Double((value >> 16) & 0xFF) / 255
-        let g = Double((value >> 8) & 0xFF) / 255
-        let b = Double(value & 0xFF) / 255
-        self.init(red: r, green: g, blue: b)
     }
 }

--- a/StayInTouch/StayInTouch/Shared/BrandColors.swift
+++ b/StayInTouch/StayInTouch/Shared/BrandColors.swift
@@ -1,0 +1,24 @@
+//
+//  BrandColors.swift
+//  KeepInTouch
+//
+//  Single source of truth for brand color hex values shared across the
+//  main app's DesignSystem and the widget extension. Widgets run in a
+//  separate process and can't import DesignSystem.swift, so brand hex
+//  values lived in two places before — see issue #285.
+//
+//  Pattern: expose both the raw hex string (for places that build
+//  adaptive light/dark variants from strings) and the resolved SwiftUI
+//  Color (for direct use). Semantic / adaptive wrapping still belongs
+//  in DesignSystem.swift.
+//
+
+import SwiftUI
+
+enum BrandColors {
+    /// Hero accent green. Brand identity color used for the detail-view
+    /// CTA container, the search focus ring (light), the filter accent
+    /// (light), and the widget's "all caught up" glyph.
+    static let heroAccentGreenHex = "3D6B4F"
+    static let heroAccentGreen = Color(hex: heroAccentGreenHex)
+}

--- a/StayInTouch/StayInTouch/Shared/Color+Hex.swift
+++ b/StayInTouch/StayInTouch/Shared/Color+Hex.swift
@@ -2,7 +2,8 @@
 //  Color+Hex.swift
 //  KeepInTouch
 //
-//  Created by Codex on 2/2/26.
+//  Hex-string <-> Color conversion. Lives in Shared/ so the widget
+//  extension and the main app use a single implementation.
 //
 
 import SwiftUI

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -218,7 +218,7 @@ enum DS {
         )
         // DESIGN: Light/dark structural difference — search focus ring: accent green light / gray-600 dark
         static let searchBarFocusRing = adaptiveColor(
-            light: UIColor(Color(hex: "3D6B4F")),
+            light: UIColor(BrandColors.heroAccentGreen),
             dark: UIColor.systemGray3
         )
         static let searchBarBorder = adaptiveColor(
@@ -232,11 +232,11 @@ enum DS {
 
         // MARK: Filters
 
-        static let filterAccent = adaptive(light: "3D6B4F", dark: "6BCB77")
+        static let filterAccent = adaptive(light: BrandColors.heroAccentGreenHex, dark: "6BCB77")
 
         // MARK: Detail Hero
 
-        static let heroAccentGreen = adaptive(light: "3D6B4F", dark: "3D6B4F")
+        static let heroAccentGreen = BrandColors.heroAccentGreen
         // DESIGN: Light/dark structural difference — hero avatar ring: solid white 4px light / white/5% dark
         static let heroAvatarRing = adaptiveColor(
             light: UIColor.white,
@@ -247,7 +247,7 @@ enum DS {
             dark: UIColor(Color(hex: "1C1C1E"))
         )
         static let ctaShadow = adaptiveColor(
-            light: UIColor(Color(hex: "3D6B4F").opacity(0.3)),
+            light: UIColor(BrandColors.heroAccentGreen.opacity(0.3)),
             dark: UIColor(Color(hex: "064E3B").opacity(0.2))
         )
 
@@ -370,7 +370,7 @@ enum DS {
                 return (Color(hex: "2D1B4E"), Color(hex: "D8B4FE"))
             default:
                 // Accent green fallback
-                return (Color(hex: "3D6B4F"), .white)
+                return (BrandColors.heroAccentGreen, .white)
             }
         }
     }

--- a/StayInTouch/StayInTouchTests/BrandColorsTests.swift
+++ b/StayInTouch/StayInTouchTests/BrandColorsTests.swift
@@ -1,0 +1,27 @@
+//
+//  BrandColorsTests.swift
+//  StayInTouchTests
+//
+//  Locks in the brand hex string shared between the app's DesignSystem
+//  and the widget. Accidental edits to the hex constant should surface
+//  as a test failure rather than a silent visual drift.
+//
+
+import XCTest
+import SwiftUI
+@testable import StayInTouch
+
+final class BrandColorsTests: XCTestCase {
+
+    func test_heroAccentGreenHex_isBrandValue() {
+        XCTAssertEqual(BrandColors.heroAccentGreenHex, "3D6B4F")
+    }
+
+    func test_heroAccentGreen_resolvesFromSharedHex() {
+        // BrandColors.heroAccentGreen must be built from the shared hex
+        // constant, not a parallel literal. Comparing Color values
+        // directly via `==` is reliable for constants created through
+        // the same initializer path.
+        XCTAssertEqual(BrandColors.heroAccentGreen, Color(hex: BrandColors.heroAccentGreenHex))
+    }
+}


### PR DESCRIPTION
## Summary

- Consolidates the brand accent green (`#3D6B4F`) — duplicated 5× in `DesignSystem.swift` and once in the widget — into a single `Shared/BrandColors.swift` source of truth.
- Moves `Color(hex:)` to `Shared/` so the widget can drop its own failable init and use the same API as the app.
- `DS.Colors.heroAccentGreen` now wraps `BrandColors.heroAccentGreen`; widget reads `BrandColors.heroAccentGreen` directly.
- Locks in the brand hex string with a small test so an accidental tweak in either target trips a red.

## Test plan

- [x] Full test suite: 0 failures
- [x] New `BrandColorsTests` passes (hex value + resolved Color wiring)
- [x] Main app + widget compile clean
- [ ] Manual: verify accent green still renders unchanged on PersonDetail CTA container, search focus ring (light mode), filter accent, and widget "all caught up" state

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)