### PR TITLE
[#310] Tech debt: Status drift fix — unify Home buckets through PersonStatusService (R5)

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
@@ -124,22 +124,15 @@ final class HomeViewModel: ObservableObject {
             searchText: searchText
         )
 
+        // Single source of truth: route all three buckets through
+        // PersonStatusService.partition so the "All Good" bucket can't
+        // silently diverge from Overdue/Due Soon (audit R5, #310).
         let service = PersonStatusService(referenceDate: Date())
+        let buckets = service.partition(filtered, cadences: cadences)
 
-        let overdue = service.overduePeople(filtered, cadences: cadences)
-        let dueSoon = service.dueSoonPeople(filtered, cadences: cadences)
-        let allGood = filtered.filter { person in
-            guard !person.isPaused else { return false }
-            let status = FrequencyCalculator().status(for: person, in: cadences)
-            return status == .onTrack
-        }
-        let allGoodByRecency = allGood.sorted {
-            ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast)
-        }
-
-        overduePeople = overdue
-        dueSoonPeople = dueSoon
-        allGoodPeople = allGoodByRecency
+        overduePeople = buckets.overdue
+        dueSoonPeople = buckets.dueSoon
+        allGoodPeople = buckets.onTrack
 
         evaluateFreshStartPrompt()
     }

--- a/StayInTouch/StayInTouch/UseCases/PersonStatusService.swift
+++ b/StayInTouch/StayInTouch/UseCases/PersonStatusService.swift
@@ -18,17 +18,7 @@ struct PersonStatusService {
         let filtered = people.filter { !($0.isPaused) }
         let overdue = filtered.filter { calculator.status(for: $0, in: cadences) == .overdue }
         return overdue.sorted { lhs, rhs in
-            let lhsOverdue = calculator.daysOverdue(for: lhs, in: cadences)
-            let rhsOverdue = calculator.daysOverdue(for: rhs, in: cadences)
-            if lhsOverdue != rhsOverdue {
-                return lhsOverdue > rhsOverdue
-            }
-            let lhsDate = calculator.effectiveLastTouchDate(for: lhs)
-            let rhsDate = calculator.effectiveLastTouchDate(for: rhs)
-            if lhsDate != rhsDate {
-                return (lhsDate ?? .distantPast) < (rhsDate ?? .distantPast)
-            }
-            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            sortOverdue(lhs, rhs, cadences: cadences)
         }
     }
 
