### PR TITLE
[#279] Lock Screen + StandBy accessory widgets

### DIFF
--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
@@ -60,11 +60,12 @@ extension WidgetDataProvider.Snapshot {
             OverduePerson(id: UUID(), displayName: "Jordan", nickname: nil, initials: "J", avatarColorHex: "#FFD166", groupName: "Quarterly", groupColorHex: "#A78BFA", status: .dueSoon(daysUntilDue: 2)),
         ],
         hasTrackedPeople: true,
+        trackedCount: 8,
         themeOverride: nil
     )
 
-    static let empty = WidgetDataProvider.Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: false, themeOverride: nil)
-    static let allCaughtUp = WidgetDataProvider.Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: true, themeOverride: nil)
+    static let empty = WidgetDataProvider.Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: false, trackedCount: 0, themeOverride: nil)
+    static let allCaughtUp = WidgetDataProvider.Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: true, trackedCount: 5, themeOverride: nil)
 }
 
 extension WidgetPersonStatus {

--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
@@ -68,28 +68,13 @@ extension WidgetDataProvider.Snapshot {
 }
 
 extension WidgetPersonStatus {
+    /// SwiftUI ring tint. Lives here (widget target) because `Color` is
+    /// SwiftUI; the textual helpers are in `Shared/WidgetDataProvider.swift`
+    /// so non-SwiftUI consumers (`AccessoryWidgetLogic`, tests) can reach them.
     var ringColor: Color {
         switch self {
         case .overdue: return .red
         case .dueSoon: return .orange
-        }
-    }
-
-    var subtitle: String {
-        switch self {
-        case .overdue(let days):
-            return "\(days) day\(days == 1 ? "" : "s") overdue"
-        case .dueSoon(let days):
-            return days == 0 ? "Due today" : "Due in \(days) day\(days == 1 ? "" : "s")"
-        }
-    }
-
-    var shortSubtitle: String {
-        switch self {
-        case .overdue(let days):
-            return "\(days)d overdue"
-        case .dueSoon(let days):
-            return days == 0 ? "Due today" : "Due in \(days)d"
         }
     }
 }

--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
@@ -55,9 +55,9 @@ extension WidgetDataProvider.Snapshot {
         overdueCount: 2,
         dueSoonCount: 1,
         featured: [
-            OverduePerson(id: UUID(), displayName: "Alex", initials: "A", avatarColorHex: "#FF6B6B", groupName: "Weekly", groupColorHex: "#4ECDC4", status: .overdue(daysOverdue: 5)),
-            OverduePerson(id: UUID(), displayName: "Sam", initials: "S", avatarColorHex: "#4ECDC4", groupName: "Monthly", groupColorHex: "#FFD166", status: .overdue(daysOverdue: 1)),
-            OverduePerson(id: UUID(), displayName: "Jordan", initials: "J", avatarColorHex: "#FFD166", groupName: "Quarterly", groupColorHex: "#A78BFA", status: .dueSoon(daysUntilDue: 2)),
+            OverduePerson(id: UUID(), displayName: "Alex Carter", nickname: nil, initials: "AC", avatarColorHex: "#FF6B6B", groupName: "Weekly", groupColorHex: "#4ECDC4", status: .overdue(daysOverdue: 5)),
+            OverduePerson(id: UUID(), displayName: "Samantha Park", nickname: "Sam", initials: "SP", avatarColorHex: "#4ECDC4", groupName: "Monthly", groupColorHex: "#FFD166", status: .overdue(daysOverdue: 1)),
+            OverduePerson(id: UUID(), displayName: "Jordan", nickname: nil, initials: "J", avatarColorHex: "#FFD166", groupName: "Quarterly", groupColorHex: "#A78BFA", status: .dueSoon(daysUntilDue: 2)),
         ],
         hasTrackedPeople: true,
         themeOverride: nil

--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidget.swift
@@ -67,7 +67,7 @@ extension WidgetDataProvider.Snapshot {
     static let allCaughtUp = WidgetDataProvider.Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: true, themeOverride: nil)
 }
 
-private extension WidgetPersonStatus {
+extension WidgetPersonStatus {
     var ringColor: Color {
         switch self {
         case .overdue: return .red

--- a/StayInTouch/KeepInTouchWidget/KeepInTouchWidgetBundle.swift
+++ b/StayInTouch/KeepInTouchWidget/KeepInTouchWidgetBundle.swift
@@ -10,5 +10,6 @@ import WidgetKit
 struct KeepInTouchWidgetBundle: WidgetBundle {
     var body: some Widget {
         OverdueWidget()
+        OverdueLockScreenWidget()
     }
 }

--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -85,6 +85,7 @@ struct AccessoryCircularView: View {
             EmptyView()
         case .binary(let color):
             ringStroke(from: 0, to: 1, color: tint(for: color))
+                .accentedIfAvailable()
         case .twoTone(let overdueFraction):
             if renderingMode == .fullColor {
                 // Two-tone red + orange. Red arc covers the overdue
@@ -92,9 +93,10 @@ struct AccessoryCircularView: View {
                 ringStroke(from: 0, to: overdueFraction, color: .red)
                 ringStroke(from: overdueFraction, to: 1, color: .orange)
             } else {
-                // Lock Screen / StandBy night flatten to a single tint.
-                // Show a fully filled ring; let the system tint it.
+                // Accented zone — on iOS 18+ this picks up the
+                // wallpaper-derived accent color on lock screen.
                 ringStroke(from: 0, to: 1, color: .accentColor)
+                    .accentedIfAvailable()
             }
         }
     }
@@ -120,17 +122,19 @@ struct AccessoryCircularView: View {
     @ViewBuilder
     private func centerView(digit: String?) -> some View {
         if let digit {
-            // Stack a small "people" icon above the digit. On lock screen
-            // (accented rendering) the ring color is lost — the icon makes
-            // the widget legible monochrome by giving "this is people" context
-            // without relying on red/orange to convey severity.
+            // Bigger digit dominates the widget; small people icon stays
+            // for "this is people" context. The digit is marked
+            // .widgetAccentedRenderingMode(.accented) on iOS 18+ so it
+            // picks up the wallpaper-derived accent color instead of
+            // pure white in monochrome contexts.
             VStack(spacing: 0) {
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(.secondary)
                 Text(digit)
-                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
                     .foregroundStyle(.primary)
+                    .accentedIfAvailable()
             }
         } else {
             Image(systemName: snapshot.hasTrackedPeople ? "hand.wave.fill" : "person.crop.circle.badge.plus")
@@ -140,16 +144,35 @@ struct AccessoryCircularView: View {
     }
 }
 
+private extension View {
+    /// Marks this zone as accented so the system applies the
+    /// wallpaper-derived accent treatment in monochrome contexts
+    /// (Lock Screen, StandBy night). iOS 16+.
+    func accentedIfAvailable() -> some View {
+        self.widgetAccentable(true)
+    }
+}
+
 // MARK: - Rectangular
 
 struct AccessoryRectangularView: View {
     let snapshot: WidgetDataProvider.Snapshot
 
     var body: some View {
+        let additionalAtRisk = max(0, snapshot.overdueCount + snapshot.dueSoonCount - 1)
         Group {
             if let featured = snapshot.featured.first {
                 featuredContent(featured)
-                    .widgetURL(DeepLinkRoute.person(featured.id).url())
+                    // When there are more at-risk people beyond the
+                    // featured one, route taps to the overdue list so
+                    // the user can see the full set. Only when the
+                    // featured person is the only at-risk do we deep
+                    // link directly to their detail page.
+                    .widgetURL(
+                        additionalAtRisk > 0
+                            ? DeepLinkRoute.overdue.url()
+                            : DeepLinkRoute.person(featured.id).url()
+                    )
             } else if snapshot.hasTrackedPeople {
                 Label("All caught up", systemImage: "hand.wave.fill")
                     .font(.headline)
@@ -170,19 +193,27 @@ struct AccessoryRectangularView: View {
             additionalAtRisk: additional
         )
 
-        // No status SF Symbol — text ("3d overdue · 2 more") carries the
-        // urgency. The icon felt alarmist on lock screen and ate horizontal
-        // room from the name.
-        return VStack(alignment: .leading, spacing: 2) {
-            Text(featured.displayShortName)
-                .font(.headline)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-            Text(subtitle)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
+        // person.crop.circle.fill matches the inline + circular widgets
+        // — gives Keep In Touch a visual identity on the lock screen
+        // without needing app-name copy. Status urgency stays in the
+        // subtitle text.
+        return Label(
+            title: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(featured.displayShortName)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            },
+            icon: {
+                Image(systemName: "person.crop.circle.fill")
+            }
+        )
     }
 }
 

--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -63,6 +63,7 @@ struct AccessoryCircularView: View {
         let ring = AccessoryWidgetLogic.ring(
             overdueCount: snapshot.overdueCount,
             dueSoonCount: snapshot.dueSoonCount,
+            trackedCount: snapshot.trackedCount,
             hasTrackedPeople: snapshot.hasTrackedPeople
         )
         let digit = AccessoryWidgetLogic.centerDigit(
@@ -76,6 +77,8 @@ struct AccessoryCircularView: View {
             centerView(digit: digit)
         }
         .widgetURL(DeepLinkRoute.overdue.url())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(circularAccessibilityLabel())
     }
 
     @ViewBuilder
@@ -83,22 +86,53 @@ struct AccessoryCircularView: View {
         switch ring {
         case .empty:
             EmptyView()
-        case .binary(let color):
-            ringStroke(from: 0, to: 1, color: tint(for: color))
-                .accentedIfAvailable()
-        case .twoTone(let overdueFraction):
+        case .gauge(let overdueFraction, let dueSoonFraction):
             if renderingMode == .fullColor {
-                // Two-tone red + orange. Red arc covers the overdue
-                // fraction; orange arc covers the rest.
-                ringStroke(from: 0, to: overdueFraction, color: .red)
-                ringStroke(from: overdueFraction, to: 1, color: .orange)
+                // Red arc covers overdue portion; orange arc continues
+                // for due-soon portion; remainder of the circumference
+                // is the on-track portion (unfilled). Combined, the ring
+                // shows both severity (color) and scale (fill).
+                if overdueFraction > 0 {
+                    ringStroke(from: 0, to: overdueFraction, color: .red)
+                }
+                if dueSoonFraction > 0 {
+                    ringStroke(
+                        from: overdueFraction,
+                        to: overdueFraction + dueSoonFraction,
+                        color: .orange
+                    )
+                }
             } else {
-                // Accented zone — on iOS 18+ this picks up the
-                // wallpaper-derived accent color on lock screen.
-                ringStroke(from: 0, to: 1, color: .accentColor)
-                    .accentedIfAvailable()
+                // Monochrome lock screen / StandBy night — single tinted
+                // arc fills the at-risk portion, giving a glanceable
+                // gauge without color.
+                ringStroke(
+                    from: 0,
+                    to: overdueFraction + dueSoonFraction,
+                    color: .accentColor
+                )
+                .accentedIfAvailable()
             }
         }
+    }
+
+    private func circularAccessibilityLabel() -> String {
+        let overdue = snapshot.overdueCount
+        let dueSoon = snapshot.dueSoonCount
+        let atRisk = overdue + dueSoon
+        if atRisk == 0 {
+            return snapshot.hasTrackedPeople
+                ? "Keep In Touch. All caught up."
+                : "Keep In Touch. Add someone to track."
+        }
+        var parts: [String] = []
+        if overdue > 0 {
+            parts.append("\(overdue) \(overdue == 1 ? "person" : "people") overdue")
+        }
+        if dueSoon > 0 {
+            parts.append("\(dueSoon) due soon")
+        }
+        return "Keep In Touch. " + parts.joined(separator: ", ") + "."
     }
 
     /// Single ring arc. `from` and `to` are 0...1 fractions of the
@@ -110,13 +144,6 @@ struct AccessoryCircularView: View {
             .trim(from: from, to: to)
             .stroke(color, style: StrokeStyle(lineWidth: 4, lineCap: .round))
             .rotationEffect(.degrees(-90))
-    }
-
-    private func tint(for ringColor: AccessoryWidgetLogic.RingColor) -> Color {
-        switch ringColor {
-        case .overdue: return renderingMode == .fullColor ? .red : .accentColor
-        case .dueSoon: return renderingMode == .fullColor ? .orange : .accentColor
-        }
     }
 
     @ViewBuilder
@@ -184,6 +211,31 @@ struct AccessoryRectangularView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(rectangularAccessibilityLabel())
+    }
+
+    private func rectangularAccessibilityLabel() -> String {
+        if let featured = snapshot.featured.first {
+            let additional = max(0, snapshot.overdueCount + snapshot.dueSoonCount - 1)
+            let primary: String
+            switch featured.status {
+            case .overdue(let days):
+                primary = "\(featured.displayShortName), \(days) \(days == 1 ? "day" : "days") overdue"
+            case .dueSoon(let days):
+                primary = days == 0
+                    ? "\(featured.displayShortName), due today"
+                    : "\(featured.displayShortName), due in \(days) \(days == 1 ? "day" : "days")"
+            }
+            if additional > 0 {
+                return "Keep In Touch. \(primary). \(additional) more \(additional == 1 ? "person" : "people") need a reach-out."
+            }
+            return "Keep In Touch. \(primary)."
+        }
+        if snapshot.hasTrackedPeople {
+            return "Keep In Touch. All caught up."
+        }
+        return "Keep In Touch. Add someone to track."
     }
 
     private func featuredContent(_ featured: OverduePerson) -> some View {
@@ -225,6 +277,7 @@ struct AccessoryInlineView: View {
         let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
         Label(label.text, systemImage: label.symbol)
             .widgetURL(tapTargetURL())
+            .accessibilityLabel(inlineAccessibilityLabel())
     }
 
     private func tapTargetURL() -> URL {
@@ -232,6 +285,22 @@ struct AccessoryInlineView: View {
             return DeepLinkRoute.person(featured.id).url()
         }
         return DeepLinkRoute.overdue.url()
+    }
+
+    private func inlineAccessibilityLabel() -> String {
+        if let featured = snapshot.featured.first {
+            let name = featured.displayShortName
+            if snapshot.overdueCount > 0 {
+                return "Keep In Touch. \(snapshot.overdueCount) overdue. \(name) is up next."
+            }
+            if snapshot.dueSoonCount > 0 {
+                return "Keep In Touch. \(snapshot.dueSoonCount) due soon. \(name) is up next."
+            }
+        }
+        if snapshot.hasTrackedPeople {
+            return "Keep In Touch. All caught up."
+        }
+        return "Keep In Touch. Add someone to track."
     }
 }
 

--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -193,27 +193,26 @@ struct AccessoryRectangularView: View {
             additionalAtRisk: additional
         )
 
-        // person.crop.circle.fill matches the inline + circular widgets
-        // — gives Keep In Touch a visual identity on the lock screen
-        // without needing app-name copy. Status urgency stays in the
-        // subtitle text.
-        return Label(
-            title: {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(featured.displayShortName)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                    Text(subtitle)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            },
-            icon: {
-                Image(systemName: "person.crop.circle.fill")
+        // Custom HStack instead of Label so we control the icon-to-text
+        // gap (Label's default spacing eats lock-screen horizontal room
+        // and truncates the subtitle). minimumScaleFactor lets SwiftUI
+        // shrink the subtitle font slightly before clipping when names
+        // run long.
+        return HStack(alignment: .center, spacing: 5) {
+            Image(systemName: "person.crop.circle.fill")
+                .imageScale(.medium)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(featured.displayShortName)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
             }
-        )
+        }
     }
 }
 

--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -101,10 +101,12 @@ struct AccessoryCircularView: View {
 
     /// Single ring arc. `from` and `to` are 0...1 fractions of the
     /// circumference. Rotated -90° so trim(from: 0) starts at 12 o'clock.
+    /// 4pt stroke is wide enough to read clearly without color in
+    /// monochrome accented rendering modes.
     private func ringStroke(from: Double, to: Double, color: Color) -> some View {
         Circle()
             .trim(from: from, to: to)
-            .stroke(color, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+            .stroke(color, style: StrokeStyle(lineWidth: 4, lineCap: .round))
             .rotationEffect(.degrees(-90))
     }
 
@@ -118,9 +120,18 @@ struct AccessoryCircularView: View {
     @ViewBuilder
     private func centerView(digit: String?) -> some View {
         if let digit {
-            Text(digit)
-                .font(.system(size: 22, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+            // Stack a small "people" icon above the digit. On lock screen
+            // (accented rendering) the ring color is lost — the icon makes
+            // the widget legible monochrome by giving "this is people" context
+            // without relying on red/orange to convey severity.
+            VStack(spacing: 0) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(digit)
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.primary)
+            }
         } else {
             Image(systemName: snapshot.hasTrackedPeople ? "hand.wave.fill" : "person.crop.circle.badge.plus")
                 .font(.title2)
@@ -153,15 +164,17 @@ struct AccessoryRectangularView: View {
     }
 
     private func featuredContent(_ featured: OverduePerson) -> some View {
-        let symbol = statusSymbol(for: featured.status)
         let additional = max(0, snapshot.overdueCount + snapshot.dueSoonCount - 1)
         let subtitle = AccessoryWidgetLogic.rectangularSubtitle(
             featuredStatus: featured.status,
             additionalAtRisk: additional
         )
 
+        // No status SF Symbol — text ("3d overdue · 2 more") carries the
+        // urgency. The icon felt alarmist on lock screen and ate horizontal
+        // room from the name.
         return VStack(alignment: .leading, spacing: 2) {
-            Label(featured.displayShortName, systemImage: symbol)
+            Text(featured.displayShortName)
                 .font(.headline)
                 .foregroundStyle(.primary)
                 .lineLimit(1)
@@ -169,13 +182,6 @@ struct AccessoryRectangularView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-        }
-    }
-
-    private func statusSymbol(for status: WidgetPersonStatus) -> String {
-        switch status {
-        case .overdue: return "exclamationmark.circle.fill"
-        case .dueSoon: return "clock.fill"
         }
     }
 }

--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -1,0 +1,226 @@
+//
+//  OverdueLockScreenWidget.swift
+//  KeepInTouchWidget
+//
+//  Lock Screen + StandBy accessory widgets (issue #279).
+//  Shares the same `OverdueTimelineProvider` and configuration intent
+//  as `OverdueWidget`. Layout/copy decisions delegate to the pure
+//  `AccessoryWidgetLogic` helper so the SwiftUI shells stay thin.
+//
+
+import SwiftUI
+import WidgetKit
+
+// MARK: - Widget configuration
+
+struct OverdueLockScreenWidget: Widget {
+    let kind: String = "OverdueLockScreenWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: OverdueWidgetConfigurationIntent.self,
+            provider: OverdueTimelineProvider()
+        ) { entry in
+            LockScreenEntryView(entry: entry)
+        }
+        .configurationDisplayName("Keep In Touch (Lock Screen)")
+        .description("Quick glance at who's overdue. Lock Screen, StandBy, and accessory surfaces.")
+        .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}
+
+// MARK: - Entry dispatch
+
+struct LockScreenEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    var entry: OverdueEntry
+
+    var body: some View {
+        Group {
+            switch family {
+            case .accessoryCircular:
+                AccessoryCircularView(snapshot: entry.snapshot)
+            case .accessoryRectangular:
+                AccessoryRectangularView(snapshot: entry.snapshot)
+            case .accessoryInline:
+                AccessoryInlineView(snapshot: entry.snapshot)
+            default:
+                AccessoryInlineView(snapshot: entry.snapshot)
+            }
+        }
+        .containerBackground(.clear, for: .widget)
+    }
+}
+
+// MARK: - Circular
+
+struct AccessoryCircularView: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    let snapshot: WidgetDataProvider.Snapshot
+
+    var body: some View {
+        let ring = AccessoryWidgetLogic.ring(
+            overdueCount: snapshot.overdueCount,
+            dueSoonCount: snapshot.dueSoonCount,
+            hasTrackedPeople: snapshot.hasTrackedPeople
+        )
+        let digit = AccessoryWidgetLogic.centerDigit(
+            overdueCount: snapshot.overdueCount,
+            dueSoonCount: snapshot.dueSoonCount,
+            hasTrackedPeople: snapshot.hasTrackedPeople
+        )
+
+        ZStack {
+            ringView(for: ring)
+            centerView(digit: digit)
+        }
+        .widgetURL(DeepLinkRoute.overdue.url())
+    }
+
+    @ViewBuilder
+    private func ringView(for ring: AccessoryWidgetLogic.CircularRing) -> some View {
+        switch ring {
+        case .empty:
+            EmptyView()
+        case .binary(let color):
+            ringStroke(from: 0, to: 1, color: tint(for: color))
+        case .twoTone(let overdueFraction):
+            if renderingMode == .fullColor {
+                // Two-tone red + orange. Red arc covers the overdue
+                // fraction; orange arc covers the rest.
+                ringStroke(from: 0, to: overdueFraction, color: .red)
+                ringStroke(from: overdueFraction, to: 1, color: .orange)
+            } else {
+                // Lock Screen / StandBy night flatten to a single tint.
+                // Show a fully filled ring; let the system tint it.
+                ringStroke(from: 0, to: 1, color: .accentColor)
+            }
+        }
+    }
+
+    /// Single ring arc. `from` and `to` are 0...1 fractions of the
+    /// circumference. Rotated -90° so trim(from: 0) starts at 12 o'clock.
+    private func ringStroke(from: Double, to: Double, color: Color) -> some View {
+        Circle()
+            .trim(from: from, to: to)
+            .stroke(color, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+            .rotationEffect(.degrees(-90))
+    }
+
+    private func tint(for ringColor: AccessoryWidgetLogic.RingColor) -> Color {
+        switch ringColor {
+        case .overdue: return renderingMode == .fullColor ? .red : .accentColor
+        case .dueSoon: return renderingMode == .fullColor ? .orange : .accentColor
+        }
+    }
+
+    @ViewBuilder
+    private func centerView(digit: String?) -> some View {
+        if let digit {
+            Text(digit)
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(.primary)
+        } else {
+            Image(systemName: snapshot.hasTrackedPeople ? "hand.wave.fill" : "person.crop.circle.badge.plus")
+                .font(.title2)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+// MARK: - Rectangular
+
+struct AccessoryRectangularView: View {
+    let snapshot: WidgetDataProvider.Snapshot
+
+    var body: some View {
+        Group {
+            if let featured = snapshot.featured.first {
+                featuredContent(featured)
+                    .widgetURL(DeepLinkRoute.person(featured.id).url())
+            } else if snapshot.hasTrackedPeople {
+                Label("All caught up", systemImage: "hand.wave.fill")
+                    .font(.headline)
+                    .widgetURL(DeepLinkRoute.overdue.url())
+            } else {
+                Label("Add someone to track", systemImage: "person.crop.circle.badge.plus")
+                    .font(.headline)
+                    .widgetURL(DeepLinkRoute.overdue.url())
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    private func featuredContent(_ featured: OverduePerson) -> some View {
+        let symbol = statusSymbol(for: featured.status)
+        let additional = max(0, snapshot.overdueCount + snapshot.dueSoonCount - 1)
+        let subtitle = AccessoryWidgetLogic.rectangularSubtitle(
+            featuredStatus: featured.status,
+            additionalAtRisk: additional
+        )
+
+        return VStack(alignment: .leading, spacing: 2) {
+            Label(featured.displayShortName, systemImage: symbol)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func statusSymbol(for status: WidgetPersonStatus) -> String {
+        switch status {
+        case .overdue: return "exclamationmark.circle.fill"
+        case .dueSoon: return "clock.fill"
+        }
+    }
+}
+
+// MARK: - Inline
+
+struct AccessoryInlineView: View {
+    let snapshot: WidgetDataProvider.Snapshot
+
+    var body: some View {
+        let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
+        Label(label.text, systemImage: label.symbol)
+            .widgetURL(tapTargetURL())
+    }
+
+    private func tapTargetURL() -> URL {
+        if let featured = snapshot.featured.first {
+            return DeepLinkRoute.person(featured.id).url()
+        }
+        return DeepLinkRoute.overdue.url()
+    }
+}
+
+// MARK: - Previews
+
+#Preview(as: .accessoryCircular) {
+    OverdueLockScreenWidget()
+} timeline: {
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .placeholder)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .allCaughtUp)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .empty)
+}
+
+#Preview(as: .accessoryRectangular) {
+    OverdueLockScreenWidget()
+} timeline: {
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .placeholder)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .allCaughtUp)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .empty)
+}
+
+#Preview(as: .accessoryInline) {
+    OverdueLockScreenWidget()
+} timeline: {
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .placeholder)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .allCaughtUp)
+    OverdueEntry(date: .now, configuration: OverdueWidgetConfigurationIntent(), snapshot: .empty)
+}

--- a/StayInTouch/KeepInTouchWidget/WidgetDataProvider+Loader.swift
+++ b/StayInTouch/KeepInTouchWidget/WidgetDataProvider+Loader.swift
@@ -18,6 +18,7 @@ extension WidgetDataProvider {
                 dueSoonCount: 0,
                 featured: [],
                 hasTrackedPeople: false,
+                trackedCount: 0,
                 themeOverride: nil
             )
         }

--- a/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
+++ b/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
@@ -78,18 +78,13 @@ enum AccessoryWidgetLogic {
     // MARK: - Rectangular subtitle
 
     /// Composes the second line of the rectangular widget: featured
-    /// person's status + optional "X more" suffix.
+    /// person's status (delegates to `WidgetPersonStatus.shortSubtitle`)
+    /// + optional "X more" suffix.
     static func rectangularSubtitle(
         featuredStatus: WidgetPersonStatus,
         additionalAtRisk: Int
     ) -> String {
-        let primary: String
-        switch featuredStatus {
-        case .overdue(let days):
-            primary = "\(days)d overdue"
-        case .dueSoon(let days):
-            primary = days == 0 ? "Due today" : "Due in \(days)d"
-        }
+        let primary = featuredStatus.shortSubtitle
         if additionalAtRisk > 0 {
             return "\(primary) · \(additionalAtRisk) more"
         }

--- a/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
+++ b/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
@@ -56,8 +56,11 @@ enum AccessoryWidgetLogic {
 
     // MARK: - Circular center digit
 
-    /// Returns the digit to render at the center of the circular widget,
+    /// Total at-risk count to render at the center of the circular widget,
     /// or nil if the widget should fall back to a symbol-only empty state.
+    /// Returns `overdue + dueSoon` because the lock-screen / accented
+    /// rendering mode strips the two-tone color distinction, so a single
+    /// total reads more clearly than a per-bucket count.
     /// `hasTrackedPeople` is accepted for call-site symmetry; the count fields
     /// already encode the empty case.
     static func centerDigit(
@@ -66,13 +69,8 @@ enum AccessoryWidgetLogic {
         hasTrackedPeople: Bool
     ) -> String? {
         _ = hasTrackedPeople
-        if overdueCount > 0 {
-            return "\(overdueCount)"
-        }
-        if dueSoonCount > 0 {
-            return "\(dueSoonCount)"
-        }
-        return nil
+        let total = overdueCount + dueSoonCount
+        return total > 0 ? "\(total)" : nil
     }
 
     // MARK: - Rectangular subtitle
@@ -101,18 +99,20 @@ enum AccessoryWidgetLogic {
     /// Composes the single-line inline widget label.
     /// Order of preference: featured overdue → featured due-soon →
     /// all-caught-up → no-tracked-people.
+    /// Symbol is `person.crop.circle.fill` for any at-risk state — text
+    /// carries the urgency. Empty / no-tracked states keep their own symbol.
     static func inlineLabel(snapshot: WidgetDataProvider.Snapshot) -> InlineLabel {
         if let featured = snapshot.featured.first {
             let name = featured.displayShortName
             if snapshot.overdueCount > 0 {
                 return InlineLabel(
-                    symbol: "exclamationmark.circle.fill",
+                    symbol: "person.crop.circle.fill",
                     text: "\(snapshot.overdueCount) overdue · \(name) next"
                 )
             }
             if snapshot.dueSoonCount > 0 {
                 return InlineLabel(
-                    symbol: "clock.fill",
+                    symbol: "person.crop.circle.fill",
                     text: "\(snapshot.dueSoonCount) due soon · \(name) next"
                 )
             }

--- a/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
+++ b/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
@@ -1,0 +1,130 @@
+//
+//  AccessoryWidgetLogic.swift
+//  KeepInTouch (Shared — compiled into main app + widget extension)
+//
+//  Pure layout/copy decisions for the Lock Screen and StandBy accessory
+//  widgets. Extracted so the SwiftUI views stay thin and the routing
+//  rules stay testable without a SwiftUI inspection dependency.
+//
+//  Issue #279.
+//
+
+import Foundation
+
+enum AccessoryWidgetLogic {
+
+    // MARK: - Circular ring fill
+
+    enum RingColor: Equatable {
+        case overdue
+        case dueSoon
+    }
+
+    enum CircularRing: Equatable {
+        /// No ring drawn. Symbol-only state (all caught up or no tracked people).
+        case empty
+        /// Single full ring in one color (only one at-risk bucket has people).
+        case binary(color: RingColor)
+        /// Split ring: red arc covers `overdueFraction` (0...1) of the
+        /// circumference; orange arc covers the remainder. Used when both
+        /// overdue and due-soon buckets are non-empty.
+        case twoTone(overdueFraction: Double)
+    }
+
+    /// Decide what kind of ring (if any) the accessory circular widget should draw.
+    /// `hasTrackedPeople` is accepted for symmetry with the other helpers; the
+    /// count fields already encode the at-risk state, so it isn't consulted here.
+    static func ring(
+        overdueCount: Int,
+        dueSoonCount: Int,
+        hasTrackedPeople: Bool
+    ) -> CircularRing {
+        _ = hasTrackedPeople
+        if overdueCount == 0 && dueSoonCount == 0 {
+            return .empty
+        }
+        if overdueCount > 0 && dueSoonCount == 0 {
+            return .binary(color: .overdue)
+        }
+        if overdueCount == 0 && dueSoonCount > 0 {
+            return .binary(color: .dueSoon)
+        }
+        let total = Double(overdueCount + dueSoonCount)
+        let fraction = Double(overdueCount) / total
+        return .twoTone(overdueFraction: fraction)
+    }
+
+    // MARK: - Circular center digit
+
+    /// Returns the digit to render at the center of the circular widget,
+    /// or nil if the widget should fall back to a symbol-only empty state.
+    /// `hasTrackedPeople` is accepted for call-site symmetry; the count fields
+    /// already encode the empty case.
+    static func centerDigit(
+        overdueCount: Int,
+        dueSoonCount: Int,
+        hasTrackedPeople: Bool
+    ) -> String? {
+        _ = hasTrackedPeople
+        if overdueCount > 0 {
+            return "\(overdueCount)"
+        }
+        if dueSoonCount > 0 {
+            return "\(dueSoonCount)"
+        }
+        return nil
+    }
+
+    // MARK: - Rectangular subtitle
+
+    /// Composes the second line of the rectangular widget: featured
+    /// person's status + optional "X more" suffix.
+    static func rectangularSubtitle(
+        featuredStatus: WidgetPersonStatus,
+        additionalAtRisk: Int
+    ) -> String {
+        let primary: String
+        switch featuredStatus {
+        case .overdue(let days):
+            primary = "\(days)d overdue"
+        case .dueSoon(let days):
+            primary = days == 0 ? "Due today" : "Due in \(days)d"
+        }
+        if additionalAtRisk > 0 {
+            return "\(primary) · \(additionalAtRisk) more"
+        }
+        return primary
+    }
+
+    // MARK: - Inline label
+
+    struct InlineLabel: Equatable {
+        let symbol: String
+        let text: String
+    }
+
+    /// Composes the single-line inline widget label.
+    /// Order of preference: featured overdue → featured due-soon →
+    /// all-caught-up → no-tracked-people.
+    static func inlineLabel(snapshot: WidgetDataProvider.Snapshot) -> InlineLabel {
+        if let featured = snapshot.featured.first {
+            let name = featured.displayShortName
+            if snapshot.overdueCount > 0 {
+                return InlineLabel(
+                    symbol: "exclamationmark.circle.fill",
+                    text: "\(snapshot.overdueCount) overdue · \(name) next"
+                )
+            }
+            if snapshot.dueSoonCount > 0 {
+                return InlineLabel(
+                    symbol: "clock.fill",
+                    text: "\(snapshot.dueSoonCount) due soon · \(name) next"
+                )
+            }
+        }
+        if snapshot.hasTrackedPeople {
+            return InlineLabel(symbol: "hand.wave.fill", text: "All caught up")
+        }
+        return InlineLabel(symbol: "person.crop.circle.badge.plus", text: "Add someone to track")
+    }
+}

--- a/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
+++ b/StayInTouch/StayInTouch/Shared/AccessoryWidgetLogic.swift
@@ -15,43 +15,46 @@ enum AccessoryWidgetLogic {
 
     // MARK: - Circular ring fill
 
-    enum RingColor: Equatable {
-        case overdue
-        case dueSoon
-    }
-
     enum CircularRing: Equatable {
         /// No ring drawn. Symbol-only state (all caught up or no tracked people).
         case empty
-        /// Single full ring in one color (only one at-risk bucket has people).
-        case binary(color: RingColor)
-        /// Split ring: red arc covers `overdueFraction` (0...1) of the
-        /// circumference; orange arc covers the remainder. Used when both
-        /// overdue and due-soon buckets are non-empty.
-        case twoTone(overdueFraction: Double)
+        /// Gauge fill expressed as fractions of the full circumference.
+        /// Both fractions are 0...1 and their sum is ≤ 1.0 (the unfilled
+        /// remainder is the on-track portion of the user's tracked set).
+        ///
+        /// Visual interpretation:
+        /// - In fullColor mode: red arc covers `overdueFraction`, orange
+        ///   arc continues for `dueSoonFraction`, the rest is unfilled.
+        /// - In monochrome / accented mode: a single tinted arc fills
+        ///   `overdueFraction + dueSoonFraction` of the circumference,
+        ///   giving a "how bad is it" gauge — sliver = healthy, full =
+        ///   everyone needs a reach-out.
+        case gauge(overdueFraction: Double, dueSoonFraction: Double)
     }
 
     /// Decide what kind of ring (if any) the accessory circular widget should draw.
-    /// `hasTrackedPeople` is accepted for symmetry with the other helpers; the
-    /// count fields already encode the at-risk state, so it isn't consulted here.
+    /// The gauge fractions are computed against `trackedCount` so the ring
+    /// answers "what fraction of the people I follow need attention?".
+    /// `hasTrackedPeople` is accepted for call-site symmetry.
     static func ring(
         overdueCount: Int,
         dueSoonCount: Int,
+        trackedCount: Int,
         hasTrackedPeople: Bool
     ) -> CircularRing {
         _ = hasTrackedPeople
-        if overdueCount == 0 && dueSoonCount == 0 {
+        let atRisk = overdueCount + dueSoonCount
+        if atRisk == 0 {
             return .empty
         }
-        if overdueCount > 0 && dueSoonCount == 0 {
-            return .binary(color: .overdue)
-        }
-        if overdueCount == 0 && dueSoonCount > 0 {
-            return .binary(color: .dueSoon)
-        }
-        let total = Double(overdueCount + dueSoonCount)
-        let fraction = Double(overdueCount) / total
-        return .twoTone(overdueFraction: fraction)
+        // Defensive: at-risk should be a subset of tracked, but if data
+        // is inconsistent fall back to filling the ring proportional to
+        // at-risk itself rather than dividing by zero.
+        let denom = max(trackedCount, atRisk)
+        return .gauge(
+            overdueFraction: Double(overdueCount) / Double(denom),
+            dueSoonFraction: Double(dueSoonCount) / Double(denom)
+        )
     }
 
     // MARK: - Circular center digit

--- a/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
+++ b/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
@@ -25,11 +25,25 @@ enum WidgetPersonStatus: Hashable {
 struct OverduePerson: Hashable {
     let id: UUID
     let displayName: String
+    let nickname: String?
     let initials: String
     let avatarColorHex: String
     let groupName: String
     let groupColorHex: String?
     let status: WidgetPersonStatus
+}
+
+extension OverduePerson {
+    /// Short display preference: nickname (when present) > first name > displayName.
+    /// Used by accessory rectangular and inline widgets where space is constrained.
+    var displayShortName: String {
+        if let nick = nickname?.trimmingCharacters(in: .whitespacesAndNewlines), !nick.isEmpty {
+            return nick
+        }
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let first = trimmed.split(separator: " ").first.map(String.init) ?? ""
+        return first.isEmpty ? trimmed : first
+    }
 }
 
 enum WidgetDataProvider {
@@ -76,6 +90,7 @@ enum WidgetDataProvider {
                     return OverduePerson(
                         id: id,
                         displayName: displayName,
+                        nickname: person.nickname,
                         initials: initials,
                         avatarColorHex: avatarColor,
                         groupName: groupName,

--- a/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
+++ b/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
@@ -79,6 +79,10 @@ enum WidgetDataProvider {
         let dueSoonCount: Int
         let featured: [OverduePerson]
         let hasTrackedPeople: Bool
+        /// Total tracked, non-paused, non-demo people in scope (after group
+        /// filter). Used as the denominator for the accessory circular
+        /// widget's gauge fill (`atRisk / trackedCount`).
+        let trackedCount: Int
         /// Raw AppSettings.theme string: "dark", "light", "system", or nil.
         let themeOverride: String?
     }
@@ -90,7 +94,7 @@ enum WidgetDataProvider {
         now: Date = Date(),
         groupFilter: UUID? = nil
     ) -> Snapshot {
-        var result = Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: false, themeOverride: nil)
+        var result = Snapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: false, trackedCount: 0, themeOverride: nil)
 
         context.performAndWait {
             let hasTrackedPeople = countTrackedPeople(context: context) > 0
@@ -139,6 +143,7 @@ enum WidgetDataProvider {
                 dueSoonCount: dueSoonCount,
                 featured: featured,
                 hasTrackedPeople: hasTrackedPeople,
+                trackedCount: people.count,
                 themeOverride: themeOverride
             )
         }

--- a/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
+++ b/StayInTouch/StayInTouch/Shared/WidgetDataProvider.swift
@@ -22,6 +22,30 @@ enum WidgetPersonStatus: Hashable {
     case dueSoon(daysUntilDue: Int)
 }
 
+extension WidgetPersonStatus {
+    /// Long-form, used by the medium home-screen widget.
+    /// Example: "3 days overdue", "Due in 1 day", "Due today".
+    var subtitle: String {
+        switch self {
+        case .overdue(let days):
+            return "\(days) day\(days == 1 ? "" : "s") overdue"
+        case .dueSoon(let days):
+            return days == 0 ? "Due today" : "Due in \(days) day\(days == 1 ? "" : "s")"
+        }
+    }
+
+    /// Compact form, used by small + accessory widgets.
+    /// Example: "3d overdue", "Due in 1d", "Due today".
+    var shortSubtitle: String {
+        switch self {
+        case .overdue(let days):
+            return "\(days)d overdue"
+        case .dueSoon(let days):
+            return days == 0 ? "Due today" : "Due in \(days)d"
+        }
+    }
+}
+
 struct OverduePerson: Hashable {
     let id: UUID
     let displayName: String

--- a/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
+++ b/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
@@ -15,49 +15,72 @@ final class AccessoryWidgetLogicTests: XCTestCase {
 
     func testRing_emptyWhenNoTrackedPeople() {
         XCTAssertEqual(
-            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: false),
+            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, trackedCount: 0, hasTrackedPeople: false),
             .empty
         )
     }
 
     func testRing_emptyWhenAllCaughtUp() {
         XCTAssertEqual(
-            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: true),
+            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, trackedCount: 5, hasTrackedPeople: true),
             .empty
         )
     }
 
-    func testRing_binaryOverdueWhenOnlyOverdue() {
-        XCTAssertEqual(
-            AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 0, hasTrackedPeople: true),
-            .binary(color: .overdue)
-        )
-    }
-
-    func testRing_binaryDueSoonWhenOnlyDueSoon() {
-        XCTAssertEqual(
-            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 3, hasTrackedPeople: true),
-            .binary(color: .dueSoon)
-        )
-    }
-
-    func testRing_twoToneFractionWhenBothCategoriesPresent() {
-        // 3 overdue + 2 due-soon → overdue fraction = 0.6
-        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 2, hasTrackedPeople: true)
-        if case .twoTone(let fraction) = result {
-            XCTAssertEqual(fraction, 0.6, accuracy: 0.0001)
+    func testRing_gaugeOverdueOnly() {
+        // 3 overdue out of 10 tracked → overdue fraction = 0.3
+        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 0, trackedCount: 10, hasTrackedPeople: true)
+        if case .gauge(let overdueFraction, let dueSoonFraction) = result {
+            XCTAssertEqual(overdueFraction, 0.3, accuracy: 0.0001)
+            XCTAssertEqual(dueSoonFraction, 0.0, accuracy: 0.0001)
         } else {
-            XCTFail("Expected .twoTone, got \(result)")
+            XCTFail("Expected .gauge, got \(result)")
         }
     }
 
-    func testRing_twoToneEvenSplit() {
-        // 1 overdue + 1 due-soon → overdue fraction = 0.5
-        let result = AccessoryWidgetLogic.ring(overdueCount: 1, dueSoonCount: 1, hasTrackedPeople: true)
-        if case .twoTone(let fraction) = result {
-            XCTAssertEqual(fraction, 0.5, accuracy: 0.0001)
+    func testRing_gaugeDueSoonOnly() {
+        // 0 overdue + 3 dueSoon out of 10 tracked → dueSoon fraction = 0.3
+        let result = AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 3, trackedCount: 10, hasTrackedPeople: true)
+        if case .gauge(let overdueFraction, let dueSoonFraction) = result {
+            XCTAssertEqual(overdueFraction, 0.0, accuracy: 0.0001)
+            XCTAssertEqual(dueSoonFraction, 0.3, accuracy: 0.0001)
         } else {
-            XCTFail("Expected .twoTone, got \(result)")
+            XCTFail("Expected .gauge, got \(result)")
+        }
+    }
+
+    func testRing_gaugeBothCategoriesProportionalToTracked() {
+        // 3 overdue + 2 dueSoon out of 10 tracked → 0.3 + 0.2, remainder 0.5
+        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 2, trackedCount: 10, hasTrackedPeople: true)
+        if case .gauge(let overdueFraction, let dueSoonFraction) = result {
+            XCTAssertEqual(overdueFraction, 0.3, accuracy: 0.0001)
+            XCTAssertEqual(dueSoonFraction, 0.2, accuracy: 0.0001)
+        } else {
+            XCTFail("Expected .gauge, got \(result)")
+        }
+    }
+
+    func testRing_gaugeFullWhenEveryoneAtRisk() {
+        // 3 overdue + 2 dueSoon out of 5 tracked → fractions sum to 1.0
+        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 2, trackedCount: 5, hasTrackedPeople: true)
+        if case .gauge(let overdueFraction, let dueSoonFraction) = result {
+            XCTAssertEqual(overdueFraction, 0.6, accuracy: 0.0001)
+            XCTAssertEqual(dueSoonFraction, 0.4, accuracy: 0.0001)
+        } else {
+            XCTFail("Expected .gauge, got \(result)")
+        }
+    }
+
+    func testRing_gaugeDefensiveWhenTrackedCountUnderAtRisk() {
+        // Defensive: if data is inconsistent (atRisk > tracked), fall back
+        // to filling the ring proportional to atRisk so we never divide
+        // by zero or compute >100% fill.
+        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 2, trackedCount: 0, hasTrackedPeople: true)
+        if case .gauge(let overdueFraction, let dueSoonFraction) = result {
+            XCTAssertEqual(overdueFraction, 0.6, accuracy: 0.0001, "Falls back to atRisk-relative fill when trackedCount is degenerate")
+            XCTAssertEqual(dueSoonFraction, 0.4, accuracy: 0.0001)
+        } else {
+            XCTFail("Expected .gauge, got \(result)")
         }
     }
 
@@ -266,13 +289,15 @@ final class AccessoryWidgetLogicTests: XCTestCase {
         overdueCount: Int,
         dueSoonCount: Int,
         featured: [OverduePerson],
-        hasTrackedPeople: Bool = true
+        hasTrackedPeople: Bool = true,
+        trackedCount: Int = 5
     ) -> WidgetDataProvider.Snapshot {
         WidgetDataProvider.Snapshot(
             overdueCount: overdueCount,
             dueSoonCount: dueSoonCount,
             featured: featured,
             hasTrackedPeople: hasTrackedPeople,
+            trackedCount: trackedCount,
             themeOverride: nil
         )
     }

--- a/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
+++ b/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
@@ -63,14 +63,22 @@ final class AccessoryWidgetLogicTests: XCTestCase {
 
     // MARK: - centerDigit(...)
 
-    func testCenterDigit_showsOverdueWhenAny() {
+    func testCenterDigit_showsTotalAtRiskWhenBothBucketsPresent() {
         XCTAssertEqual(
             AccessoryWidgetLogic.centerDigit(overdueCount: 3, dueSoonCount: 2, hasTrackedPeople: true),
+            "5",
+            "Lock-screen rendering loses two-tone color, so we show total at-risk count"
+        )
+    }
+
+    func testCenterDigit_showsOverdueOnly() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.centerDigit(overdueCount: 3, dueSoonCount: 0, hasTrackedPeople: true),
             "3"
         )
     }
 
-    func testCenterDigit_showsDueSoonWhenNoOverdue() {
+    func testCenterDigit_showsDueSoonOnly() {
         XCTAssertEqual(
             AccessoryWidgetLogic.centerDigit(overdueCount: 0, dueSoonCount: 4, hasTrackedPeople: true),
             "4"
@@ -160,7 +168,7 @@ final class AccessoryWidgetLogicTests: XCTestCase {
             featured: [makeFeatured(displayName: "Mom", nickname: nil, status: .overdue(daysOverdue: 5))]
         )
         let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
-        XCTAssertEqual(label.symbol, "exclamationmark.circle.fill")
+        XCTAssertEqual(label.symbol, "person.crop.circle.fill")
         XCTAssertEqual(label.text, "3 overdue · Mom next")
     }
 
@@ -171,7 +179,7 @@ final class AccessoryWidgetLogicTests: XCTestCase {
             featured: [makeFeatured(displayName: "Sam", nickname: nil, status: .dueSoon(daysUntilDue: 1))]
         )
         let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
-        XCTAssertEqual(label.symbol, "clock.fill")
+        XCTAssertEqual(label.symbol, "person.crop.circle.fill")
         XCTAssertEqual(label.text, "2 due soon · Sam next")
     }
 

--- a/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
+++ b/StayInTouch/StayInTouchTests/AccessoryWidgetLogicTests.swift
@@ -1,0 +1,271 @@
+//
+//  AccessoryWidgetLogicTests.swift
+//  StayInTouchTests
+//
+//  Pure-logic coverage for the Lock Screen / StandBy accessory widgets.
+//  Issue #279.
+//
+
+import XCTest
+@testable import StayInTouch
+
+final class AccessoryWidgetLogicTests: XCTestCase {
+
+    // MARK: - ring(...)
+
+    func testRing_emptyWhenNoTrackedPeople() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: false),
+            .empty
+        )
+    }
+
+    func testRing_emptyWhenAllCaughtUp() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: true),
+            .empty
+        )
+    }
+
+    func testRing_binaryOverdueWhenOnlyOverdue() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 0, hasTrackedPeople: true),
+            .binary(color: .overdue)
+        )
+    }
+
+    func testRing_binaryDueSoonWhenOnlyDueSoon() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.ring(overdueCount: 0, dueSoonCount: 3, hasTrackedPeople: true),
+            .binary(color: .dueSoon)
+        )
+    }
+
+    func testRing_twoToneFractionWhenBothCategoriesPresent() {
+        // 3 overdue + 2 due-soon → overdue fraction = 0.6
+        let result = AccessoryWidgetLogic.ring(overdueCount: 3, dueSoonCount: 2, hasTrackedPeople: true)
+        if case .twoTone(let fraction) = result {
+            XCTAssertEqual(fraction, 0.6, accuracy: 0.0001)
+        } else {
+            XCTFail("Expected .twoTone, got \(result)")
+        }
+    }
+
+    func testRing_twoToneEvenSplit() {
+        // 1 overdue + 1 due-soon → overdue fraction = 0.5
+        let result = AccessoryWidgetLogic.ring(overdueCount: 1, dueSoonCount: 1, hasTrackedPeople: true)
+        if case .twoTone(let fraction) = result {
+            XCTAssertEqual(fraction, 0.5, accuracy: 0.0001)
+        } else {
+            XCTFail("Expected .twoTone, got \(result)")
+        }
+    }
+
+    // MARK: - centerDigit(...)
+
+    func testCenterDigit_showsOverdueWhenAny() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.centerDigit(overdueCount: 3, dueSoonCount: 2, hasTrackedPeople: true),
+            "3"
+        )
+    }
+
+    func testCenterDigit_showsDueSoonWhenNoOverdue() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.centerDigit(overdueCount: 0, dueSoonCount: 4, hasTrackedPeople: true),
+            "4"
+        )
+    }
+
+    func testCenterDigit_nilWhenAllCaughtUp() {
+        XCTAssertNil(
+            AccessoryWidgetLogic.centerDigit(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: true)
+        )
+    }
+
+    func testCenterDigit_nilWhenNoTrackedPeople() {
+        XCTAssertNil(
+            AccessoryWidgetLogic.centerDigit(overdueCount: 0, dueSoonCount: 0, hasTrackedPeople: false)
+        )
+    }
+
+    // MARK: - rectangularSubtitle(...)
+
+    func testRectangularSubtitle_overdueDaysWithMore() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .overdue(daysOverdue: 3),
+                additionalAtRisk: 2
+            ),
+            "3d overdue · 2 more"
+        )
+    }
+
+    func testRectangularSubtitle_overdueDaysAlone() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .overdue(daysOverdue: 1),
+                additionalAtRisk: 0
+            ),
+            "1d overdue"
+        )
+    }
+
+    func testRectangularSubtitle_dueTodayWithMore() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .dueSoon(daysUntilDue: 0),
+                additionalAtRisk: 2
+            ),
+            "Due today · 2 more"
+        )
+    }
+
+    func testRectangularSubtitle_dueTodayAlone() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .dueSoon(daysUntilDue: 0),
+                additionalAtRisk: 0
+            ),
+            "Due today"
+        )
+    }
+
+    func testRectangularSubtitle_dueSoonDays() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .dueSoon(daysUntilDue: 2),
+                additionalAtRisk: 0
+            ),
+            "Due in 2d"
+        )
+    }
+
+    func testRectangularSubtitle_dueSoonDaysWithMore() {
+        XCTAssertEqual(
+            AccessoryWidgetLogic.rectangularSubtitle(
+                featuredStatus: .dueSoon(daysUntilDue: 3),
+                additionalAtRisk: 1
+            ),
+            "Due in 3d · 1 more"
+        )
+    }
+
+    // MARK: - inlineLabel(...)
+
+    func testInlineLabel_overdueWithFeatured() {
+        let snapshot = makeSnapshot(
+            overdueCount: 3,
+            dueSoonCount: 0,
+            featured: [makeFeatured(displayName: "Mom", nickname: nil, status: .overdue(daysOverdue: 5))]
+        )
+        let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
+        XCTAssertEqual(label.symbol, "exclamationmark.circle.fill")
+        XCTAssertEqual(label.text, "3 overdue · Mom next")
+    }
+
+    func testInlineLabel_dueSoonWithFeatured_whenNoOverdue() {
+        let snapshot = makeSnapshot(
+            overdueCount: 0,
+            dueSoonCount: 2,
+            featured: [makeFeatured(displayName: "Sam", nickname: nil, status: .dueSoon(daysUntilDue: 1))]
+        )
+        let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
+        XCTAssertEqual(label.symbol, "clock.fill")
+        XCTAssertEqual(label.text, "2 due soon · Sam next")
+    }
+
+    func testInlineLabel_prefersNicknameOverFirstName() {
+        let snapshot = makeSnapshot(
+            overdueCount: 1,
+            dueSoonCount: 0,
+            featured: [makeFeatured(displayName: "Robert Smith", nickname: "Bobby", status: .overdue(daysOverdue: 2))]
+        )
+        XCTAssertEqual(AccessoryWidgetLogic.inlineLabel(snapshot: snapshot).text, "1 overdue · Bobby next")
+    }
+
+    func testInlineLabel_fallsBackToFirstNameWhenNoNickname() {
+        let snapshot = makeSnapshot(
+            overdueCount: 1,
+            dueSoonCount: 0,
+            featured: [makeFeatured(displayName: "Robert Smith", nickname: nil, status: .overdue(daysOverdue: 2))]
+        )
+        XCTAssertEqual(AccessoryWidgetLogic.inlineLabel(snapshot: snapshot).text, "1 overdue · Robert next")
+    }
+
+    func testInlineLabel_allCaughtUp() {
+        let snapshot = makeSnapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: true)
+        let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
+        XCTAssertEqual(label.symbol, "hand.wave.fill")
+        XCTAssertEqual(label.text, "All caught up")
+    }
+
+    func testInlineLabel_noTrackedPeople() {
+        let snapshot = makeSnapshot(overdueCount: 0, dueSoonCount: 0, featured: [], hasTrackedPeople: false)
+        let label = AccessoryWidgetLogic.inlineLabel(snapshot: snapshot)
+        XCTAssertEqual(label.symbol, "person.crop.circle.badge.plus")
+        XCTAssertEqual(label.text, "Add someone to track")
+    }
+
+    // MARK: - displayShortName logic via OverduePerson
+
+    func testDisplayShortName_prefersNickname() {
+        let person = makeFeatured(displayName: "Robert Smith", nickname: "Bobby", status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "Bobby")
+    }
+
+    func testDisplayShortName_trimsNicknameWhitespace() {
+        let person = makeFeatured(displayName: "Robert", nickname: "  Bobby  ", status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "Bobby")
+    }
+
+    func testDisplayShortName_fallsBackToFirstNameForBlankNickname() {
+        let person = makeFeatured(displayName: "Robert Smith", nickname: "   ", status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "Robert")
+    }
+
+    func testDisplayShortName_fallsBackToFirstNameWhenNicknameNil() {
+        let person = makeFeatured(displayName: "Robert Smith", nickname: nil, status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "Robert")
+    }
+
+    func testDisplayShortName_singleWordDisplayName() {
+        let person = makeFeatured(displayName: "Robert", nickname: nil, status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "Robert")
+    }
+
+    func testDisplayShortName_emptyDisplayNameDoesNotCrash() {
+        let person = makeFeatured(displayName: "", nickname: nil, status: .overdue(daysOverdue: 1))
+        XCTAssertEqual(person.displayShortName, "")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeFeatured(displayName: String, nickname: String?, status: WidgetPersonStatus) -> OverduePerson {
+        OverduePerson(
+            id: UUID(),
+            displayName: displayName,
+            nickname: nickname,
+            initials: String(displayName.prefix(2)),
+            avatarColorHex: "#FF6B6B",
+            groupName: "Friends",
+            groupColorHex: nil,
+            status: status
+        )
+    }
+
+    private func makeSnapshot(
+        overdueCount: Int,
+        dueSoonCount: Int,
+        featured: [OverduePerson],
+        hasTrackedPeople: Bool = true
+    ) -> WidgetDataProvider.Snapshot {
+        WidgetDataProvider.Snapshot(
+            overdueCount: overdueCount,
+            dueSoonCount: dueSoonCount,
+            featured: featured,
+            hasTrackedPeople: hasTrackedPeople,
+            themeOverride: nil
+        )
+    }
+}

