### PR TITLE
[#299] Streamline Log Connection picker: collapse TouchMethod to medium-only

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/Mappings/TouchEventEntity+Mapping.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Mappings/TouchEventEntity+Mapping.swift
@@ -13,12 +13,26 @@ extension TouchEventEntity {
             id: requiredField(id, entity: "TouchEventEntity", field: "id", fallback: UUID()),
             personId: requiredField(personId, entity: "TouchEventEntity", field: "personId", fallback: UUID()),
             at: requiredField(at, entity: "TouchEventEntity", field: "at", fallback: Date()),
-            method: TouchMethod(rawValue: method ?? TouchMethod.other.rawValue) ?? .other,
+            method: Self.coerceMethod(method),
             notes: notes,
             timeOfDay: timeOfDay.flatMap(TimeOfDay.init(rawValue:)),
             createdAt: requiredField(createdAt, entity: "TouchEventEntity", field: "createdAt", fallback: Date()),
             modifiedAt: requiredField(modifiedAt, entity: "TouchEventEntity", field: "modifiedAt", fallback: Date())
         )
+    }
+
+    // Legacy raw values "WhatsApp" and "Signal" came from #296's TouchMethod
+    // expansion. #299 collapsed TouchMethod to medium-only, so they read as
+    // .text. On next save the row is rewritten with the canonical raw value.
+    private static func coerceMethod(_ rawValue: String?) -> TouchMethod {
+        switch rawValue {
+        case "WhatsApp", "Signal":
+            return .text
+        case let value?:
+            return TouchMethod(rawValue: value) ?? .other
+        case nil:
+            return .other
+        }
     }
 
     /// Returns `value` if non-nil; otherwise logs a data-corruption warning and returns the fallback.

--- a/StayInTouch/StayInTouch/Domain/ValueObjects/PreferredMessenger.swift
+++ b/StayInTouch/StayInTouch/Domain/ValueObjects/PreferredMessenger.swift
@@ -31,11 +31,12 @@ enum PreferredMessenger: String, CaseIterable, Codable {
     }
 
     /// TouchMethod recorded when a touch is auto-logged via this messenger.
+    /// All three messengers are text-medium apps and log as `.text` (#299).
+    /// The per-contact app preference is preserved on `Person.preferredMessenger`,
+    /// not duplicated on each `TouchEvent`.
     var touchMethod: TouchMethod {
         switch self {
-        case .iMessage: return .text
-        case .whatsapp: return .whatsapp
-        case .signal: return .signal
+        case .iMessage, .whatsapp, .signal: return .text
         }
     }
 

