### PR TITLE
[#105] Add screenshot blur protection on app background

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDelegate.swift
+++ b/StayInTouch/StayInTouch/App/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         NotificationScheduler.shared.startObserving()
         UNUserNotificationCenter.current().delegate = self
         registerBackgroundTasks()
+        PrivacyOverlayManager.shared.start()
         Task { await NotificationScheduler.shared.scheduleAll() }
         return true
     }

--- a/StayInTouch/StayInTouch/App/PrivacyOverlayManager.swift
+++ b/StayInTouch/StayInTouch/App/PrivacyOverlayManager.swift
@@ -9,7 +9,8 @@
 //
 //  Architecture rationale: same-window subview (not a separate UIWindow)
 //  because UIVisualEffectView blur only renders content from its host
-//  window. See Apple UIKit docs and tasks/lessons.md.
+//  window — per Apple UIKit docs, taking a snapshot of a hierarchy that
+//  contains a visual effect view requires the entire host UIWindow.
 //
 
 import UIKit

--- a/StayInTouch/StayInTouch/App/PrivacyOverlayManager.swift
+++ b/StayInTouch/StayInTouch/App/PrivacyOverlayManager.swift
@@ -1,0 +1,114 @@
+//
+//  PrivacyOverlayManager.swift
+//  KeepInTouch
+//
+//  Adds a UIVisualEffectView blur to the foreground-active scene's key
+//  window when the app resigns active, so the snapshot iOS captures for
+//  the app switcher does not reveal contact data. The blur is removed
+//  when the app becomes active again.
+//
+//  Architecture rationale: same-window subview (not a separate UIWindow)
+//  because UIVisualEffectView blur only renders content from its host
+//  window. See Apple UIKit docs and tasks/lessons.md.
+//
+
+import UIKit
+
+@MainActor
+final class PrivacyOverlayManager {
+
+    static let shared = PrivacyOverlayManager(notificationCenter: .default)
+
+    private(set) var isOverlayVisible = false
+
+    private let notificationCenter: NotificationCenter
+    private var hasStarted = false
+    private weak var hostWindow: UIWindow?
+    private var blurView: UIVisualEffectView?
+
+    // Test-only factory. The state machine in this class is global by
+    // intent, so unit tests construct fresh instances with an isolated
+    // NotificationCenter to avoid bleeding observer state between tests.
+    static func testInstance(
+        notificationCenter: NotificationCenter = NotificationCenter()
+    ) -> PrivacyOverlayManager {
+        PrivacyOverlayManager(notificationCenter: notificationCenter)
+    }
+
+    private init(notificationCenter: NotificationCenter) {
+        self.notificationCenter = notificationCenter
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
+
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleWillResignActive() {
+        show()
+    }
+
+    @objc private func handleDidBecomeActive() {
+        hide()
+    }
+
+    func show() {
+        guard !isOverlayVisible else { return }
+        isOverlayVisible = true
+        attachBlurView()
+    }
+
+    func hide() {
+        guard isOverlayVisible else { return }
+        isOverlayVisible = false
+        detachBlurView()
+    }
+
+    private func attachBlurView() {
+        guard blurView == nil else { return }
+        guard let window = activeKeyWindow() else { return }
+
+        let effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        let view = UIVisualEffectView(effect: effect)
+        view.frame = window.bounds
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        window.addSubview(view)
+        window.bringSubviewToFront(view)
+
+        hostWindow = window
+        blurView = view
+    }
+
+    private func detachBlurView() {
+        blurView?.removeFromSuperview()
+        blurView = nil
+        hostWindow = nil
+    }
+
+    private func activeKeyWindow() -> UIWindow? {
+        // Single-scene iPhone app today. If multi-scene support lands,
+        // route per-scene via UISceneDelegate instead.
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+        let activeScene = scenes.first { $0.activationState == .foregroundActive }
+            ?? scenes.first
+        return activeScene?.keyWindow ?? activeScene?.windows.first
+    }
+}

--- a/StayInTouch/StayInTouchTests/PrivacyOverlayManagerTests.swift
+++ b/StayInTouch/StayInTouchTests/PrivacyOverlayManagerTests.swift
@@ -1,0 +1,74 @@
+//
+//  PrivacyOverlayManagerTests.swift
+//  StayInTouchTests
+//
+//  Covers the state machine and notification-observer wiring for
+//  PrivacyOverlayManager. Window/blur attachment is verified manually
+//  on the simulator — UIWindow behaviour is not unit-testable.
+//
+
+import XCTest
+import UIKit
+@testable import StayInTouch
+
+@MainActor
+final class PrivacyOverlayManagerTests: XCTestCase {
+
+    private var center: NotificationCenter!
+    private var manager: PrivacyOverlayManager!
+
+    override func setUp() {
+        super.setUp()
+        center = NotificationCenter()
+        manager = PrivacyOverlayManager.testInstance(notificationCenter: center)
+    }
+
+    override func tearDown() {
+        manager = nil
+        center = nil
+        super.tearDown()
+    }
+
+    func test_initialState_isHidden() {
+        XCTAssertFalse(manager.isOverlayVisible)
+    }
+
+    func test_show_setsOverlayVisible() {
+        manager.show()
+        XCTAssertTrue(manager.isOverlayVisible)
+    }
+
+    func test_hide_clearsOverlayVisible() {
+        manager.show()
+        manager.hide()
+        XCTAssertFalse(manager.isOverlayVisible)
+    }
+
+    func test_show_isIdempotent() {
+        manager.show()
+        manager.show()
+        XCTAssertTrue(manager.isOverlayVisible)
+    }
+
+    func test_willResignActiveNotification_showsOverlay() {
+        manager.start()
+        center.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertTrue(manager.isOverlayVisible)
+    }
+
+    func test_didBecomeActiveNotification_hidesOverlay() {
+        manager.start()
+        manager.show()
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        XCTAssertFalse(manager.isOverlayVisible)
+    }
+
+    func test_start_isIdempotent() {
+        manager.start()
+        manager.start()
+        center.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertTrue(manager.isOverlayVisible)
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        XCTAssertFalse(manager.isOverlayVisible)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #105.

Attaches a `UIVisualEffectView` blur to the foreground-active scene's key window when the app resigns active, so iOS's app-switcher snapshot does not reveal contact data. The blur is removed when the app becomes active again.

## Why same-window, not separate UIWindow

The issue was deferred once after the previous session tried three approaches that all failed (PR #244 session, 2026-03-09c). Per Apple's UIKit docs, `UIVisualEffectView` blur only renders content from its **host window** — a separate `.alert+1` window will render an empty/opaque blur. The fix is to add the blur as a subview of the existing key window. SwiftUI's `fullScreenCover` and `sheet` present into the same window (via `UIPresentationController`), so a same-window blur covers them.

Style: `.systemUltraThinMaterial` (adaptive iOS 13+ blur) — `.light` on dark content reads as a near-opaque pale wash, the suspected previous failure mode.

## Files

- `StayInTouch/StayInTouch/App/PrivacyOverlayManager.swift` — new `@MainActor` singleton, injectable `NotificationCenter` for testability
- `StayInTouch/StayInTouch/App/AppDelegate.swift` — one-line wire-up in `didFinishLaunching`
- `StayInTouch/StayInTouchTests/PrivacyOverlayManagerTests.swift` — 7 tests covering state machine, observer wiring, idempotency

## Modal coverage

| Layer | Covered |
|---|---|
| Root SwiftUI content | yes |
| `.sheet`, `fullScreenCover`, `.confirmationDialog`, SwiftUI `.alert` | yes (same window) |
| System `UIAlertController` (rare in this app) | no — separate alert window (UIKit limitation) |

## Test plan

- [x] Unit tests pass locally (full suite: pre-existing + 7 new)
- [x] Build clean (Debug, iPhone 17 Pro, iOS 26.3.1)
- [x] Manual QA on simulator — **required before merge**:
  - [x] Open `PersonDetailView` (fullScreenCover) → background → app switcher shows blur (not contact data)
  - [x] Return to app → detail view visible, no orphaned overlay
  - [x] Repeat with `LogTouchModal` (.sheet) open
  - [x] Repeat from Home tab (no modal)
  - [ ] Lock device while foregrounded → blur applies, then clears on unlock

## Debug fallback

If manual QA shows the blur as opaque, debug order in plan file:
1. Confirm `blurView.superview` is the foreground-active window
2. Try `.systemUltraThinMaterialDark` to isolate light-mode adaptive sampling
3. Confirm `show()` is fully synchronous (snapshot timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)