### PR TITLE
[#308] Tech debt: Repository CRUD base (R1)

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataCadenceRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataCadenceRepository.swift
@@ -17,10 +17,7 @@ final class CoreDataCadenceRepository: CadenceRepository {
     func fetch(id: UUID) -> Cadence? {
         var result: Cadence?
         context.performAndWait {
-            let request: NSFetchRequest<GroupEntity> = GroupEntity.fetchRequest()
-            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            request.fetchLimit = 1
-            result = (try? context.fetch(request))?.first?.toDomain()
+            result = fetchEntityByID(request: GroupEntity.fetchRequest(), id: id, in: context)?.toDomain()
         }
         return result
     }
@@ -47,53 +44,38 @@ final class CoreDataCadenceRepository: CadenceRepository {
     }
 
     func save(_ cadence: Cadence) throws {
-        do {
-            try context.performAndWait {
-                let entity = fetchEntity(id: cadence.id) ?? GroupEntity(context: context)
-                entity.apply(cadence)
-                try context.save()
-            }
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Cadence", underlying: error)
+        // Cadence mutations do not affect widget content; skip the refresh.
+        try upsertEntity(
+            id: cadence.id,
+            fetchRequest: { GroupEntity.fetchRequest() },
+            entityLabel: "Cadence",
+            in: context,
+            refreshWidgets: false
+        ) { entity in
+            entity.apply(cadence)
         }
     }
 
     func batchSave(_ cadences: [Cadence]) throws {
-        do {
-            try context.performAndWait {
-                for cadence in cadences {
-                    let entity = fetchEntity(id: cadence.id) ?? GroupEntity(context: context)
-                    entity.apply(cadence)
-                }
-                try context.save()
-            }
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Cadence", underlying: error)
+        try batchUpsertEntities(
+            cadences,
+            id: { $0.id },
+            fetchRequest: { GroupEntity.fetchRequest() },
+            entityLabel: "Cadence",
+            in: context,
+            refreshWidgets: false
+        ) { cadence, entity in
+            entity.apply(cadence)
         }
     }
 
     func delete(id: UUID) throws {
-        do {
-            try context.performAndWait {
-                guard let entity = fetchEntity(id: id) else { return }
-                context.delete(entity)
-                try context.save()
-            }
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.deleteFailed(entity: "Cadence", id: id, underlying: error)
-        }
-    }
-
-    private func fetchEntity(id: UUID) -> GroupEntity? {
-        let request: NSFetchRequest<GroupEntity> = GroupEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        request.fetchLimit = 1
-        return try? context.fetch(request).first
+        try deleteEntityByID(
+            fetchRequest: { GroupEntity.fetchRequest() },
+            id: id,
+            entityLabel: "Cadence",
+            in: context,
+            refreshWidgets: false
+        )
     }
 }

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataGroupRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataGroupRepository.swift
@@ -17,10 +17,7 @@ final class CoreDataGroupRepository: GroupRepository {
     func fetch(id: UUID) -> Group? {
         var result: Group?
         context.performAndWait {
-            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
-            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            request.fetchLimit = 1
-            result = (try? context.fetch(request))?.first?.toDomain()
+            result = fetchEntityByID(request: TagEntity.fetchRequest(), id: id, in: context)?.toDomain()
         }
         return result
     }
@@ -36,56 +33,34 @@ final class CoreDataGroupRepository: GroupRepository {
     }
 
     func save(_ group: Group) throws {
-        do {
-            try context.performAndWait {
-                let entity = fetchEntity(id: group.id) ?? TagEntity(context: context)
-                entity.apply(group)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Group", underlying: error)
+        try upsertEntity(
+            id: group.id,
+            fetchRequest: { TagEntity.fetchRequest() },
+            entityLabel: "Group",
+            in: context
+        ) { entity in
+            entity.apply(group)
         }
     }
 
     func batchSave(_ groups: [Group]) throws {
-        do {
-            try context.performAndWait {
-                for group in groups {
-                    let entity = fetchEntity(id: group.id) ?? TagEntity(context: context)
-                    entity.apply(group)
-                }
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Group", underlying: error)
+        try batchUpsertEntities(
+            groups,
+            id: { $0.id },
+            fetchRequest: { TagEntity.fetchRequest() },
+            entityLabel: "Group",
+            in: context
+        ) { group, entity in
+            entity.apply(group)
         }
     }
 
     func delete(id: UUID) throws {
-        do {
-            try context.performAndWait {
-                guard let entity = fetchEntity(id: id) else { return }
-                context.delete(entity)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.deleteFailed(entity: "Group", id: id, underlying: error)
-        }
-    }
-
-    private func fetchEntity(id: UUID) -> TagEntity? {
-        let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        request.fetchLimit = 1
-        return try? context.fetch(request).first
+        try deleteEntityByID(
+            fetchRequest: { TagEntity.fetchRequest() },
+            id: id,
+            entityLabel: "Group",
+            in: context
+        )
     }
 }

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
@@ -17,10 +17,7 @@ final class CoreDataPersonRepository: PersonRepository {
     func fetch(id: UUID) -> Person? {
         var result: Person?
         context.performAndWait {
-            let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
-            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            request.fetchLimit = 1
-            result = (try? context.fetch(request))?.first?.toDomain()
+            result = fetchEntityByID(request: PersonEntity.fetchRequest(), id: id, in: context)?.toDomain()
         }
         return result
     }
@@ -127,57 +124,35 @@ final class CoreDataPersonRepository: PersonRepository {
     }
 
     func save(_ person: Person) throws {
-        do {
-            try context.performAndWait {
-                let entity = fetchEntity(id: person.id) ?? PersonEntity(context: context)
-                entity.apply(person)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Person", underlying: error)
+        try upsertEntity(
+            id: person.id,
+            fetchRequest: { PersonEntity.fetchRequest() },
+            entityLabel: "Person",
+            in: context
+        ) { entity in
+            entity.apply(person)
         }
     }
 
     func batchSave(_ persons: [Person]) throws {
-        do {
-            try context.performAndWait {
-                for person in persons {
-                    let entity = fetchEntity(id: person.id) ?? PersonEntity(context: context)
-                    entity.apply(person)
-                }
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "Person", underlying: error)
+        try batchUpsertEntities(
+            persons,
+            id: { $0.id },
+            fetchRequest: { PersonEntity.fetchRequest() },
+            entityLabel: "Person",
+            in: context
+        ) { person, entity in
+            entity.apply(person)
         }
     }
 
     func delete(id: UUID) throws {
-        do {
-            try context.performAndWait {
-                guard let entity = fetchEntity(id: id) else { return }
-                context.delete(entity)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.deleteFailed(entity: "Person", id: id, underlying: error)
-        }
-    }
-
-    private func fetchEntity(id: UUID) -> PersonEntity? {
-        let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        request.fetchLimit = 1
-        return try? context.fetch(request).first
+        try deleteEntityByID(
+            fetchRequest: { PersonEntity.fetchRequest() },
+            id: id,
+            entityLabel: "Person",
+            in: context
+        )
     }
 
     private func basePredicate(includePaused: Bool) -> NSPredicate {

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift
@@ -1,0 +1,145 @@
+//
+//  CoreDataRepositoryHelpers.swift
+//  KeepInTouch
+//
+//  Generic CRUD helpers for Core Data repositories. Each public repository
+//  (Person, TouchEvent, Group, Cadence) had ~60 lines of nearly-identical
+//  upsert / delete / fetch-by-id boilerplate. These helpers centralize that
+//  surface while preserving exact behavior:
+//
+//  - All access occurs inside `context.performAndWait` for thread safety.
+//  - `WidgetRefresher.reloadAllTimelines()` fires on every successful save /
+//    batchSave / delete by default. Callers that must not refresh widgets
+//    (e.g. CadenceRepository, whose mutations do not affect widget content)
+//    pass `refreshWidgets: false`.
+//  - Errors are wrapped in `RepositoryError.saveFailed` / `.deleteFailed`
+//    with the entity label supplied by the caller.
+//
+//  Helpers are free functions (not a base class) because the four repositories
+//  conform to distinct protocols with different query surfaces; inheritance
+//  would force generics across protocol boundaries without simplifying calls.
+//
+//  Callers supply a `fetchRequest:` closure that returns the codegen-generated
+//  typed request (e.g. `PersonEntity.fetchRequest() as! NSFetchRequest<PersonEntity>`).
+//  This is necessary because the Swift class names (e.g. `PersonEntity`,
+//  `TagEntity`) do not match the `.xcdatamodel` entity names (`Person`, `Tag`),
+//  so deriving the entity name from `String(describing:)` would be wrong.
+//
+
+import CoreData
+
+// MARK: - Fetch one entity by UUID id
+
+/// Fetches a single managed object by its `id` UUID using the supplied request.
+///
+/// Must be called from inside `context.perform` / `context.performAndWait`.
+/// Used both by public `fetch(id:)` accessors (which wrap their own perform
+/// block) and by internal upsert paths (which are already inside one).
+func fetchEntityByID<Entity: NSManagedObject>(
+    request: NSFetchRequest<Entity>,
+    id: UUID,
+    in context: NSManagedObjectContext
+) -> Entity? {
+    request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+    request.fetchLimit = 1
+    return try? context.fetch(request).first
+}
+
+// MARK: - Save (upsert) one domain object
+
+/// Upserts a domain object into its Core Data entity, saves the context, and
+/// optionally reloads widget timelines.
+///
+/// - Parameters:
+///   - id: Primary key on the entity (`id` attribute).
+///   - fetchRequest: Factory returning a fresh typed fetch request for the
+///     entity (e.g. `{ PersonEntity.fetchRequest() as! NSFetchRequest<PersonEntity> }`).
+///     A new request is created per call so predicates don't leak between calls.
+///   - entityLabel: Human-readable label used in `RepositoryError.saveFailed`.
+///   - context: Backing context (used inside `performAndWait`).
+///   - refreshWidgets: When true (default), fires `WidgetRefresher.reloadAllTimelines()`
+///     after a successful save. Pass false for entities that do not affect widgets.
+///   - apply: Closure that copies domain state onto a freshly-fetched-or-created entity.
+func upsertEntity<Entity: NSManagedObject>(
+    id: UUID,
+    fetchRequest: @escaping () -> NSFetchRequest<Entity>,
+    entityLabel: String,
+    in context: NSManagedObjectContext,
+    refreshWidgets: Bool = true,
+    apply: @escaping (Entity) -> Void
+) throws {
+    do {
+        try context.performAndWait {
+            let entity = fetchEntityByID(request: fetchRequest(), id: id, in: context) ?? Entity(context: context)
+            apply(entity)
+            try context.save()
+        }
+        if refreshWidgets {
+            WidgetRefresher.reloadAllTimelines()
+        }
+    } catch let error as RepositoryError {
+        throw error
+    } catch {
+        throw RepositoryError.saveFailed(entity: entityLabel, underlying: error)
+    }
+}
+
+// MARK: - Batch save (upsert) many domain objects
+
+/// Upserts a sequence of domain objects in a single save. Identical semantics
+/// to `upsertEntity` but groups all writes into one `context.save()` and one
+/// widget refresh at the end.
+func batchUpsertEntities<Entity: NSManagedObject, Domain>(
+    _ domains: [Domain],
+    id: (Domain) -> UUID,
+    fetchRequest: @escaping () -> NSFetchRequest<Entity>,
+    entityLabel: String,
+    in context: NSManagedObjectContext,
+    refreshWidgets: Bool = true,
+    apply: @escaping (Domain, Entity) -> Void
+) throws {
+    do {
+        try context.performAndWait {
+            for domain in domains {
+                let entity = fetchEntityByID(request: fetchRequest(), id: id(domain), in: context) ?? Entity(context: context)
+                apply(domain, entity)
+            }
+            try context.save()
+        }
+        if refreshWidgets {
+            WidgetRefresher.reloadAllTimelines()
+        }
+    } catch let error as RepositoryError {
+        throw error
+    } catch {
+        throw RepositoryError.saveFailed(entity: entityLabel, underlying: error)
+    }
+}
+
+// MARK: - Delete by id
+
+/// Deletes the entity with the given id, saves, and optionally reloads widget
+/// timelines. A missing entity is a no-op (matches prior behavior — repos do
+/// not throw on delete-of-nonexistent).
+func deleteEntityByID<Entity: NSManagedObject>(
+    fetchRequest: @escaping () -> NSFetchRequest<Entity>,
+    id: UUID,
+    entityLabel: String,
+    in context: NSManagedObjectContext,
+    refreshWidgets: Bool = true
+) throws {
+    do {
+        try context.performAndWait {
+            guard let entity = fetchEntityByID(request: fetchRequest(), id: id, in: context) else { return }
+            context.delete(entity)
+            try context.save()
+        }
+        if refreshWidgets {
+            WidgetRefresher.reloadAllTimelines()
+        }
+    } catch let error as RepositoryError {
+        throw error
+    } catch {
+        throw RepositoryError.deleteFailed(entity: entityLabel, id: id, underlying: error)
+    }
+}

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataTouchEventRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataTouchEventRepository.swift
@@ -17,10 +17,7 @@ final class CoreDataTouchEventRepository: TouchEventRepository {
     func fetch(id: UUID) -> TouchEvent? {
         var result: TouchEvent?
         context.performAndWait {
-            let request: NSFetchRequest<TouchEventEntity> = TouchEventEntity.fetchRequest()
-            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            request.fetchLimit = 1
-            result = (try? context.fetch(request))?.first?.toDomain()
+            result = fetchEntityByID(request: TouchEventEntity.fetchRequest(), id: id, in: context)?.toDomain()
         }
         return result
     }
@@ -63,56 +60,34 @@ final class CoreDataTouchEventRepository: TouchEventRepository {
     }
 
     func save(_ touchEvent: TouchEvent) throws {
-        do {
-            try context.performAndWait {
-                let entity = fetchEntity(id: touchEvent.id) ?? TouchEventEntity(context: context)
-                entity.apply(touchEvent)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "TouchEvent", underlying: error)
+        try upsertEntity(
+            id: touchEvent.id,
+            fetchRequest: { TouchEventEntity.fetchRequest() },
+            entityLabel: "TouchEvent",
+            in: context
+        ) { entity in
+            entity.apply(touchEvent)
         }
     }
 
     func batchSave(_ touchEvents: [TouchEvent]) throws {
-        do {
-            try context.performAndWait {
-                for touchEvent in touchEvents {
-                    let entity = fetchEntity(id: touchEvent.id) ?? TouchEventEntity(context: context)
-                    entity.apply(touchEvent)
-                }
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.saveFailed(entity: "TouchEvent", underlying: error)
+        try batchUpsertEntities(
+            touchEvents,
+            id: { $0.id },
+            fetchRequest: { TouchEventEntity.fetchRequest() },
+            entityLabel: "TouchEvent",
+            in: context
+        ) { touchEvent, entity in
+            entity.apply(touchEvent)
         }
     }
 
     func delete(id: UUID) throws {
-        do {
-            try context.performAndWait {
-                guard let entity = fetchEntity(id: id) else { return }
-                context.delete(entity)
-                try context.save()
-            }
-            WidgetRefresher.reloadAllTimelines()
-        } catch let error as RepositoryError {
-            throw error
-        } catch {
-            throw RepositoryError.deleteFailed(entity: "TouchEvent", id: id, underlying: error)
-        }
-    }
-
-    private func fetchEntity(id: UUID) -> TouchEventEntity? {
-        let request: NSFetchRequest<TouchEventEntity> = TouchEventEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        request.fetchLimit = 1
-        return try? context.fetch(request).first
+        try deleteEntityByID(
+            fetchRequest: { TouchEventEntity.fetchRequest() },
+            id: id,
+            entityLabel: "TouchEvent",
+            in: context
+        )
     }
 }


### PR DESCRIPTION
## Summary

Closes the R1 finding from the parent tech-debt audit (#302): eliminate the duplicated `save` / `batchSave` / `delete` / `fetchEntity` boilerplate across the four Core Data repositories.

**Approach: Option B (free helpers) — not Option A (generic base class).**

Rationale for B over A:
- The four repos conform to *different* protocols (`PersonRepository`, `TouchEventRepository`, `GroupRepository`, `CadenceRepository`) — a Swift generic base class can't conform to all of them at once.
- Cadence intentionally does NOT fire `WidgetRefresher.reloadAllTimelines()`; an inheritance hierarchy would need an override or a flag baked in either way. A `refreshWidgets: Bool = true` parameter on free helpers handles this cleanly.
- No inheritance in the codebase today; helpers fit the existing style. Less invasive to call sites.

New file: `StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift`.

Helpers exposed:
- `fetchEntityByID(request:id:in:)` — fetch one entity by `id` UUID
- `upsertEntity(id:fetchRequest:entityLabel:in:refreshWidgets:apply:)` — upsert + save + (optional) widget refresh + error wrap
- `batchUpsertEntities(_:id:fetchRequest:entityLabel:in:refreshWidgets:apply:)` — batch upsert
- `deleteEntityByID(fetchRequest:id:entityLabel:in:refreshWidgets:)` — delete + save + (optional) widget refresh

Why `fetchRequest:` is a closure rather than a `Entity.Type`: the `.xcdatamodel` entity names (`Person`, `Tag`, `Group`, `TouchEvent`) do NOT match the Swift class names (`PersonEntity`, `TagEntity`, `GroupEntity`, `TouchEventEntity`). Deriving the name via `String(describing: Entity.self)` would crash at fetch time. Passing the codegen-generated typed factory keeps the existing naming intact.

## North star: zero observable behavior change

- All access still inside `context.performAndWait` — thread-safety discipline preserved
- `WidgetRefresher.reloadAllTimelines()` still fires on every successful Person / TouchEvent / Group save / batchSave / delete (helper default)
- Cadence still does NOT fire `WidgetRefresher` (helper calls pass `refreshWidgets: false`, matching prior behavior)
- `RepositoryError.saveFailed` and `.deleteFailed` thrown with identical entity labels (`"Person"`, `"TouchEvent"`, `"Group"`, `"Cadence"`)
- Delete-of-nonexistent still a no-op (no throw)
- Public repository protocol surfaces unchanged
- No `NSBatchDeleteRequest` introduced (out of scope per PR 4)
- No `context.count(for:)` introduced (out of scope per PR 7)
- No xcdatamodel changes

## LOC

| File | Before | After | Δ |
| --- | --- | --- | --- |
| CoreDataPersonRepository.swift | 189 | 164 | −25 |
| CoreDataTouchEventRepository.swift | 118 | 93 | −25 |
| CoreDataGroupRepository.swift | 91 | 66 | −25 |
| CoreDataCadenceRepository.swift | 99 | 81 | −18 |
| CoreDataRepositoryHelpers.swift (new) | 0 | 145 | +145 |
| **Total** | **497** | **549** | **+52** |

Net repos+helpers grows by 52 lines because the helpers include comments + multiple generic signatures. But the **CRUD section of each repo** (save / batchSave / delete / private fetchEntity) shrinks from ~55 lines to ~30 lines — about 45-55%, near the audit's ~60% target. The per-repo growth opens up if future repos are added: each new repo gets CRUD for ~30 lines instead of ~55.

## Tests

- Before: ~340 (per project memory note, possibly outdated)
- After (this run): **598 unique tests passing, 0 failing** — `** TEST SUCCEEDED **`
- All four repo-specific test files (`CoreDataPersonRepositoryTests`, `CoreDataTouchEventRepositoryTests`, `CoreDataCadenceRepositoryTests`, plus repo coverage in `RepositoryTests`) pass unchanged. No test files were modified.

## Widget-refresh verification

`grep -rn WidgetRefresher StayInTouch/StayInTouch/` confirms the only call sites are:
- `CoreDataRepositoryHelpers.swift` (3 call sites — one each for upsert / batchUpsert / delete, gated on `refreshWidgets`)
- `CoreDataAppSettingsRepository.swift` (unchanged — out of scope)
- `BulkLogTouchUseCase.swift` (unchanged — out of scope)

Per-entity refresh contract traced by reading the four repo files:
- Person `save` / `batchSave` / `delete` → helper defaults (refreshWidgets: true) → refresh fires
- TouchEvent `save` / `batchSave` / `delete` → helper defaults → refresh fires
- Group `save` / `batchSave` / `delete` → helper defaults → refresh fires
- Cadence `save` / `batchSave` / `delete` → `refreshWidgets: false` → refresh does NOT fire (matches prior)

## Test plan

- [x] Full build succeeds: `xcodebuild ... build` → BUILD SUCCEEDED
- [x] Full test suite: `xcodebuild ... test` → 598 passing, 0 failing, TEST SUCCEEDED
- [x] WidgetRefresher call-site trace matches prior behavior per entity
- [x] No public repository protocol changes
- [x] No xcdatamodel changes
- [x] No NSBatchDeleteRequest / `context.count(for:)` introduced
- [ ] Manual smoke: log a touch, edit a group, delete a person — widgets refresh as before; cadence edit does not refresh widgets (matches prior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)