--- a/StayInTouch/StayInTouch/Domain/ValueObjects/TouchMethod.swift
+++ b/StayInTouch/StayInTouch/Domain/ValueObjects/TouchMethod.swift
@@ -12,8 +12,6 @@ enum TouchMethod: String, CaseIterable, Codable {
     case call = "Call"
     case irl = "IRL"
     case email = "Email"
-    case whatsapp = "WhatsApp"
-    case signal = "Signal"
     case facetime = "FaceTime"
     case other = "Other"
 }

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -480,8 +480,6 @@ enum DS {
         case .call: return "phone.fill"
         case .irl: return "person.2.fill"
         case .email: return "envelope.fill"
-        case .whatsapp: return "bubble.left.and.bubble.right.fill"
-        case .signal: return "lock.message.fill"
         case .facetime: return "video.fill"
         case .other: return "ellipsis.circle.fill"
         }

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -498,12 +498,16 @@ final class PersonDetailViewModel: ObservableObject {
         case message(explicit: PreferredMessenger?)
 
         /// TouchMethod to log when this routing succeeds.
-        /// For `.message(explicit: nil)` the caller MUST pass the resolved
-        /// default messenger (typically `viewModel.resolvedMessenger`) —
-        /// otherwise a contact with a saved WhatsApp/Signal preference
-        /// would log as `.text` even though the actual app opened was
-        /// WhatsApp/Signal. The signature forces this at the call site so
-        /// the regression can't be reintroduced silently.
+        ///
+        /// `.call` always logs `.call`; `.faceTime` always logs `.facetime`.
+        /// `.message(explicit:)` delegates to `PreferredMessenger.touchMethod`
+        /// — after #299 all three text-medium messengers (iMessage, WhatsApp,
+        /// Signal) log as `.text`, with the per-contact app preference
+        /// preserved on `Person.preferredMessenger`. The `defaultMessenger:`
+        /// parameter is retained so the routing→logging boundary stays
+        /// explicit at every call site — if a new non-text messenger is
+        /// added later that should log distinctly, the contract is already
+        /// in place to surface the resolved messenger here.
         func resolvedTouchMethod(defaultMessenger: PreferredMessenger) -> TouchMethod {
             switch self {
             case .call: return .call

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/EditTouchModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/EditTouchModal.swift
@@ -35,30 +35,7 @@ struct EditTouchModal: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
-                HStack(spacing: DS.Spacing.md) {
-                    ForEach(TouchMethod.allCases, id: \.self) { touchMethod in
-                        Button {
-                            selectedMethod = touchMethod
-                        } label: {
-                            VStack(spacing: DS.Spacing.xs) {
-                                Image(systemName: DS.touchMethodIcon(touchMethod))
-                                    .font(.title2)
-                                Text(touchMethod.rawValue)
-                                    .font(DS.Typography.caption)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, DS.Spacing.sm)
-                            .background(
-                                selectedMethod == touchMethod
-                                    ? DS.Colors.accent.opacity(0.12)
-                                    : Color.clear
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
-                        }
-                        .buttonStyle(.plain)
-                        .foregroundColor(selectedMethod == touchMethod ? DS.Colors.accent : DS.Colors.secondaryText)
-                    }
-                }
+                TouchMethodPicker(selection: $selectedMethod)
 
                 Picker("Time of Day", selection: $selectedTimeOfDay) {
                     Text("None").tag(TimeOfDay?.none)

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/LogTouchModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/LogTouchModal.swift
@@ -20,32 +20,7 @@ struct LogTouchModal: View {
     var body: some View {
         NavigationStack {
             Form {
-                HStack(spacing: DS.Spacing.md) {
-                    ForEach(TouchMethod.allCases, id: \.self) { touchMethod in
-                        Button {
-                            selectedMethod = touchMethod
-                        } label: {
-                            VStack(spacing: DS.Spacing.xs) {
-                                Image(systemName: DS.touchMethodIcon(touchMethod))
-                                    .font(.title2)
-                                Text(touchMethod.rawValue)
-                                    .font(DS.Typography.caption)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, DS.Spacing.sm)
-                            .background(
-                                selectedMethod == touchMethod
-                                    ? DS.Colors.accent.opacity(0.12)
-                                    : Color.clear
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
-                        }
-                        .buttonStyle(.plain)
-                        .foregroundColor(selectedMethod == touchMethod ? DS.Colors.accent : DS.Colors.secondaryText)
-                        .accessibilityLabel("\(touchMethod.rawValue)\(selectedMethod == touchMethod ? ", selected" : "")")
-                        .accessibilityHint("Sets connection type to \(touchMethod.rawValue)")
-                    }
-                }
+                TouchMethodPicker(selection: $selectedMethod)
 
                 DatePicker("Date", selection: $touchDate, in: ...Date(), displayedComponents: .date)
 

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -392,9 +392,10 @@ struct PersonDetailView: View {
     /// have to reproduce that dance. The plain `method:` overload is for
     /// codepaths that don't need messenger preference handling (email + FaceTime).
     private func executeQuickAction(url: URL, routing: PersonDetailViewModel.PhoneRouting) {
-        // Resolve the messenger ONCE — used for both the auto-logged TouchMethod
-        // (so `.message` with a sticky WhatsApp preference logs `.whatsapp`,
-        // not `.text`) and the self-heal target on failure.
+        // Resolve the messenger ONCE — used for the self-heal target on failure.
+        // The auto-logged TouchMethod is always `.text` for text-medium messengers
+        // (#299 collapsed TouchMethod to medium-only); the which-app signal lives
+        // on `Person.preferredMessenger`.
         let resolvedMessenger: PreferredMessenger? = {
             if case .message(let explicit) = routing { return explicit ?? viewModel.resolvedMessenger }
             return nil

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/TouchMethodPicker.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/TouchMethodPicker.swift
@@ -1,0 +1,138 @@
+//
+//  TouchMethodPicker.swift
+//  KeepInTouch
+//
+//  Created by Codex on 5/17/26.
+//
+
+import SwiftUI
+
+/// Picker for the touch method. Used by both `LogTouchModal` (new touches)
+/// and `EditTouchModal` (existing touches).
+///
+/// Layout: 4-tile primary row (Text / Call / IRL / More…). The 4th tile
+/// opens a sheet with secondary methods (FaceTime / Email / Other). When a
+/// secondary method is currently selected, the 4th tile renders as that
+/// method with a checkmark so the current selection stays visible without
+/// reopening the sheet.
+///
+/// Replaces the pre-#299 `ForEach(TouchMethod.allCases)` layout which
+/// became cramped after PR #296 added routing-only cases to the enum.
+struct TouchMethodPicker: View {
+    @Binding var selection: TouchMethod
+
+    @State private var showingMoreSheet = false
+
+    private static let primary: [TouchMethod] = [.text, .call, .irl]
+    private static let secondary: [TouchMethod] = [.facetime, .email, .other]
+
+    var body: some View {
+        HStack(spacing: DS.Spacing.md) {
+            ForEach(Self.primary, id: \.self) { method in
+                tile(for: method)
+            }
+            moreTile
+        }
+        .sheet(isPresented: $showingMoreSheet) {
+            moreSheetContent
+        }
+    }
+
+    @ViewBuilder
+    private func tile(for method: TouchMethod) -> some View {
+        Button {
+            selection = method
+        } label: {
+            tileLabel(
+                icon: DS.touchMethodIcon(method),
+                text: method.rawValue,
+                isSelected: selection == method
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(method.rawValue)\(selection == method ? ", selected" : "")")
+        .accessibilityHint("Sets connection type to \(method.rawValue)")
+    }
+
+    @ViewBuilder
+    private var moreTile: some View {
+        let selectedSecondary = Self.secondary.contains(selection) ? selection : nil
+        Button {
+            showingMoreSheet = true
+        } label: {
+            if let method = selectedSecondary {
+                tileLabel(
+                    icon: DS.touchMethodIcon(method),
+                    text: method.rawValue,
+                    isSelected: true
+                )
+            } else {
+                tileLabel(
+                    icon: "ellipsis.circle.fill",
+                    text: "More",
+                    isSelected: false
+                )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+            selectedSecondary.map { "More, currently \($0.rawValue)" } ?? "More connection types"
+        )
+        .accessibilityHint("Opens picker with FaceTime, Email, and Other")
+    }
+
+    private func tileLabel(icon: String, text: String, isSelected: Bool) -> some View {
+        VStack(spacing: DS.Spacing.xs) {
+            Image(systemName: icon)
+                .font(.title2)
+            Text(text)
+                .font(DS.Typography.caption)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DS.Spacing.sm)
+        .background(
+            isSelected ? DS.Colors.accent.opacity(0.12) : Color.clear
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+        .foregroundColor(isSelected ? DS.Colors.accent : DS.Colors.secondaryText)
+    }
+
+    @ViewBuilder
+    private var moreSheetContent: some View {
+        NavigationStack {
+            List {
+                ForEach(Self.secondary, id: \.self) { method in
+                    Button {
+                        selection = method
+                        showingMoreSheet = false
+                    } label: {
+                        HStack {
+                            Image(systemName: DS.touchMethodIcon(method))
+                                .font(.body)
+                                .frame(width: 24)
+                                .foregroundColor(DS.Colors.secondaryText)
+                            Text(method.rawValue)
+                                .foregroundColor(.primary)
+                            Spacer()
+                            if selection == method {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(DS.Colors.accent)
+                            }
+                        }
+                    }
+                    .accessibilityLabel("\(method.rawValue)\(selection == method ? ", selected" : "")")
+                    .accessibilityHint("Sets connection type to \(method.rawValue)")
+                }
+            }
+            .navigationTitle("More")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") { showingMoreSheet = false }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}

--- a/StayInTouch/StayInTouchTests/PersonDetailViewModelMessengerTests.swift
+++ b/StayInTouch/StayInTouchTests/PersonDetailViewModelMessengerTests.swift
@@ -174,28 +174,28 @@ final class PersonDetailViewModelMessengerTests: XCTestCase {
         )
     }
 
-    func testResolvedTouchMethodForExplicitMessengerUsesExplicit() {
-        // .message(.whatsapp) always logs .whatsapp, regardless of the default.
+    func testResolvedTouchMethodForExplicitMessengerLogsTextMedium() {
+        // #299: TouchMethod collapsed to medium-only. WhatsApp and Signal are
+        // text-medium apps — they route correctly via PreferredMessenger but
+        // log as .text. Per-touch app identity is no longer recorded; the
+        // per-contact preference lives on Person.preferredMessenger.
         XCTAssertEqual(
             PersonDetailViewModel.PhoneRouting.message(explicit: .whatsapp)
                 .resolvedTouchMethod(defaultMessenger: .iMessage),
-            .whatsapp
+            .text
         )
         XCTAssertEqual(
             PersonDetailViewModel.PhoneRouting.message(explicit: .signal)
                 .resolvedTouchMethod(defaultMessenger: .whatsapp),
-            .signal
+            .text
         )
     }
 
-    /// Regression test for the bug introduced in commit fd46a1e and fixed in
-    /// the follow-up: when the user has a sticky WhatsApp/Signal preference
-    /// and single-taps the Message card (no explicit pick), the touch must
-    /// be logged with the resolved messenger's TouchMethod, NOT iMessage's
-    /// `.text`. The bug surfaced because `.message(explicit: nil)` previously
-    /// defaulted to `.iMessage` regardless of saved preference, so a tap
-    /// that correctly opened WhatsApp would log as Text in history.
-    func testResolvedTouchMethodForImplicitMessengerUsesDefault() {
+    /// Sticky messenger preferences (WhatsApp/Signal) still ROUTE to the
+    /// correct app on single-tap, but the logged TouchMethod is .text for
+    /// all text-medium apps after #299. The which-app signal is preserved
+    /// on Person.preferredMessenger, not duplicated on each TouchEvent.
+    func testResolvedTouchMethodForImplicitMessengerAlwaysTextMedium() {
         XCTAssertEqual(
             PersonDetailViewModel.PhoneRouting.message(explicit: nil)
                 .resolvedTouchMethod(defaultMessenger: .iMessage),
@@ -204,14 +204,14 @@ final class PersonDetailViewModelMessengerTests: XCTestCase {
         XCTAssertEqual(
             PersonDetailViewModel.PhoneRouting.message(explicit: nil)
                 .resolvedTouchMethod(defaultMessenger: .whatsapp),
-            .whatsapp,
-            "Sticky WhatsApp preference must log .whatsapp on single-tap, not .text"
+            .text,
+            "Sticky WhatsApp preference routes to WhatsApp app but logs as .text medium (#299)"
         )
         XCTAssertEqual(
             PersonDetailViewModel.PhoneRouting.message(explicit: nil)
                 .resolvedTouchMethod(defaultMessenger: .signal),
-            .signal,
-            "Sticky Signal preference must log .signal on single-tap, not .text"
+            .text,
+            "Sticky Signal preference routes to Signal app but logs as .text medium (#299)"
         )
     }
 }

--- a/StayInTouch/StayInTouchTests/TouchEventEntityMappingTests.swift
+++ b/StayInTouch/StayInTouchTests/TouchEventEntityMappingTests.swift
@@ -1,0 +1,124 @@
+//
+//  TouchEventEntityMappingTests.swift
+//  KeepInTouchTests
+//
+//  Created by Codex on 5/17/26.
+//
+
+import CoreData
+import XCTest
+@testable import StayInTouch
+
+final class TouchEventEntityMappingTests: XCTestCase {
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+        context = CoreDataTestStack().container.viewContext
+    }
+
+    // MARK: - Legacy raw-value coercion (#299)
+    //
+    // PR #296 added `.whatsapp` and `.signal` TouchMethod cases that were
+    // removed in #299 (collapsed to medium-only). Existing TouchEvent rows
+    // persisted with "WhatsApp" or "Signal" string raw values must continue
+    // to load — they coerce to `.text` on read. On next save the row is
+    // rewritten with the canonical raw value (rolling natural migration).
+
+    func testLegacyWhatsAppRawValueCoercesToText() {
+        let entity = makeEntity(methodRawValue: "WhatsApp")
+
+        let domain = entity.toDomain()
+
+        XCTAssertEqual(domain.method, .text, "Legacy WhatsApp raw value must coerce to .text")
+    }
+
+    func testLegacySignalRawValueCoercesToText() {
+        let entity = makeEntity(methodRawValue: "Signal")
+
+        let domain = entity.toDomain()
+
+        XCTAssertEqual(domain.method, .text, "Legacy Signal raw value must coerce to .text")
+    }
+
+    // MARK: - Canonical raw values continue to map correctly
+
+    func testTextRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "Text").toDomain().method, .text)
+    }
+
+    func testCallRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "Call").toDomain().method, .call)
+    }
+
+    func testIRLRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "IRL").toDomain().method, .irl)
+    }
+
+    func testEmailRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "Email").toDomain().method, .email)
+    }
+
+    func testFaceTimeRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "FaceTime").toDomain().method, .facetime)
+    }
+
+    func testOtherRawValueMaps() {
+        XCTAssertEqual(makeEntity(methodRawValue: "Other").toDomain().method, .other)
+    }
+
+    func testUnknownRawValueFallsBackToOther() {
+        XCTAssertEqual(
+            makeEntity(methodRawValue: "Telegram").toDomain().method,
+            .other,
+            "Unknown raw values must fall back to .other rather than crashing"
+        )
+    }
+
+    func testNilRawValueFallsBackToOther() {
+        let entity = TouchEventEntity(context: context)
+        entity.id = UUID()
+        entity.personId = UUID()
+        entity.at = Date()
+        entity.method = nil
+        entity.createdAt = Date()
+        entity.modifiedAt = Date()
+
+        XCTAssertEqual(entity.toDomain().method, .other)
+    }
+
+    // MARK: - Round-trip for canonical cases
+
+    func testRoundTripFaceTimeMethod() {
+        let entity = TouchEventEntity(context: context)
+        let touchEvent = TouchEvent(
+            id: UUID(),
+            personId: UUID(),
+            at: Date(),
+            method: .facetime,
+            notes: nil,
+            timeOfDay: nil,
+            createdAt: Date(),
+            modifiedAt: Date()
+        )
+        entity.apply(touchEvent)
+
+        let roundTripped = entity.toDomain()
+
+        XCTAssertEqual(roundTripped.method, .facetime)
+        XCTAssertEqual(entity.method, "FaceTime", "Canonical raw value must persist as 'FaceTime'")
+    }
+
+    // MARK: - Helpers
+
+    private func makeEntity(methodRawValue: String) -> TouchEventEntity {
+        let entity = TouchEventEntity(context: context)
+        entity.id = UUID()
+        entity.personId = UUID()
+        entity.at = Date()
+        entity.method = methodRawValue
+        entity.createdAt = Date()
+        entity.modifiedAt = Date()
+        return entity
+    }
+}


### PR DESCRIPTION
Closes #299.

## Summary

- **Collapse `TouchMethod` to medium-only** — remove `.whatsapp` and `.signal`, keep `.facetime`. PR #296 conflated routing (which messenger app?) with logging (what medium?). WhatsApp and Signal are text-medium apps; per-contact app preference lives on `Person.preferredMessenger`, which is unchanged.
- **Rebuild picker** — replace the cramped horizontal row in both `LogTouchModal` and `EditTouchModal` with a 4-tile primary row (Text / Call / IRL / More…) where the "More" tile opens a sheet listing FaceTime / Email / Other. When a secondary method is selected, the "More" tile reflects it with the method's icon + name + checkmark.
- **Rolling natural migration** — legacy "WhatsApp" / "Signal" raw values in `TouchEvent.method` coerce to `.text` on read via `TouchEventEntity+Mapping.toDomain()`. Next save rewrites with the canonical value. No Core Data version bump.

## Why this design

After PR #296, both modals iterated `TouchMethod.allCases`, so adding routing-only enum cases leaked them into the manual-logging picker as 8 cramped truncated tiles ("What-sApp", "Sig-nal", "Face Time", "Oth-er"). The fix isn't a picker workaround — it's removing the conflation at its source. Routing concerns stay in `PreferredMessenger` + `MessengerRouter`; analytical concerns stay in `TouchMethod`.

## Architecture

- `PreferredMessenger.touchMethod` (single switch) is the routing→logging bridge — now returns `.text` for all three text-medium apps (iMessage, WhatsApp, Signal). `MessengerRouter` / `CallerRouter` deep-link dispatch is unchanged.
- `TouchMethodPicker` is a new shared SwiftUI component used by both `LogTouchModal` and `EditTouchModal`.

## Tests

- 10 new `TouchEventEntityMappingTests` covering legacy WhatsApp/Signal coercion + canonical round-trip + nil/unknown fallback.
- Updated `PersonDetailViewModelMessengerTests` assertions for medium-only behavior (sticky WhatsApp/Signal preference now logs `.text`, not `.whatsapp`/`.signal`).
- Full unit suite green.

## Test plan

- [x] Full unit suite passes locally (`xcode_test` MCP — "Tests passed")
- [x] Build clean (`xcode_build` MCP — "Build succeeded")
- [ ] **Manual QA in simulator** (boot from `main` first to seed legacy `.whatsapp` data, then upgrade to this branch):
  - [ ] Existing `.whatsapp` / `.signal` touches display as "Text" in touch history (no crash, no blank).
  - [ ] Open Log Connection — see 4 clean tiles (Text / Call / IRL / More…), no truncation.
  - [ ] Tap "More" → sheet shows FaceTime / Email / Other → pick FaceTime → sheet dismisses → primary row reflects FaceTime selection.
  - [ ] Tap "Done" → touch logged with `.facetime`.
  - [ ] Tap Message on a contact with WhatsApp preference set → WhatsApp opens (unchanged routing) → touch logged as `.text` (changed from `.whatsapp`).
  - [ ] Long-press Call → FaceTime → FaceTime opens → touch logged as `.facetime` (unchanged).
  - [ ] Open EditTouchModal on a legacy `.whatsapp` touch → method shows as "Text" → can re-save.
  - [ ] Message-button long-press picker still shows iMessage / WhatsApp / Signal options based on availability (`PreferredMessenger` unaffected).

## NOT in scope

- D5 nextTouchNotes prefill chip → filed as #300 (needs usage instrumentation first).
- Removing `.facetime` — explicitly kept (video call is a distinct medium).
- D1 / D3 / D4 delight ideas (rejected during plan-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)