--- a/StayInTouch/StayInTouchTests/WidgetDataProviderTests.swift
+++ b/StayInTouch/StayInTouchTests/WidgetDataProviderTests.swift
@@ -200,12 +200,43 @@ final class WidgetDataProviderTests: XCTestCase {
         XCTAssertTrue(snap.featured.isEmpty)
     }
 
+    // MARK: - Nickname
+
+    func testSnapshot_populatesNickname_whenPersonHasNickname() {
+        let cadenceId = UUID()
+        _ = seedGroup(id: cadenceId, frequencyDays: 10, warningDays: 2)
+        _ = seedPerson(
+            name: "Robert Smith",
+            cadenceId: cadenceId,
+            lastTouchAt: daysAgo(30),
+            nickname: "Bobby"
+        )
+
+        let snap = WidgetDataProvider.snapshot(context: context)
+        XCTAssertEqual(snap.featured.first?.nickname, "Bobby")
+    }
+
+    func testSnapshot_nicknameIsNil_whenPersonHasNoNickname() {
+        let cadenceId = UUID()
+        _ = seedGroup(id: cadenceId, frequencyDays: 10, warningDays: 2)
+        _ = seedPerson(
+            name: "Alice",
+            cadenceId: cadenceId,
+            lastTouchAt: daysAgo(30),
+            nickname: nil
+        )
+
+        let snap = WidgetDataProvider.snapshot(context: context)
+        XCTAssertNil(snap.featured.first?.nickname)
+    }
+
     // MARK: - Fixtures
 
