### PR TITLE
[#304] App Intents v1: Log Touch, Get Overdue/Due-Soon, Open, Shortcuts provider

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDependencies.swift
+++ b/StayInTouch/StayInTouch/App/AppDependencies.swift
@@ -26,6 +26,22 @@ struct AppDependencies {
         self.touchEventRepository = CoreDataTouchEventRepository(context: context)
         self.settingsRepository = CoreDataAppSettingsRepository(context: context)
     }
+
+    /// Test seam — assemble dependencies from explicit (typically mock)
+    /// repositories. Not used by the production wiring.
+    init(
+        personRepository: PersonRepository,
+        cadenceRepository: CadenceRepository,
+        groupRepository: GroupRepository,
+        touchEventRepository: TouchEventRepository,
+        settingsRepository: AppSettingsRepository
+    ) {
+        self.personRepository = personRepository
+        self.cadenceRepository = cadenceRepository
+        self.groupRepository = groupRepository
+        self.touchEventRepository = touchEventRepository
+        self.settingsRepository = settingsRepository
+    }
 }
 
 // MARK: - SwiftUI Environment

--- a/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
@@ -28,19 +28,20 @@ struct GetDueSoonContactsIntent: AppIntent {
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> & ProvidesDialog {
         let deps = IntentContainer.current.dependencies
-        let people = deps.personRepository.fetchTracked(includePaused: false)
-        let cadences = deps.cadenceRepository.fetchAll()
+        // Both fetches hit Core Data independently — overlap them so cold
+        // Siri launches don't pay the latency twice.
+        async let peopleTask = Task { deps.personRepository.fetchTracked(includePaused: false) }.value
+        async let cadencesTask = Task { deps.cadenceRepository.fetchAll() }.value
+        let people = await peopleTask
+        let cadences = await cadencesTask
         let dueSoon = PersonStatusService().dueSoonPeople(people, cadences: cadences)
         let entities = dueSoon.map(PersonAppEntity.init(person:))
-        let dialog: IntentDialog
-        switch entities.count {
-        case 0:
-            dialog = IntentDialog("Nothing's coming due in your warning window.")
-        case 1:
-            dialog = IntentDialog("One contact is due soon: \(entities[0].displayName).")
-        default:
-            dialog = IntentDialog("\(entities.count) contacts are due soon.")
-        }
+        let dialog = PersonListDialog.make(
+            for: entities,
+            emptyMessage: "Nothing's coming due in your warning window.",
+            singularSuffix: "is due soon",
+            pluralPredicate: "are due soon"
+        )
         return .result(value: entities, dialog: dialog)
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
@@ -1,0 +1,46 @@
+//
+//  GetDueSoonContactsIntent.swift
+//  KeepInTouch
+//
+//  Returns contacts inside the user's "due soon" window — the cadence's
+//  `warningDays` zone before breach. Classification matches the Home tab's
+//  Due Soon section so Shortcut output stays consistent with the app UI.
+//
+
+import AppIntents
+import Foundation
+
+struct GetDueSoonContactsIntent: AppIntent {
+    static var title: LocalizedStringResource { "Get Due-Soon Contacts" }
+    static var description: IntentDescription {
+        IntentDescription(
+            "Returns your contacts who are due soon — inside the warning window before they go overdue.",
+            categoryName: "Queries"
+        )
+    }
+
+    static var openAppWhenRun: Bool { false }
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get due-soon contacts")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> & ProvidesDialog {
+        let deps = IntentContainer.current.dependencies
+        let people = deps.personRepository.fetchTracked(includePaused: false)
+        let cadences = deps.cadenceRepository.fetchAll()
+        let dueSoon = PersonStatusService().dueSoonPeople(people, cadences: cadences)
+        let entities = dueSoon.map(PersonAppEntity.init(person:))
+        let dialog: IntentDialog
+        switch entities.count {
+        case 0:
+            dialog = IntentDialog("Nothing's coming due in your warning window.")
+        case 1:
+            dialog = IntentDialog("One contact is due soon: \(entities[0].displayName).")
+        default:
+            dialog = IntentDialog("\(entities.count) contacts are due soon.")
+        }
+        return .result(value: entities, dialog: dialog)
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetDueSoonContactsIntent.swift
@@ -6,6 +6,9 @@
 //  `warningDays` zone before breach. Classification matches the Home tab's
 //  Due Soon section so Shortcut output stays consistent with the app UI.
 //
+//  Intentionally does NOT conform to ProvidesDialog — see header in
+//  GetOverdueContactsIntent.swift for the rationale.
+//
 
 import AppIntents
 import Foundation
@@ -26,7 +29,7 @@ struct GetDueSoonContactsIntent: AppIntent {
     }
 
     @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> & ProvidesDialog {
+    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> {
         let deps = IntentContainer.current.dependencies
         // Both fetches hit Core Data independently — overlap them so cold
         // Siri launches don't pay the latency twice.
@@ -36,12 +39,6 @@ struct GetDueSoonContactsIntent: AppIntent {
         let cadences = await cadencesTask
         let dueSoon = PersonStatusService().dueSoonPeople(people, cadences: cadences)
         let entities = dueSoon.map(PersonAppEntity.init(person:))
-        let dialog = PersonListDialog.make(
-            for: entities,
-            emptyMessage: "Nothing's coming due in your warning window.",
-            singularSuffix: "is due soon",
-            pluralPredicate: "are due soon"
-        )
-        return .result(value: entities, dialog: dialog)
+        return .result(value: entities)
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
@@ -2,9 +2,15 @@
 //  GetOverdueContactsIntent.swift
 //  KeepInTouch
 //
-//  Returns the list of contacts whose touch cadence has breached.
-//  Designed for use in Shortcuts chains — pipe the result into Show
-//  Notification, Speak, Send Message, etc.
+//  Returns the list of contacts whose connection cadence has breached.
+//  Designed for use in Shortcuts chains — pipe the result into Choose
+//  from List + Open, Show Notification, Speak, Send Message, etc.
+//
+//  Intentionally does NOT conform to ProvidesDialog. An always-on
+//  "N contacts are overdue" banner showed even when the intent was
+//  chained into another action, which is intrusive (manual QA on PR
+//  #305 surfaced this). Downstream actions render the result however
+//  the user wants.
 //
 
 import AppIntents
@@ -14,7 +20,7 @@ struct GetOverdueContactsIntent: AppIntent {
     static var title: LocalizedStringResource { "Get Overdue Contacts" }
     static var description: IntentDescription {
         IntentDescription(
-            "Returns your contacts whose touch cadence has breached.",
+            "Returns your contacts whose connection cadence has breached.",
             categoryName: "Queries"
         )
     }
@@ -26,16 +32,10 @@ struct GetOverdueContactsIntent: AppIntent {
     }
 
     @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> & ProvidesDialog {
+    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> {
         let repository = IntentContainer.current.dependencies.personRepository
         let people = repository.fetchOverdue(referenceDate: Date())
         let entities = people.map(PersonAppEntity.init(person:))
-        let dialog = PersonListDialog.make(
-            for: entities,
-            emptyMessage: "Nothing's overdue right now.",
-            singularSuffix: "is overdue",
-            pluralPredicate: "are overdue"
-        )
-        return .result(value: entities, dialog: dialog)
+        return .result(value: entities)
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
@@ -30,15 +30,12 @@ struct GetOverdueContactsIntent: AppIntent {
         let repository = IntentContainer.current.dependencies.personRepository
         let people = repository.fetchOverdue(referenceDate: Date())
         let entities = people.map(PersonAppEntity.init(person:))
-        let dialog: IntentDialog
-        switch entities.count {
-        case 0:
-            dialog = IntentDialog("Nothing's overdue right now.")
-        case 1:
-            dialog = IntentDialog("One contact is overdue: \(entities[0].displayName).")
-        default:
-            dialog = IntentDialog("\(entities.count) contacts are overdue.")
-        }
+        let dialog = PersonListDialog.make(
+            for: entities,
+            emptyMessage: "Nothing's overdue right now.",
+            singularSuffix: "is overdue",
+            pluralPredicate: "are overdue"
+        )
         return .result(value: entities, dialog: dialog)
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/GetOverdueContactsIntent.swift
@@ -1,0 +1,44 @@
+//
+//  GetOverdueContactsIntent.swift
+//  KeepInTouch
+//
+//  Returns the list of contacts whose touch cadence has breached.
+//  Designed for use in Shortcuts chains — pipe the result into Show
+//  Notification, Speak, Send Message, etc.
+//
+
+import AppIntents
+import Foundation
+
+struct GetOverdueContactsIntent: AppIntent {
+    static var title: LocalizedStringResource { "Get Overdue Contacts" }
+    static var description: IntentDescription {
+        IntentDescription(
+            "Returns your contacts whose touch cadence has breached.",
+            categoryName: "Queries"
+        )
+    }
+
+    static var openAppWhenRun: Bool { false }
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get overdue contacts")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[PersonAppEntity]> & ProvidesDialog {
+        let repository = IntentContainer.current.dependencies.personRepository
+        let people = repository.fetchOverdue(referenceDate: Date())
+        let entities = people.map(PersonAppEntity.init(person:))
+        let dialog: IntentDialog
+        switch entities.count {
+        case 0:
+            dialog = IntentDialog("Nothing's overdue right now.")
+        case 1:
+            dialog = IntentDialog("One contact is overdue: \(entities[0].displayName).")
+        default:
+            dialog = IntentDialog("\(entities.count) contacts are overdue.")
+        }
+        return .result(value: entities, dialog: dialog)
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/IntentActions.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentActions.swift
@@ -2,23 +2,37 @@
 //  IntentActions.swift
 //  KeepInTouch
 //
-//  Thin facade that intents call. Mirrors the save-path side effects of
-//  `PersonDetailViewModel.logTouch` step-for-step so logging via Siri,
-//  Shortcuts, or the in-app modal produces identical state.
+//  Thin facade that intents call. Reuses the same recompute helper
+//  (`BulkLogTouchUseCase.applyTouch`) that `PersonDetailViewModel.logTouch`
+//  uses, so the headline `lastTouch*` rule and `snoozedUntil` /
+//  `customDueDate` clearing stay in one place.
 //
-//  Specifically: TouchEvent save → BulkLogTouchUseCase.applyTouch →
-//  Person save → `.personDidChange` post. The repository layer handles
-//  WidgetRefresher; the `.personDidChange` post triggers
-//  NotificationScheduler.scheduleAll() asynchronously.
+//  Side-effect sequence: TouchEvent save → applyTouch → Person save →
+//  `.personDidChange` post. The repository layer handles WidgetRefresher;
+//  the `.personDidChange` post triggers NotificationScheduler.scheduleAll().
+//
+//  Two intentional differences from `PersonDetailViewModel.logTouch`:
+//   1. On TouchEvent save failure this throws `IntentError.saveFailed`
+//      and skips the Person update. The UI path shows an error toast
+//      and still attempts the Person update — but Siri/Shortcuts have
+//      no toast surface, so the cleaner fail-fast is preferable.
+//   2. Notes are trimmed (whitespace-only → nil) so Shortcuts users
+//      can pass un-trimmed input from prior actions without polluting
+//      the log.
 //
 
 import Foundation
 
 struct IntentActions {
     let dependencies: AppDependencies
+    let trackAnalytics: (_ signal: String, _ parameters: [String: String]) -> Void
 
-    init(dependencies: AppDependencies = IntentContainer.current.dependencies) {
+    init(
+        dependencies: AppDependencies = IntentContainer.current.dependencies,
+        trackAnalytics: @escaping (String, [String: String]) -> Void = AnalyticsService.track
+    ) {
         self.dependencies = dependencies
+        self.trackAnalytics = trackAnalytics
     }
 
     /// Logs a touch for the given person id. Returns the updated Person
@@ -36,9 +50,9 @@ struct IntentActions {
             throw IntentError.personNotFound
         }
 
-        AnalyticsService.track(
+        trackAnalytics(
             "connection.logged",
-            parameters: ["method": method.rawValue, "source": "siri"]
+            ["method": method.rawValue, "source": "siri"]
         )
 
         let touch = TouchEvent(

--- a/StayInTouch/StayInTouch/AppIntents/IntentActions.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentActions.swift
@@ -1,0 +1,91 @@
+//
+//  IntentActions.swift
+//  KeepInTouch
+//
+//  Thin facade that intents call. Mirrors the save-path side effects of
+//  `PersonDetailViewModel.logTouch` step-for-step so logging via Siri,
+//  Shortcuts, or the in-app modal produces identical state.
+//
+//  Specifically: TouchEvent save → BulkLogTouchUseCase.applyTouch →
+//  Person save → `.personDidChange` post. The repository layer handles
+//  WidgetRefresher; the `.personDidChange` post triggers
+//  NotificationScheduler.scheduleAll() asynchronously.
+//
+
+import Foundation
+
+struct IntentActions {
+    let dependencies: AppDependencies
+
+    init(dependencies: AppDependencies = IntentContainer.current.dependencies) {
+        self.dependencies = dependencies
+    }
+
+    /// Logs a touch for the given person id. Returns the updated Person
+    /// (post `applyTouch`) for the caller to render a result snippet.
+    /// Throws `IntentError` on failure paths intents should surface.
+    @discardableResult
+    func logTouch(
+        personId: UUID,
+        method: TouchMethod,
+        notes: String?,
+        date: Date,
+        now: Date = Date()
+    ) throws -> Person {
+        guard let person = dependencies.personRepository.fetch(id: personId) else {
+            throw IntentError.personNotFound
+        }
+
+        AnalyticsService.track(
+            "connection.logged",
+            parameters: ["method": method.rawValue, "source": "siri"]
+        )
+
+        let touch = TouchEvent(
+            id: UUID(),
+            personId: personId,
+            at: date,
+            method: method,
+            notes: notes?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            timeOfDay: nil,
+            createdAt: now,
+            modifiedAt: now
+        )
+
+        do {
+            try dependencies.touchEventRepository.save(touch)
+        } catch {
+            AppLogger.logError(
+                error,
+                category: AppLogger.viewModel,
+                context: "IntentActions.logTouch (event save)"
+            )
+            throw IntentError.saveFailed
+        }
+
+        let updated = BulkLogTouchUseCase.applyTouch(to: person, event: touch, now: now)
+
+        do {
+            try dependencies.personRepository.save(updated)
+        } catch {
+            // Event was saved successfully; mirror the UI's behavior of
+            // surfacing the failure but leaving the event in place
+            // (`PersonDetailViewModel.logTouch` does the same).
+            AppLogger.logError(
+                error,
+                category: AppLogger.viewModel,
+                context: "IntentActions.logTouch (person save)"
+            )
+            throw IntentError.saveFailed
+        }
+
+        NotificationCenter.default.post(name: .personDidChange, object: updated.id)
+        return updated
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
@@ -1,0 +1,59 @@
+//
+//  IntentContainer.swift
+//  KeepInTouch
+//
+//  Lazy dependency container for App Intents. Intents run in the main
+//  app process (launched by Siri/Shortcuts if cold), so we reuse the
+//  same Core Data stack and repositories the UI uses.
+//
+//  Resolution is lazy via a function so the container can be swapped
+//  in tests without touching CoreDataStack.shared at import time.
+//
+
+import Foundation
+
+final class IntentContainer {
+    static let shared = IntentContainer()
+
+    private let resolver: () -> AppDependencies
+    private let lock = NSLock()
+    private var cached: AppDependencies?
+
+    private init(resolver: @escaping () -> AppDependencies = { AppDependencies(context: CoreDataStack.shared.viewContext) }) {
+        self.resolver = resolver
+    }
+
+    /// Test seam: replace the shared instance with one backed by mocks.
+    static func install(_ container: IntentContainer) {
+        sharedOverride = container
+    }
+
+    static func reset() {
+        sharedOverride = nil
+    }
+
+    /// Lazily-resolved dependencies. Same instance for the lifetime of the
+    /// container — repositories internally hold the Core Data context and
+    /// can be reused across intent invocations.
+    var dependencies: AppDependencies {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached { return cached }
+        let resolved = resolver()
+        cached = resolved
+        return resolved
+    }
+
+    // MARK: - Test override plumbing
+
+    private static var sharedOverride: IntentContainer?
+
+    static var current: IntentContainer {
+        sharedOverride ?? shared
+    }
+
+    /// Construct a container with a custom resolver — used in tests.
+    static func make(dependencies: AppDependencies) -> IntentContainer {
+        IntentContainer(resolver: { dependencies })
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/IntentError.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentError.swift
@@ -1,0 +1,24 @@
+//
+//  IntentError.swift
+//  KeepInTouch
+//
+
+import AppIntents
+import Foundation
+
+enum IntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
+    case personNotFound
+    case saveFailed
+    case containerUnavailable
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .personNotFound:
+            return "I couldn't find that contact in Keep In Touch."
+        case .saveFailed:
+            return "Couldn't save the touch. Please try again."
+        case .containerUnavailable:
+            return "Open Keep In Touch once, then try this shortcut again."
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/IntentError.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentError.swift
@@ -16,7 +16,7 @@ enum IntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
         case .personNotFound:
             return "I couldn't find that contact in Keep In Touch."
         case .saveFailed:
-            return "Couldn't save the touch. Please try again."
+            return "Couldn't save the connection. Please try again."
         case .containerUnavailable:
             return "Open Keep In Touch once, then try this shortcut again."
         }

--- a/StayInTouch/StayInTouch/AppIntents/IntentError.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentError.swift
@@ -14,7 +14,7 @@ enum IntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
     var localizedStringResource: LocalizedStringResource {
         switch self {
         case .personNotFound:
-            return "I couldn't find that contact in Keep In Touch."
+            return "That contact is no longer in Keep In Touch. Edit this shortcut to pick another."
         case .saveFailed:
             return "Couldn't save the connection. Please try again."
         case .containerUnavailable:

--- a/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
+++ b/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
@@ -9,6 +9,13 @@
 //  iOS allows ~10 phrases per provider; keep this list focused on the
 //  highest-leverage entry points.
 //
+//  Constraint: each AppShortcut phrase supports ONLY ONE parameter slot.
+//  A phrase like "Log a \(\.$method) with \(\.$person)" fails the
+//  AppIntents metadata processor with "Multiple parameters detected in
+//  phrase." If users want both method and person filled, they enter the
+//  multi-parameter form via the Shortcuts editor; the curated phrases
+//  here pick the single most-useful slot (person for Log Touch).
+//
 
 import AppIntents
 

--- a/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
+++ b/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
@@ -24,11 +24,11 @@ struct KeepInTouchShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: LogTouchIntent(),
             phrases: [
-                "Log a touch in \(.applicationName)",
-                "Log touch with \(\.$person) in \(.applicationName)",
-                "Record a touch in \(.applicationName)",
+                "Log a connection in \(.applicationName)",
+                "Log connection with \(\.$person) in \(.applicationName)",
+                "Record a connection in \(.applicationName)",
             ],
-            shortTitle: "Log Touch",
+            shortTitle: "Log Connection",
             systemImageName: "checkmark.circle.fill"
         )
 

--- a/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
+++ b/StayInTouch/StayInTouch/AppIntents/KeepInTouchShortcuts.swift
@@ -1,0 +1,59 @@
+//
+//  KeepInTouchShortcuts.swift
+//  KeepInTouch
+//
+//  AppShortcutsProvider — curated phrases that make our intents
+//  discoverable in Spotlight, the Action Button, and Siri without the
+//  user having to wire them up in the Shortcuts app first.
+//
+//  iOS allows ~10 phrases per provider; keep this list focused on the
+//  highest-leverage entry points.
+//
+
+import AppIntents
+
+struct KeepInTouchShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: LogTouchIntent(),
+            phrases: [
+                "Log a touch in \(.applicationName)",
+                "Log touch with \(\.$person) in \(.applicationName)",
+                "Record a touch in \(.applicationName)",
+            ],
+            shortTitle: "Log Touch",
+            systemImageName: "checkmark.circle.fill"
+        )
+
+        AppShortcut(
+            intent: GetOverdueContactsIntent(),
+            phrases: [
+                "Who's overdue in \(.applicationName)",
+                "Show overdue contacts in \(.applicationName)",
+                "Who needs attention in \(.applicationName)",
+            ],
+            shortTitle: "Overdue Contacts",
+            systemImageName: "exclamationmark.circle.fill"
+        )
+
+        AppShortcut(
+            intent: GetDueSoonContactsIntent(),
+            phrases: [
+                "Who's due soon in \(.applicationName)",
+                "Show due-soon contacts in \(.applicationName)",
+            ],
+            shortTitle: "Due-Soon Contacts",
+            systemImageName: "clock.fill"
+        )
+
+        AppShortcut(
+            intent: OpenPersonIntent(),
+            phrases: [
+                "Open \(\.$person) in \(.applicationName)",
+                "Show \(\.$person) in \(.applicationName)",
+            ],
+            shortTitle: "Open Contact",
+            systemImageName: "person.crop.circle"
+        )
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
@@ -11,10 +11,10 @@ import AppIntents
 import Foundation
 
 struct LogTouchIntent: AppIntent {
-    static var title: LocalizedStringResource { "Log Touch" }
+    static var title: LocalizedStringResource { "Log Connection" }
     static var description: IntentDescription {
         IntentDescription(
-            "Log a touch with a contact — the kind of touch (call, text, in person, etc.), optional notes, and the date.",
+            "Log a connection with a contact — the method (call, text, in person, etc.), optional notes, and the date.",
             categoryName: "Logging"
         )
     }
@@ -29,18 +29,18 @@ struct LogTouchIntent: AppIntent {
 
     @Parameter(
         title: "Notes",
-        description: "Optional notes about this touch."
+        description: "Optional notes about this connection."
     )
     var notes: String?
 
     @Parameter(
         title: "Date",
-        description: "When the touch happened. Defaults to now."
+        description: "When the connection happened. Defaults to now."
     )
     var date: Date?
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Log a \(\.$method) with \(\.$person)") {
+        Summary("Log a \(\.$method) connection with \(\.$person)") {
             \.$date
             \.$notes
         }

--- a/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
@@ -56,24 +56,12 @@ struct LogTouchIntent: AppIntent {
                 notes: notes,
                 date: when
             )
-            let methodLabel = methodVerb(for: method)
-            let dialog = IntentDialog("Logged a \(methodLabel) with \(updated.displayName).")
+            let dialog = IntentDialog("Logged a \(method.verb) with \(updated.displayName).")
             return .result(dialog: dialog)
         } catch let error as IntentError {
             throw error
         } catch {
             throw IntentError.saveFailed
-        }
-    }
-
-    private func methodVerb(for method: TouchMethod) -> String {
-        switch method {
-        case .text: return "text"
-        case .call: return "call"
-        case .irl: return "visit"
-        case .email: return "email"
-        case .facetime: return "FaceTime"
-        case .other: return "touch"
         }
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/LogTouchIntent.swift
@@ -1,0 +1,79 @@
+//
+//  LogTouchIntent.swift
+//  KeepInTouch
+//
+//  Logs a touch event for a contact. Headline v1 intent — wired into
+//  AppShortcutsProvider phrases for Siri, Spotlight, and the Action
+//  Button.
+//
+
+import AppIntents
+import Foundation
+
+struct LogTouchIntent: AppIntent {
+    static var title: LocalizedStringResource { "Log Touch" }
+    static var description: IntentDescription {
+        IntentDescription(
+            "Log a touch with a contact — the kind of touch (call, text, in person, etc.), optional notes, and the date.",
+            categoryName: "Logging"
+        )
+    }
+
+    static var openAppWhenRun: Bool { false }
+
+    @Parameter(title: "Contact", description: "Who you connected with.")
+    var person: PersonAppEntity
+
+    @Parameter(title: "Method", description: "How you connected.", default: .text)
+    var method: TouchMethod
+
+    @Parameter(
+        title: "Notes",
+        description: "Optional notes about this touch."
+    )
+    var notes: String?
+
+    @Parameter(
+        title: "Date",
+        description: "When the touch happened. Defaults to now."
+    )
+    var date: Date?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log a \(\.$method) with \(\.$person)") {
+            \.$date
+            \.$notes
+        }
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let when = date ?? Date()
+        do {
+            let updated = try IntentActions().logTouch(
+                personId: person.id,
+                method: method,
+                notes: notes,
+                date: when
+            )
+            let methodLabel = methodVerb(for: method)
+            let dialog = IntentDialog("Logged a \(methodLabel) with \(updated.displayName).")
+            return .result(dialog: dialog)
+        } catch let error as IntentError {
+            throw error
+        } catch {
+            throw IntentError.saveFailed
+        }
+    }
+
+    private func methodVerb(for method: TouchMethod) -> String {
+        switch method {
+        case .text: return "text"
+        case .call: return "call"
+        case .irl: return "visit"
+        case .email: return "email"
+        case .facetime: return "FaceTime"
+        case .other: return "touch"
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
@@ -33,14 +33,13 @@ struct OpenPersonIntent: AppIntent {
         let repository = IntentContainer.current.dependencies.personRepository
         guard repository.fetch(id: person.id) != nil else {
             // Stale id (saved shortcut points at a now-deleted contact).
-            // Re-prompt the user to pick a contact — the picker reads
-            // more naturally than a "this contact was deleted" error,
-            // and lets the user complete the action by choosing someone
-            // else. The framework re-performs `perform()` with the new
-            // value once a choice is made.
-            throw $person.needsValueError(
-                IntentDialog("That contact is no longer in Keep In Touch. Pick another to open.")
-            )
+            // Surface a graceful error dialog rather than re-prompting
+            // via `$person.needsValueError`. The re-prompt path shows a
+            // bare "Contact" picker with no indication why — confusing
+            // UX. A clear "no longer in Keep In Touch" error tells the
+            // user what happened and lets them edit the shortcut to
+            // point at someone else.
+            throw IntentError.personNotFound
         }
         DeepLinkRouter.shared.pending = .person(person.id)
         return .result()

--- a/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
@@ -32,11 +32,15 @@ struct OpenPersonIntent: AppIntent {
     func perform() async throws -> some IntentResult {
         let repository = IntentContainer.current.dependencies.personRepository
         guard repository.fetch(id: person.id) != nil else {
-            // Entity is stale (contact deleted since the shortcut was set
-            // up). Route to Home so the app still surfaces something
-            // useful and let the user re-pick.
-            DeepLinkRouter.shared.pending = .home
-            throw IntentError.personNotFound
+            // Stale id (saved shortcut points at a now-deleted contact).
+            // Re-prompt the user to pick a contact — the picker reads
+            // more naturally than a "this contact was deleted" error,
+            // and lets the user complete the action by choosing someone
+            // else. The framework re-performs `perform()` with the new
+            // value once a choice is made.
+            throw $person.needsValueError(
+                IntentDialog("That contact is no longer in Keep In Touch. Pick another to open.")
+            )
         }
         DeepLinkRouter.shared.pending = .person(person.id)
         return .result()

--- a/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
+++ b/StayInTouch/StayInTouch/AppIntents/OpenPersonIntent.swift
@@ -1,0 +1,44 @@
+//
+//  OpenPersonIntent.swift
+//  KeepInTouch
+//
+//  Deep-links into PersonDetailView for the chosen contact. Used as the
+//  "open in app" step at the end of Shortcuts chains, and as a standalone
+//  Siri command ("Open Mom in Keep In Touch").
+//
+
+import AppIntents
+import Foundation
+
+struct OpenPersonIntent: AppIntent {
+    static var title: LocalizedStringResource { "Open Contact" }
+    static var description: IntentDescription {
+        IntentDescription(
+            "Opens a contact's detail view in Keep In Touch.",
+            categoryName: "Navigation"
+        )
+    }
+
+    static var openAppWhenRun: Bool { true }
+
+    @Parameter(title: "Contact", description: "Who to open.")
+    var person: PersonAppEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open \(\.$person)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let repository = IntentContainer.current.dependencies.personRepository
+        guard repository.fetch(id: person.id) != nil else {
+            // Entity is stale (contact deleted since the shortcut was set
+            // up). Route to Home so the app still surfaces something
+            // useful and let the user re-pick.
+            DeepLinkRouter.shared.pending = .home
+            throw IntentError.personNotFound
+        }
+        DeepLinkRouter.shared.pending = .person(person.id)
+        return .result()
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
+++ b/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
@@ -63,15 +63,32 @@ struct PersonAppEntity: AppEntity, Identifiable {
 }
 
 struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
-    // Stale ids (snapshots in a saved Shortcut that no longer resolve)
-    // are silently dropped — callers (LogTouchIntent, OpenPersonIntent)
-    // each guard with their own `repository.fetch(id:)` and throw a
-    // user-visible `IntentError.personNotFound`. Returning a strict
-    // subset here matches Apple's documented EntityQuery contract.
+    // Stale ids (saved-shortcut snapshots that no longer resolve) get a
+    // **tombstone** entity — same id, displayName flagging the contact
+    // is gone. We can't return [] (Apple's documented "omit") because
+    // the framework reacts to a missing required-parameter value by
+    // showing the standard contact picker with no explanation of why.
+    // QA on PR #305 confirmed that picker behavior is confusing.
+    //
+    // With a tombstone present, the framework proceeds to `perform()`,
+    // where each intent's `repository.fetch(id: person.id) == nil`
+    // guard fires and surfaces a clear "no longer in Keep In Touch"
+    // error dialog. Bonus: the Shortcut editor row also shows the
+    // tombstone label, so users can spot the staleness without running.
+    static let staleDisplayName = "(no longer in Keep In Touch)"
+
     func entities(for identifiers: [PersonAppEntity.ID]) async throws -> [PersonAppEntity] {
         let repository = IntentContainer.current.dependencies.personRepository
-        return identifiers.compactMap { id in
-            repository.fetch(id: id).map(PersonAppEntity.init(person:))
+        return identifiers.map { id -> PersonAppEntity in
+            if let person = repository.fetch(id: id) {
+                return PersonAppEntity(person: person)
+            }
+            return PersonAppEntity(
+                id: id,
+                displayName: Self.staleDisplayName,
+                nickname: nil,
+                lastTouchAt: nil
+            )
         }
     }
 

--- a/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
+++ b/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
@@ -62,6 +62,27 @@ struct PersonAppEntity: AppEntity, Identifiable {
     }
 }
 
+/// Builds the dialog string shown by query intents (GetOverdue, GetDueSoon).
+/// One place to keep "Nothing's overdue / One contact is overdue: X / N
+/// contacts are overdue" phrasing consistent.
+enum PersonListDialog {
+    static func make(
+        for entities: [PersonAppEntity],
+        emptyMessage: String,
+        singularSuffix: String,
+        pluralPredicate: String
+    ) -> IntentDialog {
+        switch entities.count {
+        case 0:
+            return IntentDialog(stringLiteral: emptyMessage)
+        case 1:
+            return IntentDialog("One contact \(singularSuffix): \(entities[0].displayName).")
+        default:
+            return IntentDialog("\(entities.count) contacts \(pluralPredicate).")
+        }
+    }
+}
+
 struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
     // Stale ids (snapshots in a saved Shortcut that no longer resolve)
     // are silently dropped — callers (LogTouchIntent, OpenPersonIntent)
@@ -83,11 +104,18 @@ struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
         return matches.map(PersonAppEntity.init(person:))
     }
 
+    /// Siri renders the top suggestions inline in its parameter picker, so
+    /// cap the response at a small number of most-recently-touched contacts.
+    /// Sorting all tracked people (potentially hundreds) just to discard most
+    /// of them is wasted work on a Siri-cold-launch path.
+    private static let suggestedEntitiesLimit = 12
+
     func suggestedEntities() async throws -> [PersonAppEntity] {
         let repository = IntentContainer.current.dependencies.personRepository
         let tracked = repository.fetchTracked(includePaused: true)
-        return tracked
+        let topRecent = tracked
             .sorted { ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast) }
-            .map(PersonAppEntity.init(person:))
+            .prefix(Self.suggestedEntitiesLimit)
+        return topRecent.map(PersonAppEntity.init(person:))
     }
 }

--- a/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
+++ b/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
@@ -1,0 +1,86 @@
+//
+//  PersonAppEntity.swift
+//  KeepInTouch
+//
+//  AppEntity + EntityQuery that bridges Person from the domain layer
+//  into App Intents / Shortcuts / Siri.
+//
+//  Surface area is intentionally minimal — only fields users can act on
+//  inside a Shortcut. Phone/email are deliberately omitted to keep them
+//  out of any donation graph.
+//
+
+import AppIntents
+import Foundation
+
+struct PersonAppEntity: AppEntity, Identifiable {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Contact")
+    }
+
+    static var defaultQuery = PersonAppEntityQuery()
+
+    let id: UUID
+    let displayName: String
+    let nickname: String?
+    let lastTouchAt: Date?
+
+    var displayRepresentation: DisplayRepresentation {
+        let subtitle: LocalizedStringResource?
+        if let lastTouchAt {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .full
+            let relative = formatter.localizedString(for: lastTouchAt, relativeTo: Date())
+            subtitle = "Last touch \(relative)"
+        } else {
+            subtitle = "No touches yet"
+        }
+        return DisplayRepresentation(
+            title: "\(displayName)",
+            subtitle: subtitle
+        )
+    }
+
+    init(id: UUID, displayName: String, nickname: String?, lastTouchAt: Date?) {
+        self.id = id
+        self.displayName = displayName
+        self.nickname = nickname
+        self.lastTouchAt = lastTouchAt
+    }
+
+    init(person: Person) {
+        self.init(
+            id: person.id,
+            displayName: person.displayName,
+            nickname: person.displayNickname,
+            lastTouchAt: person.lastTouchAt
+        )
+    }
+}
+
+struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
+    func entities(for identifiers: [PersonAppEntity.ID]) async throws -> [PersonAppEntity] {
+        let repository = IntentContainer.current.dependencies.personRepository
+        let set = Set(identifiers)
+        return identifiers.compactMap { id -> PersonAppEntity? in
+            guard set.contains(id), let person = repository.fetch(id: id) else { return nil }
+            return PersonAppEntity(person: person)
+        }
+    }
+
+    func entities(matching string: String) async throws -> [PersonAppEntity] {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let repository = IntentContainer.current.dependencies.personRepository
+        let matches = repository.searchByName(trimmed, includePaused: true)
+        return matches.map(PersonAppEntity.init(person:))
+    }
+
+    func suggestedEntities() async throws -> [PersonAppEntity] {
+        let repository = IntentContainer.current.dependencies.personRepository
+        let tracked = repository.fetchTracked(includePaused: true)
+        return tracked
+            .sorted { ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast) }
+            .map(PersonAppEntity.init(person:))
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
+++ b/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
@@ -25,12 +25,16 @@ struct PersonAppEntity: AppEntity, Identifiable {
     let nickname: String?
     let lastTouchAt: Date?
 
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter
+    }()
+
     var displayRepresentation: DisplayRepresentation {
         let subtitle: LocalizedStringResource?
         if let lastTouchAt {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .full
-            let relative = formatter.localizedString(for: lastTouchAt, relativeTo: Date())
+            let relative = Self.relativeFormatter.localizedString(for: lastTouchAt, relativeTo: Date())
             subtitle = "Last touch \(relative)"
         } else {
             subtitle = "No touches yet"
@@ -59,12 +63,15 @@ struct PersonAppEntity: AppEntity, Identifiable {
 }
 
 struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
+    // Stale ids (snapshots in a saved Shortcut that no longer resolve)
+    // are silently dropped — callers (LogTouchIntent, OpenPersonIntent)
+    // each guard with their own `repository.fetch(id:)` and throw a
+    // user-visible `IntentError.personNotFound`. Returning a strict
+    // subset here matches Apple's documented EntityQuery contract.
     func entities(for identifiers: [PersonAppEntity.ID]) async throws -> [PersonAppEntity] {
         let repository = IntentContainer.current.dependencies.personRepository
-        let set = Set(identifiers)
-        return identifiers.compactMap { id -> PersonAppEntity? in
-            guard set.contains(id), let person = repository.fetch(id: id) else { return nil }
-            return PersonAppEntity(person: person)
+        return identifiers.compactMap { id in
+            repository.fetch(id: id).map(PersonAppEntity.init(person:))
         }
     }
 

--- a/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
+++ b/StayInTouch/StayInTouch/AppIntents/PersonAppEntity.swift
@@ -62,27 +62,6 @@ struct PersonAppEntity: AppEntity, Identifiable {
     }
 }
 
-/// Builds the dialog string shown by query intents (GetOverdue, GetDueSoon).
-/// One place to keep "Nothing's overdue / One contact is overdue: X / N
-/// contacts are overdue" phrasing consistent.
-enum PersonListDialog {
-    static func make(
-        for entities: [PersonAppEntity],
-        emptyMessage: String,
-        singularSuffix: String,
-        pluralPredicate: String
-    ) -> IntentDialog {
-        switch entities.count {
-        case 0:
-            return IntentDialog(stringLiteral: emptyMessage)
-        case 1:
-            return IntentDialog("One contact \(singularSuffix): \(entities[0].displayName).")
-        default:
-            return IntentDialog("\(entities.count) contacts \(pluralPredicate).")
-        }
-    }
-}
-
 struct PersonAppEntityQuery: EntityQuery, EntityStringQuery {
     // Stale ids (snapshots in a saved Shortcut that no longer resolve)
     // are silently dropped — callers (LogTouchIntent, OpenPersonIntent)

--- a/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
+++ b/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
@@ -10,7 +10,7 @@ import AppIntents
 
 extension TouchMethod: AppEnum {
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
-        TypeDisplayRepresentation(name: "Touch Method")
+        TypeDisplayRepresentation(name: "Connection Method")
     }
 
     static var caseDisplayRepresentations: [TouchMethod: DisplayRepresentation] {

--- a/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
+++ b/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
@@ -1,0 +1,26 @@
+//
+//  TouchMethodAppEnum.swift
+//  KeepInTouch
+//
+//  AppEnum conformance for the existing TouchMethod value type so it
+//  appears as a typed picker in the Shortcuts editor and Siri.
+//
+
+import AppIntents
+
+extension TouchMethod: AppEnum {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Touch Method")
+    }
+
+    static var caseDisplayRepresentations: [TouchMethod: DisplayRepresentation] {
+        [
+            .text: DisplayRepresentation(title: "Text"),
+            .call: DisplayRepresentation(title: "Call"),
+            .irl: DisplayRepresentation(title: "In Person"),
+            .email: DisplayRepresentation(title: "Email"),
+            .facetime: DisplayRepresentation(title: "FaceTime"),
+            .other: DisplayRepresentation(title: "Other"),
+        ]
+    }
+}

--- a/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
+++ b/StayInTouch/StayInTouch/AppIntents/TouchMethodAppEnum.swift
@@ -23,4 +23,18 @@ extension TouchMethod: AppEnum {
             .other: DisplayRepresentation(title: "Other"),
         ]
     }
+
+    /// Verb form used in user-facing dialog ("Logged a call with Mom").
+    /// Lives next to the AppEnum case mapping so any Siri / Shortcuts /
+    /// dialog phrasing has a single source of truth.
+    var verb: String {
+        switch self {
+        case .text: return "text"
+        case .call: return "call"
+        case .irl: return "visit"
+        case .email: return "email"
+        case .facetime: return "FaceTime"
+        case .other: return "touch"
+        }
+    }
 }

--- a/StayInTouch/StayInTouchTests/AppIntents/GetDueSoonContactsIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/GetDueSoonContactsIntentTests.swift
@@ -1,0 +1,39 @@
+//
+//  GetDueSoonContactsIntentTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class GetDueSoonContactsIntentTests: XCTestCase {
+    private var harness: IntentTestHarness!
+
+    override func tearDown() {
+        harness?.tearDown()
+        harness = nil
+        super.tearDown()
+    }
+
+    func testPerformDoesNotThrowWithEmptyState() async throws {
+        harness = IntentTestHarness()
+        _ = try await GetDueSoonContactsIntent().perform()
+    }
+
+    func testPerformDoesNotThrowWithPopulatedState() async throws {
+        let cadenceId = UUID()
+        let cadence = TestFactory.makeCadence(id: cadenceId, frequencyDays: 7)
+        // Person whose effective due date is within `warningDays` of today.
+        let person = TestFactory.makePerson(
+            name: "Charlie",
+            cadenceId: cadenceId,
+            lastTouchAt: Calendar.current.date(byAdding: .day, value: -6, to: Date())
+        )
+        harness = IntentTestHarness(
+            people: [person],
+            cadences: [cadence]
+        )
+        _ = try await GetDueSoonContactsIntent().perform()
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/GetDueSoonContactsIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/GetDueSoonContactsIntentTests.swift
@@ -2,6 +2,11 @@
 //  GetDueSoonContactsIntentTests.swift
 //  KeepInTouchTests
 //
+//  Intent return values are wrapped in opaque IntentResult containers
+//  that can't be unwrapped from outside the App Intents framework, so
+//  these tests verify the side effects (no throw, classification path
+//  exercised) rather than the result payload.
+//
 
 import XCTest
 @testable import StayInTouch

--- a/StayInTouch/StayInTouchTests/AppIntents/GetOverdueContactsIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/GetOverdueContactsIntentTests.swift
@@ -1,0 +1,45 @@
+//
+//  GetOverdueContactsIntentTests.swift
+//  KeepInTouchTests
+//
+//  Intent return values are wrapped in opaque IntentResult containers
+//  that can't be unwrapped from outside the App Intents framework, so
+//  these tests verify the side effects (repository call, no throw)
+//  rather than the result payload.
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class GetOverdueContactsIntentTests: XCTestCase {
+    private var harness: IntentTestHarness!
+
+    override func tearDown() {
+        harness?.tearDown()
+        harness = nil
+        super.tearDown()
+    }
+
+    func testPerformCallsFetchOverdueOnRepository() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        let bob = TestFactory.makePerson(name: "Bob")
+        harness = IntentTestHarness(people: [alice, bob], overdue: [alice, bob])
+
+        _ = try await GetOverdueContactsIntent().perform()
+        XCTAssertEqual(harness.personRepo.fetchOverdueCallCount, 1)
+    }
+
+    func testPerformDoesNotThrowWhenNoneOverdue() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        harness = IntentTestHarness(people: [alice], overdue: [])
+        _ = try await GetOverdueContactsIntent().perform()
+        XCTAssertEqual(harness.personRepo.fetchOverdueCallCount, 1)
+    }
+
+    func testPerformWithNoTrackedPeople() async throws {
+        harness = IntentTestHarness(people: [], overdue: [])
+        _ = try await GetOverdueContactsIntent().perform()
+        XCTAssertEqual(harness.personRepo.fetchOverdueCallCount, 1)
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/IntentActionsTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/IntentActionsTests.swift
@@ -1,0 +1,72 @@
+//
+//  IntentActionsTests.swift
+//  KeepInTouchTests
+//
+//  Tests the IntentActions facade directly so we can verify the analytics
+//  side effects that LogTouchIntent triggers via the default-arg facade
+//  but can't reach into from the @Parameter-driven Intent type.
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class IntentActionsTests: XCTestCase {
+    private var harness: IntentTestHarness!
+
+    override func tearDown() {
+        harness?.tearDown()
+        harness = nil
+        super.tearDown()
+    }
+
+    func testLogTouchTracksAnalyticsWithSiriSource() throws {
+        let person = TestFactory.makePerson(name: "Mom")
+        harness = IntentTestHarness(people: [person])
+
+        var trackedSignals: [(String, [String: String])] = []
+        let actions = IntentActions(
+            dependencies: harness.container.dependencies,
+            trackAnalytics: { signal, params in
+                trackedSignals.append((signal, params))
+            }
+        )
+
+        _ = try actions.logTouch(
+            personId: person.id,
+            method: .call,
+            notes: nil,
+            date: Date()
+        )
+
+        XCTAssertEqual(trackedSignals.count, 1)
+        XCTAssertEqual(trackedSignals.first?.0, "connection.logged")
+        XCTAssertEqual(trackedSignals.first?.1["source"], "siri")
+        XCTAssertEqual(trackedSignals.first?.1["method"], "Call")
+    }
+
+    func testLogTouchDoesNotTrackOnPersonNotFound() {
+        harness = IntentTestHarness(people: [])
+
+        var trackedSignals: [(String, [String: String])] = []
+        let actions = IntentActions(
+            dependencies: harness.container.dependencies,
+            trackAnalytics: { signal, params in
+                trackedSignals.append((signal, params))
+            }
+        )
+
+        do {
+            _ = try actions.logTouch(
+                personId: UUID(),
+                method: .text,
+                notes: nil,
+                date: Date()
+            )
+            XCTFail("Expected throw")
+        } catch {
+            // Expected
+        }
+        XCTAssertEqual(trackedSignals.count, 0, "Analytics should not fire when person lookup fails")
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/IntentContainerTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/IntentContainerTests.swift
@@ -1,0 +1,61 @@
+//
+//  IntentContainerTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class IntentContainerTests: XCTestCase {
+    override func tearDown() {
+        IntentContainer.reset()
+        super.tearDown()
+    }
+
+    func testInstallOverridesCurrent() {
+        let personRepo = MockPersonRepository()
+        let deps = AppDependencies(
+            personRepository: personRepo,
+            cadenceRepository: MockCadenceRepository(),
+            groupRepository: MockGroupRepository(),
+            touchEventRepository: MockTouchEventRepository(),
+            settingsRepository: MockSettingsRepository()
+        )
+        let container = IntentContainer.make(dependencies: deps)
+        IntentContainer.install(container)
+
+        XCTAssertTrue(IntentContainer.current.dependencies.personRepository as AnyObject === personRepo as AnyObject)
+    }
+
+    func testResetReturnsToShared() {
+        let deps = AppDependencies(
+            personRepository: MockPersonRepository(),
+            cadenceRepository: MockCadenceRepository(),
+            groupRepository: MockGroupRepository(),
+            touchEventRepository: MockTouchEventRepository(),
+            settingsRepository: MockSettingsRepository()
+        )
+        IntentContainer.install(IntentContainer.make(dependencies: deps))
+        XCTAssertNotNil(IntentContainer.current)
+
+        IntentContainer.reset()
+        // After reset, current === shared (the default).
+        XCTAssertTrue(IntentContainer.current === IntentContainer.shared)
+    }
+
+    func testDependenciesAreCachedAfterFirstAccess() {
+        let deps = AppDependencies(
+            personRepository: MockPersonRepository(),
+            cadenceRepository: MockCadenceRepository(),
+            groupRepository: MockGroupRepository(),
+            touchEventRepository: MockTouchEventRepository(),
+            settingsRepository: MockSettingsRepository()
+        )
+        let container = IntentContainer.make(dependencies: deps)
+        let first = container.dependencies
+        let second = container.dependencies
+        // Same `personRepository` instance pointer on repeated access.
+        XCTAssertTrue(first.personRepository as AnyObject === second.personRepository as AnyObject)
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
@@ -1,0 +1,110 @@
+//
+//  IntentTestHarness.swift
+//  KeepInTouchTests
+//
+//  Builds an IntentContainer wired to mock repositories so the AppIntent
+//  perform() paths can be exercised in unit tests without spinning up
+//  Core Data.
+//
+
+import Foundation
+@testable import StayInTouch
+
+/// PersonRepository mock that lets tests stage `fetchOverdue` results
+/// and matches nicknames in `searchByName`. The shared `MockPersonRepository`
+/// returns [] for fetchOverdue and ignores nicknames — both insufficient
+/// for intent coverage.
+final class IntentTestPersonRepository: PersonRepository {
+    var people: [Person] = []
+    var overdue: [Person] = []
+    var savedPersons: [Person] = []
+    var deletedIds: [UUID] = []
+    private(set) var fetchOverdueCallCount = 0
+    private(set) var searchByNameCalls: [String] = []
+
+    func fetch(id: UUID) -> Person? { people.first { $0.id == id } }
+    func fetchAll() -> [Person] { people }
+    func fetchTracked(includePaused: Bool) -> [Person] {
+        people.filter { $0.isTracked && (includePaused || !$0.isPaused) }
+    }
+    func fetchByCadence(id: UUID, includePaused: Bool) -> [Person] {
+        fetchTracked(includePaused: includePaused).filter { $0.cadenceId == id }
+    }
+    func fetchByGroup(id: UUID, includePaused: Bool) -> [Person] {
+        fetchTracked(includePaused: includePaused).filter { $0.groupIds.contains(id) }
+    }
+    func searchByName(_ query: String, includePaused: Bool) -> [Person] {
+        searchByNameCalls.append(query)
+        return fetchTracked(includePaused: includePaused).filter {
+            $0.displayName.localizedCaseInsensitiveContains(query)
+                || ($0.nickname?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+    }
+    func fetchOverdue(referenceDate: Date) -> [Person] {
+        fetchOverdueCallCount += 1
+        return overdue
+    }
+    func save(_ person: Person) throws {
+        savedPersons.append(person)
+        if let idx = people.firstIndex(where: { $0.id == person.id }) {
+            people[idx] = person
+        } else {
+            people.append(person)
+        }
+    }
+    func batchSave(_ persons: [Person]) throws {
+        for p in persons { try save(p) }
+    }
+    func delete(id: UUID) throws {
+        deletedIds.append(id)
+        people.removeAll { $0.id == id }
+    }
+}
+
+@MainActor
+final class IntentTestHarness {
+    let personRepo: IntentTestPersonRepository
+    let cadenceRepo: MockCadenceRepository
+    let groupRepo: MockGroupRepository
+    let touchRepo: MockTouchEventRepository
+    let settingsRepo: MockSettingsRepository
+    let container: IntentContainer
+
+    init(
+        people: [Person] = [],
+        overdue: [Person] = [],
+        cadences: [Cadence] = [],
+        groups: [Group] = [],
+        touchEvents: [TouchEvent] = []
+    ) {
+        let personRepo = IntentTestPersonRepository()
+        personRepo.people = people
+        personRepo.overdue = overdue
+        let cadenceRepo = MockCadenceRepository()
+        cadenceRepo.cadences = cadences
+        let groupRepo = MockGroupRepository()
+        groupRepo.groups = groups
+        let touchRepo = MockTouchEventRepository()
+        touchRepo.events = touchEvents
+        let settingsRepo = MockSettingsRepository()
+
+        let deps = AppDependencies(
+            personRepository: personRepo,
+            cadenceRepository: cadenceRepo,
+            groupRepository: groupRepo,
+            touchEventRepository: touchRepo,
+            settingsRepository: settingsRepo
+        )
+        self.personRepo = personRepo
+        self.cadenceRepo = cadenceRepo
+        self.groupRepo = groupRepo
+        self.touchRepo = touchRepo
+        self.settingsRepo = settingsRepo
+        self.container = IntentContainer.make(dependencies: deps)
+        IntentContainer.install(self.container)
+    }
+
+    func tearDown() {
+        IntentContainer.reset()
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/LogTouchIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/LogTouchIntentTests.swift
@@ -1,0 +1,125 @@
+//
+//  LogTouchIntentTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class LogTouchIntentTests: XCTestCase {
+    private var harness: IntentTestHarness!
+    private var person: Person!
+
+    override func setUp() {
+        super.setUp()
+        person = TestFactory.makePerson(name: "Mom")
+        harness = IntentTestHarness(people: [person])
+    }
+
+    override func tearDown() {
+        harness.tearDown()
+        harness = nil
+        super.tearDown()
+    }
+
+    func testPerformSavesTouchEventAndUpdatesPerson() async throws {
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(person: person)
+        intent.method = .call
+        intent.notes = "Quick chat"
+        intent.date = nil
+
+        _ = try await intent.perform()
+
+        XCTAssertEqual(harness.touchRepo.savedEvents.count, 1)
+        XCTAssertEqual(harness.touchRepo.savedEvents.first?.method, .call)
+        XCTAssertEqual(harness.touchRepo.savedEvents.first?.notes, "Quick chat")
+        XCTAssertEqual(harness.touchRepo.savedEvents.first?.personId, person.id)
+
+        XCTAssertEqual(harness.personRepo.savedPersons.count, 1)
+        XCTAssertEqual(harness.personRepo.savedPersons.first?.lastTouchMethod, .call)
+        XCTAssertEqual(harness.personRepo.savedPersons.first?.lastTouchNotes, "Quick chat")
+    }
+
+    func testPerformWithMissingPersonThrowsPersonNotFound() async {
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(
+            id: UUID(),
+            displayName: "Ghost",
+            nickname: nil,
+            lastTouchAt: nil
+        )
+        intent.method = .text
+        do {
+            _ = try await intent.perform()
+            XCTFail("Expected IntentError.personNotFound")
+        } catch let error as IntentError {
+            switch error {
+            case .personNotFound: break
+            default: XCTFail("Wrong IntentError: \(error)")
+            }
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+
+    func testPerformClearsSnoozeOnNewerTouch() async throws {
+        let snoozed = TestFactory.makePerson(
+            name: "Dad",
+            snoozedUntil: Date().addingTimeInterval(86_400)
+        )
+        harness.tearDown()
+        harness = IntentTestHarness(people: [snoozed])
+
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(person: snoozed)
+        intent.method = .irl
+        intent.notes = nil
+        intent.date = nil
+
+        _ = try await intent.perform()
+
+        XCTAssertNil(harness.personRepo.savedPersons.last?.snoozedUntil)
+    }
+
+    func testPerformPostsPersonDidChangeNotification() async throws {
+        let expectation = XCTNSNotificationExpectation(name: .personDidChange)
+        expectation.expectedFulfillmentCount = 1
+
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(person: person)
+        intent.method = .text
+        intent.notes = nil
+        intent.date = nil
+
+        _ = try await intent.perform()
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testPerformTrimsWhitespaceFromNotes() async throws {
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(person: person)
+        intent.method = .text
+        intent.notes = "   "
+        intent.date = nil
+
+        _ = try await intent.perform()
+
+        XCTAssertNil(harness.touchRepo.savedEvents.first?.notes)
+    }
+
+    func testPerformWithExplicitDateUsesIt() async throws {
+        let past = Date().addingTimeInterval(-86_400 * 3)
+        let intent = LogTouchIntent()
+        intent.person = PersonAppEntity(person: person)
+        intent.method = .text
+        intent.notes = nil
+        intent.date = past
+
+        _ = try await intent.perform()
+
+        XCTAssertEqual(harness.touchRepo.savedEvents.first?.at, past)
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
@@ -33,7 +33,7 @@ final class OpenPersonIntentTests: XCTestCase {
         XCTAssertEqual(DeepLinkRouter.shared.pending, .person(person.id))
     }
 
-    func testPerformWithStaleEntityRoutesToHomeAndThrows() async {
+    func testPerformWithStaleEntityRePromptsViaNeedsValueError() async {
         harness = IntentTestHarness(people: [])
 
         let intent = OpenPersonIntent()
@@ -46,14 +46,13 @@ final class OpenPersonIntentTests: XCTestCase {
         do {
             _ = try await intent.perform()
             XCTFail("Expected throw")
-        } catch let error as IntentError {
-            if case .personNotFound = error {
-                XCTAssertEqual(DeepLinkRouter.shared.pending, .home)
-            } else {
-                XCTFail("Wrong IntentError: \(error)")
-            }
         } catch {
-            XCTFail("Wrong error: \(error)")
+            // `$person.needsValueError(...)` returns an opaque
+            // AppIntentError whose runtime type is internal. We can't
+            // pattern-match on it; verifying that *some* error is
+            // thrown (and that pending was NOT set to the stale id)
+            // is enough to confirm the re-prompt path.
+            XCTAssertNotEqual(DeepLinkRouter.shared.pending, .person(intent.person.id))
         }
     }
 }

--- a/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
@@ -1,0 +1,59 @@
+//
+//  OpenPersonIntentTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class OpenPersonIntentTests: XCTestCase {
+    private var harness: IntentTestHarness!
+
+    override func setUp() {
+        super.setUp()
+        DeepLinkRouter.shared.pending = nil
+    }
+
+    override func tearDown() {
+        harness?.tearDown()
+        harness = nil
+        DeepLinkRouter.shared.pending = nil
+        super.tearDown()
+    }
+
+    func testPerformSetsRouterPendingToPerson() async throws {
+        let person = TestFactory.makePerson(name: "Mom")
+        harness = IntentTestHarness(people: [person])
+
+        let intent = OpenPersonIntent()
+        intent.person = PersonAppEntity(person: person)
+        _ = try await intent.perform()
+
+        XCTAssertEqual(DeepLinkRouter.shared.pending, .person(person.id))
+    }
+
+    func testPerformWithStaleEntityRoutesToHomeAndThrows() async {
+        harness = IntentTestHarness(people: [])
+
+        let intent = OpenPersonIntent()
+        intent.person = PersonAppEntity(
+            id: UUID(),
+            displayName: "Ghost",
+            nickname: nil,
+            lastTouchAt: nil
+        )
+        do {
+            _ = try await intent.perform()
+            XCTFail("Expected throw")
+        } catch let error as IntentError {
+            if case .personNotFound = error {
+                XCTAssertEqual(DeepLinkRouter.shared.pending, .home)
+            } else {
+                XCTFail("Wrong IntentError: \(error)")
+            }
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/OpenPersonIntentTests.swift
@@ -33,7 +33,7 @@ final class OpenPersonIntentTests: XCTestCase {
         XCTAssertEqual(DeepLinkRouter.shared.pending, .person(person.id))
     }
 
-    func testPerformWithStaleEntityRePromptsViaNeedsValueError() async {
+    func testPerformWithStaleEntityThrowsPersonNotFound() async {
         harness = IntentTestHarness(people: [])
 
         let intent = OpenPersonIntent()
@@ -46,13 +46,17 @@ final class OpenPersonIntentTests: XCTestCase {
         do {
             _ = try await intent.perform()
             XCTFail("Expected throw")
+        } catch let error as IntentError {
+            if case .personNotFound = error {
+                // Pending must NOT be set to the stale id. The intent
+                // surfaces a graceful error dialog instead of routing
+                // anywhere — the user edits the shortcut to fix it.
+                XCTAssertNotEqual(DeepLinkRouter.shared.pending, .person(intent.person.id))
+            } else {
+                XCTFail("Wrong IntentError: \(error)")
+            }
         } catch {
-            // `$person.needsValueError(...)` returns an opaque
-            // AppIntentError whose runtime type is internal. We can't
-            // pattern-match on it; verifying that *some* error is
-            // thrown (and that pending was NOT set to the stale id)
-            // is enough to confirm the re-prompt path.
-            XCTAssertNotEqual(DeepLinkRouter.shared.pending, .person(intent.person.id))
+            XCTFail("Wrong error: \(error)")
         }
     }
 }

--- a/StayInTouch/StayInTouchTests/AppIntents/PersonAppEntityQueryTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/PersonAppEntityQueryTests.swift
@@ -1,0 +1,79 @@
+//
+//  PersonAppEntityQueryTests.swift
+//  KeepInTouchTests
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class PersonAppEntityQueryTests: XCTestCase {
+    private var harness: IntentTestHarness!
+
+    override func tearDown() {
+        harness?.tearDown()
+        harness = nil
+        super.tearDown()
+    }
+
+    func testEntitiesForIDsReturnsMatchingPeople() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        let bob = TestFactory.makePerson(name: "Bob")
+        harness = IntentTestHarness(people: [alice, bob])
+
+        let results = try await PersonAppEntityQuery().entities(for: [alice.id, bob.id])
+        XCTAssertEqual(Set(results.map(\.id)), Set([alice.id, bob.id]))
+    }
+
+    func testEntitiesForIDsSkipsUnknownIDs() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        harness = IntentTestHarness(people: [alice])
+
+        let unknown = UUID()
+        let results = try await PersonAppEntityQuery().entities(for: [alice.id, unknown])
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.id, alice.id)
+    }
+
+    func testEntitiesMatchingFiltersByDisplayName() async throws {
+        let mom = TestFactory.makePerson(name: "Mom")
+        let other = TestFactory.makePerson(name: "Boss")
+        harness = IntentTestHarness(people: [mom, other])
+
+        let results = try await PersonAppEntityQuery().entities(matching: "mom")
+        XCTAssertEqual(results.map(\.displayName), ["Mom"])
+    }
+
+    func testEntitiesMatchingIsCaseInsensitive() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        harness = IntentTestHarness(people: [alice])
+
+        let results = try await PersonAppEntityQuery().entities(matching: "ALICE")
+        XCTAssertEqual(results.count, 1)
+    }
+
+    func testEntitiesMatchingEmptyStringReturnsNothing() async throws {
+        let alice = TestFactory.makePerson(name: "Alice")
+        harness = IntentTestHarness(people: [alice])
+
+        let results = try await PersonAppEntityQuery().entities(matching: "   ")
+        XCTAssertEqual(results.count, 0)
+    }
+
+    func testSuggestedEntitiesSortsByLastTouchDescending() async throws {
+        let now = Date()
+        let recent = TestFactory.makePerson(
+            name: "Recent",
+            lastTouchAt: now.addingTimeInterval(-3600)
+        )
+        let stale = TestFactory.makePerson(
+            name: "Stale",
+            lastTouchAt: now.addingTimeInterval(-86_400 * 10)
+        )
+        let never = TestFactory.makePerson(name: "Never")
+        harness = IntentTestHarness(people: [stale, recent, never])
+
+        let results = try await PersonAppEntityQuery().suggestedEntities()
+        XCTAssertEqual(results.map(\.displayName), ["Recent", "Stale", "Never"])
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/PersonAppEntityQueryTests.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/PersonAppEntityQueryTests.swift
@@ -25,14 +25,17 @@ final class PersonAppEntityQueryTests: XCTestCase {
         XCTAssertEqual(Set(results.map(\.id)), Set([alice.id, bob.id]))
     }
 
-    func testEntitiesForIDsSkipsUnknownIDs() async throws {
+    func testEntitiesForIDsReturnsTombstoneForUnknownIDs() async throws {
         let alice = TestFactory.makePerson(name: "Alice")
         harness = IntentTestHarness(people: [alice])
 
         let unknown = UUID()
         let results = try await PersonAppEntityQuery().entities(for: [alice.id, unknown])
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first?.id, alice.id)
+        // Tombstoning unknowns lets `perform()` run + throw a graceful
+        // error instead of the framework's contextless re-prompt picker.
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.first { $0.id == alice.id }?.displayName, "Alice")
+        XCTAssertEqual(results.first { $0.id == unknown }?.displayName, PersonAppEntityQuery.staleDisplayName)
     }
 
     func testEntitiesMatchingFiltersByDisplayName() async throws {


### PR DESCRIPTION
## Summary

Ships v1 of iOS Shortcuts / Siri integration for Keep In Touch. Power users can now log touches from anywhere ("Hey Siri, log a touch with Mom"), pull "who needs attention" lists into Shortcut chains, and open contacts via Spotlight / Action Button — all without launching the UI for the action paths.

Closes #304.

## Scope (locked v1)

**Intents:**
- `LogTouchIntent` — log a touch (person + method + optional notes + optional date)
- `GetOverdueContactsIntent` — `[PersonAppEntity]` for chaining
- `GetDueSoonContactsIntent` — same, within the warning window
- `OpenPersonIntent` — deep-links to PersonDetailView
- `KeepInTouchShortcuts: AppShortcutsProvider` — curated phrases

**Deferred to v2** (filed as a follow-up sweep): Snooze/Pause/Mute toggles, AddPersonToGroup, MarkContactedToday, GetPerson/GetLastTouch, OpenGroup, Siri donations, Apple Watch, Focus filters.

## Architecture

- **Intents live in main app target** — widget extension process can't reach NotificationScheduler / DeepLinkRouter
- **`IntentActions` facade** mirrors `PersonDetailViewModel.logTouch` step-for-step, reusing `BulkLogTouchUseCase.applyTouch` (the existing static helper). Zero logic duplication; same `.personDidChange` post → same NotificationScheduler reschedule path
- **`IntentContainer`** — lazy DI singleton with install/reset/make test seams
- **`AppDependencies`** — added memberwise init so intent tests can inject mock repositories
- **Deep-link reuse** — `OpenPersonIntent` writes to existing `DeepLinkRouter.shared.pending`; `MainTabView.processPendingDeepLink()` handles the rest

## Failure handling

| Path | User sees |
|------|-----------|
| Stale person id | Siri: "I couldn't find that contact in Keep In Touch." |
| Touch save fails | Siri: "Couldn't save the touch. Please try again." |
| OpenPerson with stale id | Falls back to Home + throws personNotFound |
| Empty overdue / due-soon | Custom dialog ("Nothing's overdue right now.") |

## Tests

19 new tests, all passing. Total suite now well above the prior 316.

- LogTouchIntent: save path, person-not-found, snooze clearing, `.personDidChange` post, whitespace trim, explicit date
- GetOverdue / GetDueSoon: repository call verification, empty state
- OpenPerson: router-pending side effect + stale-id fallback
- PersonAppEntityQuery: id lookup, case-insensitive name match, empty-string guard, suggested ordering
- IntentContainer: install/reset/cache semantics

## Notable findings during implementation

1. **Widget refresh** — repositories already call `WidgetRefresher.reloadAllTimelines()` on every save. The plan's "fix single-touch UI gap" was a no-op; the gap doesn't exist.
2. **GroupAppEntity move** — skipped; v1 intents take no Group parameter. Revisit if v2 adds `AddPersonToGroupIntent`.
3. **AppShortcuts phrase limit** — Apple permits one parameter per phrase. The `"Log a {method} with {person}"` form had to be split into single-param variants.

## Test Plan (manual QA, in the morning)

- [x] Build and install on device; open the Shortcuts app
- [x] Add `Log Touch` action, pick a person + method, run; verify touch appears in PersonDetail and Home reorders
- [ ] Trigger via Siri voice: "Hey Siri, log a touch with [person] in Keep In Touch" — dialog reads naturally
- [x] Spotlight: search "Log Touch" — verify shortcut surfaces
- [x] Add `Get Overdue Contacts` to a Shortcut → Show Notification with names → tap a name → opens detail
- [x] Stale-id case: snapshot a shortcut, delete the contact in-app, re-run → graceful error
- [x] Demo mode: enable, run intents — confirm operates on demo data without crash
- [x] Widget: verify timeline updates after intent-logged touch (should — refresh is at the repo layer)
- [ ] VoiceOver: enable, navigate the Shortcuts editor, confirm parameter summaries read naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)