@@ -37,18 +27,82 @@ struct PersonStatusService {
         let dueSoon = filtered.filter { calculator.status(for: $0, in: cadences) == .dueSoon }
 
         return dueSoon.sorted { lhs, rhs in
-            let lhsDays = daysUntilDue(for: lhs, cadences: cadences)
-            let rhsDays = daysUntilDue(for: rhs, cadences: cadences)
-            if lhsDays != rhsDays {
-                return lhsDays < rhsDays
-            }
-            let lhsDate = calculator.effectiveLastTouchDate(for: lhs)
-            let rhsDate = calculator.effectiveLastTouchDate(for: rhs)
-            if lhsDate != rhsDate {
-                return (lhsDate ?? .distantPast) < (rhsDate ?? .distantPast)
-            }
-            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            sortDueSoon(lhs, rhs, cadences: cadences)
         }
+    }
+
+    /// Partition non-paused people into the three Home buckets in a single
+    /// pass so all three buckets are routed through the same status source
+    /// (`FrequencyCalculator.status`). Eliminates the silent-divergence risk
+    /// of running a second `FrequencyCalculator` for the "All Good" bucket
+    /// while using `PersonStatusService` for the other two (audit R5, #310).
+    ///
+    /// Bucket semantics, preserved from the prior implementation:
+    /// - `overdue`: status == .overdue, sorted by daysOverdue desc, then
+    ///   effectiveLastTouchDate asc, then displayName asc.
+    /// - `dueSoon`: status == .dueSoon, sorted by daysUntilDue asc, then
+    ///   effectiveLastTouchDate asc, then displayName asc.
+    /// - `onTrack`: status == .onTrack, sorted by `lastTouchAt` desc
+    ///   (most-recently touched first; nil treated as `.distantPast`).
+    /// - Paused people are excluded from all three buckets.
+    /// - `.unknown` status (no cadence match / no effective due date)
+    ///   is excluded from all three buckets.
+    func partition(
+        _ people: [Person],
+        cadences: [Cadence]
+    ) -> (overdue: [Person], dueSoon: [Person], onTrack: [Person]) {
+        var overdue: [Person] = []
+        var dueSoon: [Person] = []
+        var onTrack: [Person] = []
+
+        for person in people where !person.isPaused {
+            switch calculator.status(for: person, in: cadences) {
+            case .overdue:
+                overdue.append(person)
+            case .dueSoon:
+                dueSoon.append(person)
+            case .onTrack:
+                onTrack.append(person)
+            case .unknown:
+                continue
+            }
+        }
+
+        overdue.sort { sortOverdue($0, $1, cadences: cadences) }
+        dueSoon.sort { sortDueSoon($0, $1, cadences: cadences) }
+        onTrack.sort { ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast) }
+
+        return (overdue, dueSoon, onTrack)
+    }
+
+    // MARK: - Private
+
+    private func sortOverdue(_ lhs: Person, _ rhs: Person, cadences: [Cadence]) -> Bool {
+        let lhsOverdue = calculator.daysOverdue(for: lhs, in: cadences)
+        let rhsOverdue = calculator.daysOverdue(for: rhs, in: cadences)
+        if lhsOverdue != rhsOverdue {
+            return lhsOverdue > rhsOverdue
+        }
+        let lhsDate = calculator.effectiveLastTouchDate(for: lhs)
+        let rhsDate = calculator.effectiveLastTouchDate(for: rhs)
+        if lhsDate != rhsDate {
+            return (lhsDate ?? .distantPast) < (rhsDate ?? .distantPast)
+        }
+        return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+    }
+
+    private func sortDueSoon(_ lhs: Person, _ rhs: Person, cadences: [Cadence]) -> Bool {
+        let lhsDays = daysUntilDue(for: lhs, cadences: cadences)
+        let rhsDays = daysUntilDue(for: rhs, cadences: cadences)
+        if lhsDays != rhsDays {
+            return lhsDays < rhsDays
+        }
+        let lhsDate = calculator.effectiveLastTouchDate(for: lhs)
+        let rhsDate = calculator.effectiveLastTouchDate(for: rhs)
+        if lhsDate != rhsDate {
+            return (lhsDate ?? .distantPast) < (rhsDate ?? .distantPast)
+        }
+        return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
     }
 
     private func daysUntilDue(for person: Person, cadences: [Cadence]) -> Int {

--- a/StayInTouch/StayInTouchTests/PersonStatusServiceTests.swift
+++ b/StayInTouch/StayInTouchTests/PersonStatusServiceTests.swift
@@ -141,4 +141,242 @@ final class PersonStatusServiceTests: XCTestCase {
         let overdue = service.overduePeople([newer, older], cadences: [cadence])
         XCTAssertEqual(overdue.first?.displayName, "Bob")
     }
+
+    // MARK: - partition() — unify Home buckets (#310, audit R5)
+
+    /// Partition must place a person in exactly the same bucket the old
+    /// HomeViewModel computation would have. Covers all status outcomes:
+    /// paused (excluded), snoozed (onTrack), overdue, dueSoon, onTrack,
+    /// no-last-touch with no cadenceAddedAt (unknown → excluded).
+    func testPartitionAssignsEachStatusToCorrectBucket() {
+        let cadenceId = UUID()
+        let now = Date()
+        let cal = Calendar.current
+
+        let cadence = Cadence(
+            id: cadenceId,
+            name: "Weekly",
+            frequencyDays: 7,
+            warningDays: 2,
+            colorHex: nil,
+            isDefault: true,
+            sortOrder: 0,
+            createdAt: now,
+            modifiedAt: now
+        )
+
+        // Cadence: 7-day frequency, 2-day warning window.
+        // referenceDate is `now`.
+        let overduePerson = makePerson(
+            name: "Overdue",
+            cadenceId: cadenceId,
+            lastTouchAt: cal.date(byAdding: .day, value: -10, to: now)  // 3 days overdue
+        )
+        let dueSoonPerson = makePerson(
+            name: "DueSoon",
+            cadenceId: cadenceId,
+            lastTouchAt: cal.date(byAdding: .day, value: -6, to: now)   // due in 1 day, warning=2
+        )
+        let onTrackPerson = makePerson(
+            name: "OnTrack",
+            cadenceId: cadenceId,
+            lastTouchAt: cal.date(byAdding: .day, value: -1, to: now)   // due in 6 days, > warning
+        )
+        let pausedOverdue = makePerson(
+            name: "PausedOverdue",
+            cadenceId: cadenceId,
+            lastTouchAt: cal.date(byAdding: .day, value: -100, to: now),
+            isPaused: true
+        )
+        let snoozedOverdue = makePerson(
+            name: "SnoozedOverdue",
+            cadenceId: cadenceId,
+            lastTouchAt: cal.date(byAdding: .day, value: -100, to: now),
+            snoozedUntil: cal.date(byAdding: .day, value: 5, to: now)
+        )
+        let unknownPerson = makePerson(
+            name: "Unknown",
+            cadenceId: cadenceId,
+            lastTouchAt: nil,
+            cadenceAddedAt: nil
+        )
+
+        let people = [overduePerson, dueSoonPerson, onTrackPerson, pausedOverdue, snoozedOverdue, unknownPerson]
+        let service = PersonStatusService(referenceDate: now)
+        let buckets = service.partition(people, cadences: [cadence])
+
+        XCTAssertEqual(buckets.overdue.map { $0.displayName }, ["Overdue"])
+        XCTAssertEqual(buckets.dueSoon.map { $0.displayName }, ["DueSoon"])
+        // Snoozed person classifies as onTrack (FrequencyCalculator behavior).
+        XCTAssertEqual(Set(buckets.onTrack.map { $0.displayName }), Set(["OnTrack", "SnoozedOverdue"]))
+
+        // Paused and unknown are excluded from all three buckets.
+        let allBucketedIds = Set(
+            (buckets.overdue + buckets.dueSoon + buckets.onTrack).map { $0.id }
+        )
+        XCTAssertFalse(allBucketedIds.contains(pausedOverdue.id), "Paused must be excluded")
+        XCTAssertFalse(allBucketedIds.contains(unknownPerson.id), "Unknown status must be excluded")
+    }
+
+    func testPartitionBucketsAreDisjoint() {
+        let cadenceId = UUID()
+        let now = Date()
+        let cal = Calendar.current
+
+        let cadence = Cadence(
+            id: cadenceId,
+            name: "Weekly",
+            frequencyDays: 7,
+            warningDays: 2,
+            colorHex: nil,
+            isDefault: true,
+            sortOrder: 0,
+            createdAt: now,
+            modifiedAt: now
+        )
+
+        let people = (0..<20).map { i -> Person in
+            // Spread last-touch from -20..-1 days so we get a mix of buckets.
+            let lastTouch = cal.date(byAdding: .day, value: -i, to: now)
+            return makePerson(name: "P\(i)", cadenceId: cadenceId, lastTouchAt: lastTouch)
+        }
+
+        let service = PersonStatusService(referenceDate: now)
+        let buckets = service.partition(people, cadences: [cadence])
+
+        let overdueIds = Set(buckets.overdue.map { $0.id })
+        let dueSoonIds = Set(buckets.dueSoon.map { $0.id })
+        let onTrackIds = Set(buckets.onTrack.map { $0.id })
+
+        XCTAssertTrue(overdueIds.isDisjoint(with: dueSoonIds))
+        XCTAssertTrue(overdueIds.isDisjoint(with: onTrackIds))
+        XCTAssertTrue(dueSoonIds.isDisjoint(with: onTrackIds))
+
+        // Union equals all input ids (no paused, no unknown in this set).
+        let union = overdueIds.union(dueSoonIds).union(onTrackIds)
+        XCTAssertEqual(union, Set(people.map { $0.id }))
+    }
+
+    /// Equivalence test: partition() must produce the SAME sets the prior
+    /// HomeViewModel.applyFilters() implementation produced — i.e. matches
+    /// the existing `overduePeople`/`dueSoonPeople` helpers exactly, plus a
+    /// "lastTouchAt desc" sort for the All Good bucket.
+    func testPartitionMatchesLegacyComputation() {
+        let cadenceId = UUID()
+        let now = Date()
+        let cal = Calendar.current
+
+        let cadence = Cadence(
+            id: cadenceId,
+            name: "Weekly",
+            frequencyDays: 7,
+            warningDays: 2,
+            colorHex: nil,
+            isDefault: true,
+            sortOrder: 0,
+            createdAt: now,
+            modifiedAt: now
+        )
+
+        // Build a varied set: overdue, due-soon, on-track, snoozed, paused, unknown.
+        let people: [Person] = [
+            makePerson(name: "A", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -30, to: now)),  // overdue
+            makePerson(name: "B", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -8, to: now)),   // overdue (1 day)
+            makePerson(name: "C", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -6, to: now)),   // due soon
+            makePerson(name: "D", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -1, to: now)),   // on track
+            makePerson(name: "E", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -2, to: now)),   // on track
+            makePerson(name: "F", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -100, to: now), isPaused: true),  // paused
+            makePerson(name: "G", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -100, to: now),
+                       snoozedUntil: cal.date(byAdding: .day, value: 3, to: now)),  // snoozed → onTrack
+        ]
+
+        let service = PersonStatusService(referenceDate: now)
+        let buckets = service.partition(people, cadences: [cadence])
+
+        // Legacy reference computation.
+        let legacyOverdue = service.overduePeople(people, cadences: [cadence])
+        let legacyDueSoon = service.dueSoonPeople(people, cadences: [cadence])
+        let legacyAllGood = people
+            .filter { !$0.isPaused }
+            .filter { FrequencyCalculator(referenceDate: now).status(for: $0, in: [cadence]) == .onTrack }
+            .sorted { ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast) }
+
+        XCTAssertEqual(buckets.overdue.map { $0.id }, legacyOverdue.map { $0.id }, "Overdue bucket must match legacy ordering and membership")
+        XCTAssertEqual(buckets.dueSoon.map { $0.id }, legacyDueSoon.map { $0.id }, "Due Soon bucket must match legacy ordering and membership")
+        XCTAssertEqual(buckets.onTrack.map { $0.id }, legacyAllGood.map { $0.id }, "All Good bucket must match legacy ordering and membership")
+    }
+
+    func testPartitionOnTrackSortedByLastTouchDescending() {
+        let cadenceId = UUID()
+        let now = Date()
+        let cal = Calendar.current
+
+        let cadence = Cadence(
+            id: cadenceId,
+            name: "Monthly",
+            frequencyDays: 30,
+            warningDays: 3,
+            colorHex: nil,
+            isDefault: true,
+            sortOrder: 0,
+            createdAt: now,
+            modifiedAt: now
+        )
+
+        let oldest = makePerson(name: "Oldest", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -10, to: now))
+        let middle = makePerson(name: "Middle", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -5, to: now))
+        let newest = makePerson(name: "Newest", cadenceId: cadenceId, lastTouchAt: cal.date(byAdding: .day, value: -1, to: now))
+
+        let service = PersonStatusService(referenceDate: now)
+        let buckets = service.partition([oldest, newest, middle], cadences: [cadence])
+
+        XCTAssertEqual(buckets.onTrack.map { $0.displayName }, ["Newest", "Middle", "Oldest"])
+    }
+
+    func testPartitionEmptyInputReturnsEmptyBuckets() {
+        let service = PersonStatusService(referenceDate: Date())
+        let buckets = service.partition([], cadences: [])
+        XCTAssertTrue(buckets.overdue.isEmpty)
+        XCTAssertTrue(buckets.dueSoon.isEmpty)
+        XCTAssertTrue(buckets.onTrack.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makePerson(
+        name: String,
+        cadenceId: UUID,
+        lastTouchAt: Date?,
+        isPaused: Bool = false,
+        snoozedUntil: Date? = nil,
+        cadenceAddedAt: Date? = Date()
+    ) -> Person {
+        Person(
+            id: UUID(),
+            cnIdentifier: nil,
+            displayName: name,
+            initials: String(name.prefix(1)),
+            avatarColor: "#FF6B6B",
+            cadenceId: cadenceId,
+            groupIds: [],
+            lastTouchAt: lastTouchAt,
+            lastTouchMethod: nil,
+            lastTouchNotes: nil,
+            nextTouchNotes: nil,
+            isPaused: isPaused,
+            isTracked: true,
+            notificationsMuted: false,
+            customBreachTime: nil,
+            snoozedUntil: snoozedUntil,
+            customDueDate: nil,
+            birthday: nil,
+            birthdayNotificationsEnabled: true,
+            contactUnavailable: false,
+            isDemoData: false,
+            cadenceAddedAt: cadenceAddedAt,
+            createdAt: Date(),
+            modifiedAt: Date(),
+            sortOrder: 0
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Eliminates the latent divergence risk between the Home view's three buckets (Overdue / Due Soon / All Good). Before this PR, the first two routed through `PersonStatusService` while the third spun up its own `FrequencyCalculator` — if `PersonStatusService` ever adjusts edge cases (snooze handling, custom due dates, etc.), the All Good bucket silently drifts.

Refactor-only. The Home view shows exactly the same people in exactly the same order as before.

## Changes

- **`PersonStatusService.partition(_:cadences:)`** — single-pass classification of non-paused people into the three buckets, all routed through `FrequencyCalculator.status`. Existing `overduePeople`/`dueSoonPeople` methods refactored to share private sort helpers (`sortOverdue`, `sortDueSoon`) with `partition`, removing internal duplication.
- **`HomeViewModel.applyFilters`** — replaces 3 separate bucket computations with a single `service.partition(...)` call.
- **`PersonStatusServiceTests`** — adds 238 LOC of unit tests covering all status combinations (overdue, dueSoon, onTrack, paused, snoozed, no-cadence, no-last-touch). All three buckets verified to contain the same Person sets as the prior implementation.

## Bucket semantics preserved

| Bucket | Filter | Sort |
|---|---|---|
| `overdue` | `status == .overdue` | `daysOverdue desc, effectiveLastTouchDate asc, displayName asc` |
| `dueSoon` | `status == .dueSoon` | `daysUntilDue asc, effectiveLastTouchDate asc, displayName asc` |
| `onTrack` | `status == .onTrack` | `lastTouchAt desc` (nil → `.distantPast`) |

Paused people excluded from all three. `.unknown` status excluded from all three.

## Verification

- `xcodebuild build` → clean
- `xcodebuild test` → all tests pass (test count increased by new partition tests)
- Behavior preserved: prior `HomeViewModelTests` (if any assert on bucket membership) pass unchanged

## North star

✅ Open the app after this merges — Home view shows the same content in the same order.

Closes #310. Tracked in #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)