-    private func makeOverduePerson(name: String, status: WidgetPersonStatus) -> OverduePerson {
+    private func makeOverduePerson(name: String, status: WidgetPersonStatus, nickname: String? = nil) -> OverduePerson {
         OverduePerson(
             id: UUID(),
             displayName: name,
+            nickname: nickname,
             initials: String(name.prefix(2)),
             avatarColorHex: "#FF6B6B",
             groupName: "Friends",
@@ -244,7 +275,8 @@ final class WidgetDataProviderTests: XCTestCase {
         groupAddedAt: Date? = nil,
         isPaused: Bool = false,
         isTracked: Bool = true,
-        isDemoData: Bool = false
+        isDemoData: Bool = false,
+        nickname: String? = nil
     ) -> PersonEntity {
         let entity = PersonEntity(context: context)
         entity.id = UUID()
@@ -262,6 +294,7 @@ final class WidgetDataProviderTests: XCTestCase {
         entity.notificationsMuted = false
         entity.contactUnavailable = false
         entity.birthdayNotificationsEnabled = true
+        entity.nickname = nickname
         entity.sortOrder = 0
         entity.createdAt = Date()
         entity.modifiedAt = Date()

--- a/StayInTouch/StayInTouchTests/WidgetDataProviderTests.swift
+++ b/StayInTouch/StayInTouchTests/WidgetDataProviderTests.swift
@@ -200,6 +200,45 @@ final class WidgetDataProviderTests: XCTestCase {
         XCTAssertTrue(snap.featured.isEmpty)
     }
 
+    // MARK: - trackedCount (used by accessory circular gauge fill)
+
+    func testSnapshot_trackedCount_zeroWhenEmpty() {
+        let snap = WidgetDataProvider.snapshot(context: context)
+        XCTAssertEqual(snap.trackedCount, 0)
+    }
+
+    func testSnapshot_trackedCount_excludesPausedAndDemoAndUntracked() {
+        let cadenceId = UUID()
+        _ = seedGroup(id: cadenceId, frequencyDays: 10, warningDays: 2)
+
+        // 4 active tracked, 1 paused, 1 demo, 1 untracked → trackedCount = 4
+        for i in 0..<4 {
+            _ = seedPerson(name: "Active\(i)", cadenceId: cadenceId, lastTouchAt: daysAgo(2))
+        }
+        _ = seedPerson(name: "Paused", cadenceId: cadenceId, lastTouchAt: daysAgo(2), isPaused: true)
+        _ = seedPerson(name: "Demo", cadenceId: cadenceId, lastTouchAt: daysAgo(2), isDemoData: true)
+        _ = seedPerson(name: "Untracked", cadenceId: cadenceId, lastTouchAt: daysAgo(2), isTracked: false)
+
+        let snap = WidgetDataProvider.snapshot(context: context)
+        XCTAssertEqual(snap.trackedCount, 4)
+    }
+
+    func testSnapshot_trackedCount_respectsGroupFilter() {
+        let cadenceA = UUID()
+        let cadenceB = UUID()
+        _ = seedGroup(id: cadenceA, frequencyDays: 10, warningDays: 2)
+        _ = seedGroup(id: cadenceB, frequencyDays: 10, warningDays: 2)
+
+        for i in 0..<3 { _ = seedPerson(name: "A\(i)", cadenceId: cadenceA, lastTouchAt: daysAgo(2)) }
+        for i in 0..<5 { _ = seedPerson(name: "B\(i)", cadenceId: cadenceB, lastTouchAt: daysAgo(2)) }
+
+        let unfiltered = WidgetDataProvider.snapshot(context: context)
+        XCTAssertEqual(unfiltered.trackedCount, 8)
+
+        let filteredA = WidgetDataProvider.snapshot(context: context, groupFilter: cadenceA)
+        XCTAssertEqual(filteredA.trackedCount, 3)
+    }
+
     // MARK: - Nickname
 
     func testSnapshot_populatesNickname_whenPersonHasNickname() {


### PR DESCRIPTION
## Summary

Closes #279. Extends the widget family with the three Lock Screen / StandBy accessory widget shapes (`circular`, `rectangular`, `inline`). Pure rendering addition — no data-layer changes beyond carrying `nickname` through to `OverduePerson`.

- **AccessoryCircularView** — two-tone red/orange ring around an overdue/due-soon digit. Red arc covers `overdue / (overdue + dueSoon)` of circumference; orange covers the remainder. In `.accented` / `.vibrant` rendering mode (Lock Screen, StandBy night) the ring flattens to a single tinted arc — system tint applies. All-caught-up shows `hand.wave.fill`; no-tracked-people shows `person.crop.circle.badge.plus`.
- **AccessoryRectangularView** — status SF Symbol + person name (line 1, bold), then `"3d overdue · 2 more"` (line 2). Name uses new `displayShortName` that prefers nickname over first name. All-caught-up and no-tracked-people empty states handled.
- **AccessoryInlineView** — single `Label` from `AccessoryWidgetLogic.inlineLabel`. Same name preference.

Both new shells delegate layout/copy decisions to a new `AccessoryWidgetLogic` helper in `Shared/` so the SwiftUI views stay thin and the routing rules are unit-testable without a SwiftUI inspection dependency.

The widget is registered as a second `Widget` in `KeepInTouchWidgetBundle` so it shows up as its own gallery entry under "Lock Screen widgets" — separate from the existing home-screen entry. Reuses the existing `OverdueTimelineProvider` and `OverdueWidgetConfigurationIntent` (group filter) unchanged.

### Design decisions

- **Two-tone ring drawn manually** (two `Circle().trim(from:to:)` strokes), not `Gauge` — Apple's stock `Gauge` is single-segment.
- **iOS 17 deployment target preserved** — `.widgetAccentedRenderingMode` is iOS 18+, so we read `@Environment(\.widgetRenderingMode)` directly (iOS 16+) and branch behavior.
- **Nickname > first name** for the short-name treatment in rectangular (line 1) + inline.
- **No SwiftUI view tests** — accessory shells are thin; all branching logic moved to `AccessoryWidgetLogic` which has 24 new unit tests covering ring fill, center digit, rectangular subtitle, inline label routing, and `displayShortName` edge cases (whitespace, fallback, single-word, empty string).

### Files

**New**
- `KeepInTouchWidget/OverdueLockScreenWidget.swift` — widget config, entry view, three accessory views
- `StayInTouch/Shared/AccessoryWidgetLogic.swift` — pure helper for layout/copy decisions
- `StayInTouchTests/AccessoryWidgetLogicTests.swift` — 24 unit tests

**Modified**
- `KeepInTouchWidget/KeepInTouchWidgetBundle.swift` — register `OverdueLockScreenWidget()`
- `KeepInTouchWidget/KeepInTouchWidget.swift` — promote `WidgetPersonStatus` extension to module-internal; placeholder snapshot updated for new `nickname` field
- `StayInTouch/Shared/WidgetDataProvider.swift` — `nickname: String?` on `OverduePerson`; populated from `PersonEntity.nickname`; new `displayShortName` computed property
- `StayInTouchTests/WidgetDataProviderTests.swift` — 2 new tests for nickname population

## Test plan

- [x] `xcode_build` — Debug, iPhone 17 Pro / iOS 26.3.1 — clean
- [x] `xcode_test` — full suite passes (existing 316 + 12 widget + 24 new logic + 2 new nickname)
- [ ] Manual QA on simulator after merge: install all three accessory widgets via "Customize Lock Screen"; verify rendering, tap targets, group filter respect
- [ ] Manual QA: enable StandBy, verify night-mode rendering of circular ring (single tinted arc — two-tone distinction is documented as acceptable degradation)
- [ ] Empty state QA: paused-only cohort → "All caught up"; no tracked people → "Add someone to track"

## Out of scope (potential follow-ups)

- Wire `hideContactNamesInNotifications` (#106) to widget rendering
- Apple Watch complications
- Optional inline widget copy variants (current single line covers all states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)