### PR TITLE
hotfix: Explicit Sendable on TouchMethod for Swift 6 strict mode

### DIFF
--- a/StayInTouch/StayInTouch/Domain/ValueObjects/TouchMethod.swift
+++ b/StayInTouch/StayInTouch/Domain/ValueObjects/TouchMethod.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum TouchMethod: String, CaseIterable, Codable {
+enum TouchMethod: String, CaseIterable, Codable, Sendable {
     case text = "Text"
     case call = "Call"
     case irl = "IRL"


### PR DESCRIPTION
## Summary

Fixes a latent Swift 6 strict-concurrency compile error in `TouchMethodAppEnum.swift:11` exposed by Xcode 26's default strict-concurrency mode:

> Conformance to 'Sendable' must occur in the same source file as enum 'TouchMethod'; use '@unchecked Sendable' for retroactive conformance; this is an error in the Swift 6 language mode

`AppEnum` inherits `Sendable`, so the existing `extension TouchMethod: AppEnum` in `AppIntents/TouchMethodAppEnum.swift` was adding `Sendable` to `TouchMethod` retroactively — invalid in strict mode.

## Fix

One-line: declare `Sendable` directly on the enum in `Domain/ValueObjects/TouchMethod.swift`:

```swift
enum TouchMethod: String, CaseIterable, Codable, Sendable {
```

`TouchMethod` is a pure String-backed enum with no stored properties beyond the raw value — the conformance is trivially safe, no `@unchecked` needed.

## Verification

- Build with strict concurrency on `iPhone 17 Pro / iOS 26.3.1` simulator → succeeds (previously failed with the error above)
- No behavior change; only the type's protocol conformance list shifts

## Origin

Latent issue introduced by PR #305 (App Intents v1) — the extension that retroactively added Sendable predates the Swift 6 default-strict toggle. Surfaced now because Xcode 26 enables strict concurrency by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)