### PR TITLE
[#311] Tech debt: PersonDetailVM in-place + Notification cascade debounce (E1, E5, E7)

### DIFF
--- a/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
+++ b/StayInTouch/StayInTouch/Data/Contacts/ContactsFetcher.swift
@@ -272,4 +272,53 @@ enum ContactsFetcher {
         }
         return Birthday.from(dateComponents: dateComponents)
     }
+
+    /// Batch-fetches birthdays for many identifiers in a single Contacts XPC
+    /// round-trip. Replaces N invocations of `fetchBirthday(identifier:)`
+    /// (each of which instantiates a fresh `CNContactStore` and crosses the
+    /// XPC boundary) with one `unifiedContacts(matching:keysToFetch:)` call
+    /// using `CNContact.predicateForContacts(withIdentifiers:)`.
+    ///
+    /// Returns a dictionary keyed by `cnIdentifier`. Identifiers with no
+    /// birthday — or that don't resolve to a contact — are simply absent from
+    /// the result (no error). Returns an empty dictionary if Contacts access
+    /// is not authorized or the input is empty.
+    static func fetchBirthdays(identifiers: [String]) -> [String: Birthday] {
+        guard !identifiers.isEmpty else { return [:] }
+
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        switch status {
+        case .denied, .restricted, .notDetermined:
+            return [:]
+        case .authorized, .limited:
+            break
+        @unknown default:
+            break
+        }
+
+        let store = CNContactStore()
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactBirthdayKey as CNKeyDescriptor
+        ]
+        let predicate = CNContact.predicateForContacts(withIdentifiers: identifiers)
+
+        let contacts: [CNContact]
+        do {
+            contacts = try store.unifiedContacts(matching: predicate, keysToFetch: keys)
+        } catch {
+            AppLogger.logError(error, category: AppLogger.contacts, context: "ContactsFetcher.fetchBirthdays")
+            return [:]
+        }
+
+        var result: [String: Birthday] = [:]
+        for contact in contacts {
+            guard let dateComponents = contact.birthday,
+                  let birthday = Birthday.from(dateComponents: dateComponents) else {
+                continue
+            }
+            result[contact.identifier] = birthday
+        }
+        return result
+    }
 }

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -115,17 +115,20 @@ final class NotificationScheduler {
         stopObserving()
         registerCategories()
 
+        // Deliver on .main so scheduleAllDebounced()'s access to the
+        // shared pendingScheduleTask is serialized — observer posts can
+        // originate from any thread, and the debouncer mutates shared state.
         settingsObserver = NotificationCenter.default.addObserver(
             forName: .settingsDidChange,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] _ in
             self?.scheduleAllDebounced()
         }
         personObserver = NotificationCenter.default.addObserver(
             forName: .personDidChange,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] _ in
             self?.scheduleAllDebounced()
         }

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -416,21 +416,34 @@ private extension NotificationScheduler {
         let hideNames = settings.hideContactNamesInNotifications
         let time = settings.birthdayNotificationTime
 
-        // Collect eligible (person, birthday) pairs grouped by calendar date
-        struct BirthdayKey: Hashable { let month: Int; let day: Int }
-        var groups: [BirthdayKey: [(Person, Birthday)]] = [:]
-
+        // First pass: filter eligibility (cheap, in-memory) and collect the
+        // set of `cnIdentifier`s we need to resolve from the Contacts store.
+        // Previously each eligible person without a stored birthday opened a
+        // fresh CNContactStore — N people = N XPC round-trips. Batch them.
+        var eligible: [Person] = []
+        var idsNeedingContactBirthday: [String] = []
         for person in people {
             guard person.birthdayNotificationsEnabled else { continue }
             guard !person.notificationsMuted else { continue }
             if !ignoreSnoozePause, person.isSnoozed() { continue }
+            eligible.append(person)
+            if person.birthday == nil, let cnId = person.cnIdentifier {
+                idsNeedingContactBirthday.append(cnId)
+            }
+        }
 
-            // Resolve birthday: stored first, then contact-sourced
+        let contactBirthdaysById = ContactsFetcher.fetchBirthdays(identifiers: idsNeedingContactBirthday)
+
+        // Second pass: assemble (person, birthday) pairs grouped by calendar date.
+        struct BirthdayKey: Hashable { let month: Int; let day: Int }
+        var groups: [BirthdayKey: [(Person, Birthday)]] = [:]
+
+        for person in eligible {
             let birthday: Birthday?
             if let stored = person.birthday {
                 birthday = stored
             } else if let cnId = person.cnIdentifier {
-                birthday = ContactsFetcher.fetchBirthday(identifier: cnId)
+                birthday = contactBirthdaysById[cnId]
             } else {
                 birthday = nil
             }

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -63,16 +63,30 @@ final class NotificationScheduler {
     private var settingsObserver: NSObjectProtocol?
     private var personObserver: NSObjectProtocol?
 
+    /// Coalescing window for `.personDidChange` / `.settingsDidChange` bursts.
+    /// A single Person Detail tap (toggle pause, set custom breach time, etc.)
+    /// historically triggered scheduleAll(); rapid succession of edits would
+    /// re-run the entire classification + scheduling pipeline N times. This
+    /// debouncer collapses bursts within `debounceInterval` into one run.
+    /// Set to 1.0s — long enough to absorb typical UI tap bursts, short enough
+    /// that the user-visible reschedule still feels immediate. Direct
+    /// `scheduleAll()` callers (AppDelegate didFinishLaunching, scenePhase
+    /// transitions, background refresh) bypass the debouncer.
+    private let debounceInterval: TimeInterval
+    private var pendingScheduleTask: Task<Void, Never>?
+
     init(
         settingsRepository: AppSettingsRepository = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext),
         personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
         cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        notificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current()
+        notificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current(),
+        debounceInterval: TimeInterval = 1.0
     ) {
         self.settingsRepository = settingsRepository
         self.personRepository = personRepository
         self.cadenceRepository = cadenceRepository
         self.notificationCenter = notificationCenter
+        self.debounceInterval = debounceInterval
     }
 
     func registerCategories() {
@@ -106,14 +120,14 @@ final class NotificationScheduler {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            Task { await self?.scheduleAll() }
+            self?.scheduleAllDebounced()
         }
         personObserver = NotificationCenter.default.addObserver(
             forName: .personDidChange,
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            Task { await self?.scheduleAll() }
+            self?.scheduleAllDebounced()
         }
     }
 
@@ -125,6 +139,32 @@ final class NotificationScheduler {
         if let observer = personObserver {
             NotificationCenter.default.removeObserver(observer)
             personObserver = nil
+        }
+        pendingScheduleTask?.cancel()
+        pendingScheduleTask = nil
+    }
+
+    /// Coalesces a burst of `.personDidChange` / `.settingsDidChange` posts into
+    /// a single `scheduleAll()` run. Each call cancels the previous pending
+    /// task (if it has not started its work yet) and queues a fresh sleep +
+    /// scheduleAll. If the sleep is cancelled the task exits without calling
+    /// scheduleAll — the *next* post will schedule again. If the sleep has
+    /// already elapsed and `scheduleAll()` is in flight, we let it complete
+    /// and the new post enqueues a fresh task — no reschedule is ever lost.
+    ///
+    /// This intentionally does NOT change the content, timing, identifier, or
+    /// trigger of the resulting UNNotificationRequests — only *how often*
+    /// scheduleAll runs in response to upstream change posts.
+    func scheduleAllDebounced() {
+        pendingScheduleTask?.cancel()
+        let interval = debounceInterval
+        pendingScheduleTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            } catch {
+                return  // cancelled before sleep elapsed — newer post will reschedule
+            }
+            await self?.scheduleAll()
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -190,8 +190,8 @@ final class PersonDetailViewModel: ObservableObject {
     func changeCadence(to cadenceId: UUID) {
         if isPreview { return }
         let updated = AssignCadenceUseCase().assign(person: person, to: cadenceId)
+        // savePerson refreshes the cadence in-place when cadenceId changes.
         savePerson(updated)
-        cadence = cadenceRepository.fetch(id: cadenceId)
     }
 
     func togglePause() {
@@ -308,8 +308,8 @@ final class PersonDetailViewModel: ObservableObject {
         var updated = person
         updated.groupIds.append(group.id)
         updated.modifiedAt = Date()
+        // savePerson refreshes availableGroups in-place when groupIds changes.
         savePerson(updated)
-        availableGroups = groups.filter { !updated.groupIds.contains($0.id) }
     }
 
     func removeGroup(_ group: Group) {
@@ -317,8 +317,8 @@ final class PersonDetailViewModel: ObservableObject {
         var updated = person
         updated.groupIds.removeAll { $0 == group.id }
         updated.modifiedAt = Date()
+        // savePerson refreshes availableGroups in-place when groupIds changes.
         savePerson(updated)
-        availableGroups = groups.filter { !updated.groupIds.contains($0.id) }
     }
 
     func logTouch(method: TouchMethod, notes: String?, date: Date, timeOfDay: TimeOfDay? = nil) {
@@ -595,11 +595,27 @@ final class PersonDetailViewModel: ObservableObject {
         return url
     }
 
+    /// Persists `updated` and refreshes only the derived state whose inputs
+    /// actually changed. Avoids the prior `load()` cascade (refetch of person +
+    /// cadences + groups + touch events) on every keystroke-grade mutation
+    /// (toggle pause, mute, custom breach time, etc.). Posts
+    /// `.personDidChange` so downstream observers (NotificationScheduler,
+    /// HomeView, ContactsListView) still see every mutation — the debounce on
+    /// the scheduler side coalesces bursts without dropping any.
     private func savePerson(_ updated: Person) {
+        let previous = person
         do {
             try personRepository.save(updated)
             person = updated
-            load()
+
+            // Only re-derive caches whose inputs actually changed.
+            if previous.cadenceId != updated.cadenceId {
+                cadence = cadenceRepository.fetch(id: updated.cadenceId)
+            }
+            if previous.groupIds != updated.groupIds {
+                availableGroups = groups.filter { !updated.groupIds.contains($0.id) }
+            }
+
             NotificationCenter.default.post(name: .personDidChange, object: updated.id)
         } catch let error as RepositoryError {
             AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.savePerson")

--- a/StayInTouch/StayInTouchTests/NotificationSchedulerTests.swift
+++ b/StayInTouch/StayInTouchTests/NotificationSchedulerTests.swift
@@ -841,4 +841,67 @@ final class NotificationSchedulerTests: XCTestCase {
         XCTAssertEqual(request.content.categoryIdentifier, NotificationIdentifier.categoryBirthday,
                        "Single-person birthday notification should retain categoryIdentifier for Log Connection action")
     }
+
+    // MARK: - Debounced observer coalescing (Issue #311 / E5)
+
+    /// A burst of `.personDidChange` posts within the debounce window should
+    /// collapse into a single `scheduleAll()` run. Critically — no post is
+    /// allowed to *replace* notifications with stale state: the eventual
+    /// scheduleAll always sees the latest repository contents.
+    func testScheduleAllDebounced_coalescesBurst_intoSingleScheduleAll() async throws {
+        // Short debounce so the test finishes quickly.
+        let debounce: TimeInterval = 0.1
+        sut = NotificationScheduler(
+            settingsRepository: mockSettingsRepo,
+            personRepository: mockPersonRepo,
+            cadenceRepository: mockCadenceRepo,
+            notificationCenter: mockNotificationCenter,
+            debounceInterval: debounce
+        )
+        mockSettingsRepo.settings = makeSettingsWithNotifications()
+        seedWeeklyGroup()
+        mockPersonRepo.people = [makeOverduePerson(name: "Alice")]
+
+        // Fire a burst of 5 change posts.
+        for _ in 0..<5 {
+            sut.scheduleAllDebounced()
+        }
+
+        // Wait long enough for the debounce window + scheduleAll to finish.
+        try await Task.sleep(nanoseconds: UInt64(debounce * 4 * 1_000_000_000))
+
+        // Exactly one removeAll cycle should have run (= one scheduleAll).
+        XCTAssertEqual(mockNotificationCenter.removeAllCallCount, 1,
+            "5 bursty posts should collapse into 1 scheduleAll() run; got \(mockNotificationCenter.removeAllCallCount)")
+        // And the schedule should have produced at least one notification request
+        // (the overdue person), proving the debounced run actually executed.
+        XCTAssertFalse(mockNotificationCenter.addedRequests.isEmpty,
+            "Debounced scheduleAll should still produce notification requests")
+    }
+
+    /// Posts that are spaced *farther apart* than the debounce window must
+    /// each trigger their own scheduleAll — debouncing must not silently
+    /// drop a legitimate reschedule.
+    func testScheduleAllDebounced_postsBeyondWindow_eachTriggerScheduleAll() async throws {
+        let debounce: TimeInterval = 0.05
+        sut = NotificationScheduler(
+            settingsRepository: mockSettingsRepo,
+            personRepository: mockPersonRepo,
+            cadenceRepository: mockCadenceRepo,
+            notificationCenter: mockNotificationCenter,
+            debounceInterval: debounce
+        )
+        mockSettingsRepo.settings = makeSettingsWithNotifications()
+        seedWeeklyGroup()
+        mockPersonRepo.people = [makeOverduePerson(name: "Alice")]
+
+        sut.scheduleAllDebounced()
+        // Sleep > debounce window so the first scheduleAll completes.
+        try await Task.sleep(nanoseconds: UInt64(debounce * 4 * 1_000_000_000))
+        sut.scheduleAllDebounced()
+        try await Task.sleep(nanoseconds: UInt64(debounce * 4 * 1_000_000_000))
+
+        XCTAssertEqual(mockNotificationCenter.removeAllCallCount, 2,
+            "Two posts separated by > debounce window must each trigger their own scheduleAll()")
+    }
 }

--- a/StayInTouch/StayInTouchTests/PersonDetailViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/PersonDetailViewModelTests.swift
@@ -558,4 +558,60 @@ final class PersonDetailViewModelTests: XCTestCase {
         XCTAssertNil(previewVM.openEmailAction())
         XCTAssertNil(previewVM.routeActionWithValue(.call, value: "+15551234567"))
     }
+
+    // MARK: - In-Place Updates (Issue #311 / E1)
+
+    /// Simple field mutations (toggle pause, mute notifications, etc.) used to
+    /// trigger a full `load()`, refetching cadences, groups, and touch events.
+    /// In-place updates only touch caches whose inputs actually changed.
+    func test_simpleMutation_doesNotRefetchUnrelatedState() {
+        // Reset counters after init's load() call.
+        cadenceRepo.fetchAllCallCount = 0
+        touchRepo.fetchAllForPersonCallCount = 0
+
+        sut.setNotificationsMuted(true)
+
+        XCTAssertTrue(sut.person.notificationsMuted, "Mutation should still update person in place")
+        XCTAssertEqual(cadenceRepo.fetchAllCallCount, 0,
+            "Toggling notifications-muted should not refetch all cadences")
+        XCTAssertEqual(touchRepo.fetchAllForPersonCallCount, 0,
+            "Toggling notifications-muted should not refetch touch events")
+    }
+
+    func test_togglePause_doesNotRefetchUnrelatedState() {
+        cadenceRepo.fetchAllCallCount = 0
+        touchRepo.fetchAllForPersonCallCount = 0
+
+        sut.togglePause()
+
+        XCTAssertTrue(sut.person.isPaused)
+        XCTAssertEqual(cadenceRepo.fetchAllCallCount, 0)
+        XCTAssertEqual(touchRepo.fetchAllForPersonCallCount, 0)
+    }
+
+    func test_changeCadence_refreshesCadenceCache() {
+        let newCadence = TestFactory.makeCadence(name: "Monthly", frequencyDays: 30)
+        cadenceRepo.cadences.append(newCadence)
+
+        sut.changeCadence(to: newCadence.id)
+
+        // Cadence cache should reflect the new selection without a full reload.
+        XCTAssertEqual(sut.cadence?.id, newCadence.id)
+        XCTAssertEqual(sut.person.cadenceId, newCadence.id)
+    }
+
+    func test_addGroup_refreshesAvailableGroups() {
+        let groupA = TestFactory.makeGroup(name: "A")
+        let groupB = TestFactory.makeGroup(name: "B")
+        groupRepo.groups = [groupA, groupB]
+        sut.load()
+
+        XCTAssertEqual(sut.availableGroups.count, 2)
+
+        sut.addGroup(groupA)
+
+        XCTAssertTrue(sut.person.groupIds.contains(groupA.id))
+        XCTAssertEqual(sut.availableGroups.count, 1, "availableGroups should refresh in-place when groupIds changes")
+        XCTAssertEqual(sut.availableGroups.first?.id, groupB.id)
+    }
 }

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
@@ -58,9 +58,13 @@ final class MockPersonRepository: PersonRepository {
 
 final class MockCadenceRepository: CadenceRepository {
     var cadences: [Cadence] = []
+    var fetchAllCallCount = 0
 
     func fetch(id: UUID) -> Cadence? { cadences.first { $0.id == id } }
-    func fetchAll() -> [Cadence] { cadences }
+    func fetchAll() -> [Cadence] {
+        fetchAllCallCount += 1
+        return cadences
+    }
     func fetchDefaultCadences() -> [Cadence] { cadences.filter { $0.isDefault } }
     func save(_ cadence: Cadence) throws {
         if let idx = cadences.firstIndex(where: { $0.id == cadence.id }) {
@@ -105,10 +109,12 @@ class MockTouchEventRepository: TouchEventRepository {
     var events: [TouchEvent] = []
     var savedEvents: [TouchEvent] = []
     var deletedIds: [UUID] = []
+    var fetchAllForPersonCallCount = 0
 
     func fetch(id: UUID) -> TouchEvent? { events.first { $0.id == id } }
     func fetchAll(for personId: UUID) -> [TouchEvent] {
-        events.filter { $0.personId == personId }
+        fetchAllForPersonCallCount += 1
+        return events.filter { $0.personId == personId }
     }
     func fetchAll(since: Date?) -> [TouchEvent] {
         let filtered = since.map { date in events.filter { $0.at >= date } } ?? events


### PR DESCRIPTION
Closes #311. Parent audit: #302. Wave B, PR 3 of 13.

Three coupled efficiency issues in the Person Detail / Notification scheduling path:

## E1 — PersonDetailViewModel.savePerson updates in place
Previously called `load()` after every mutation, refetching person + all cadences + all groups + available groups + all touch events. Toggling pause, muting notifications, saving a next-touch note (~13 entrypoints) all paid the full reload cost.

Now: set `self.person = updated` in place, and only refresh the cadence cache when `cadenceId` changed and `availableGroups` when `groupIds` changed.

## E5 — Debounce NotificationScheduler observer cascade
`.personDidChange` / `.settingsDidChange` re-ran `scheduleAll()` with no coalescing — a single batch edit could fire the entire classification + scheduling pipeline several times.

Added a 1.0s coalescing window via `scheduleAllDebounced()`: bursts within the window collapse to one run; posts beyond the window each get their own run. No reschedule is dropped. Observers deliver on `.main` so the debouncer's shared state is serialized.

## E7 — Batch CNContactStore birthday fetch
`ContactsFetcher.fetchBirthday(identifier:)` instantiated a fresh `CNContactStore` per call. 100 contacts = 100 XPC round-trips.

Added `ContactsFetcher.fetchBirthdays(identifiers:)` that uses one `CNContactStore` and one `unifiedContacts(matching: CNContact.predicateForContacts(withIdentifiers:), keysToFetch:)` call. `scheduleBirthdays` now does two passes — eligibility filter in-memory, then one batch fetch.

## Notification timing preserved

Per audit constraint: the emitted `UNNotificationRequest`s are byte-for-byte identical — same body, title, identifier, trigger, badge, category. Only the *rate* of `scheduleAll()` invocations and the *number* of Contacts XPC calls change. Direct callers in AppDelegate (`didFinishLaunching`, scenePhase, background refresh) continue to call `scheduleAll()` directly and bypass the debouncer.

All existing `NotificationSchedulerTests` pass unchanged.

## Context7 findings cited
- `CNContact.predicateForContacts(withIdentifiers:)` + `unifiedContacts(matching:keysToFetch:)` confirmed as the canonical batch API for fetching multiple unified contacts by identifier in one XPC round-trip (Apple Contacts framework docs).

## Test count delta
+5 new tests (3 PersonDetailViewModel in-place verification, 2 NotificationScheduler debounce semantics). Full suite green (~344 unit tests + UI tests).

## Test plan
- [x] xcodebuild build clean
- [x] xcodebuild test full suite passes
- [x] Existing NotificationSchedulerTests pass unchanged (timing semantics)
- [x] New PersonDetailViewModelTests verify simple mutations no longer refetch unrelated state
- [x] New NotificationScheduler tests verify burst coalescing + window-spaced posts each get a run
- [x] Manual smoke: toggle pause on Person Detail, confirm notifications still scheduled
- [x] Manual smoke: birthday notifications still fire for contacts whose birthday is in CNContact (not Person.birthday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)