### PR TITLE
[#316] Tech debt: Batch saves (E4, E8, E12, E6)

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift
@@ -118,6 +118,57 @@ func batchUpsertEntities<Entity: NSManagedObject, Domain>(
 
 // MARK: - Delete by id
 
+// MARK: - Batch delete by ids
+
+/// Deletes all entities whose `id` is in the supplied list in a single
+/// `context.save()` and fires one widget refresh at the end. Missing ids
+/// are no-ops (matches the singular `deleteEntityByID` contract). Empty
+/// input is a no-op — no save, no refresh, no error.
+///
+/// Implementation uses an `IN` predicate to fetch the entities in one
+/// round-trip, then `context.delete` each. We do not use
+/// `NSBatchDeleteRequest` here because:
+///   1. The caller hands us a small, known-bounded set of ids (cascade on
+///      person deletion: typically <100 touch events). The fetch+delete
+///      cost is negligible vs the upside of running through the regular
+///      managed-object change-tracking path (which keeps any in-memory
+///      faults / fetched results controllers consistent without the
+///      merge-into-viewContext dance NSBatchDeleteRequest requires).
+///   2. The cost being optimized is N transactions → 1 transaction (the
+///      audit finding), not N object loads → 0 loads.
+func batchDeleteEntitiesByID<Entity: NSManagedObject>(
+    fetchRequest: @escaping () -> NSFetchRequest<Entity>,
+    ids: [UUID],
+    entityLabel: String,
+    in context: NSManagedObjectContext,
+    refreshWidgets: Bool = true
+) throws {
+    guard !ids.isEmpty else { return }
+    do {
+        try context.performAndWait {
+            let request = fetchRequest()
+            request.predicate = NSPredicate(format: "id IN %@", ids as CVarArg)
+            let entities = (try? context.fetch(request)) ?? []
+            guard !entities.isEmpty else { return }
+            for entity in entities {
+                context.delete(entity)
+            }
+            try context.save()
+        }
+        if refreshWidgets {
+            WidgetRefresher.reloadAllTimelines()
+        }
+    } catch let error as RepositoryError {
+        throw error
+    } catch {
+        // Reuse `.deleteFailed` shape — we surface the first id for diagnostics.
+        // Callers don't need per-id failure detail; the whole batch is atomic.
+        throw RepositoryError.deleteFailed(entity: entityLabel, id: ids.first ?? UUID(), underlying: error)
+    }
+}
+
+// MARK: - Delete by id
+
 /// Deletes the entity with the given id, saves, and optionally reloads widget
 /// timelines. A missing entity is a no-op (matches prior behavior — repos do
 /// not throw on delete-of-nonexistent).

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataTouchEventRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataTouchEventRepository.swift
@@ -90,4 +90,13 @@ final class CoreDataTouchEventRepository: TouchEventRepository {
             in: context
         )
     }
+
+    func batchDelete(ids: [UUID]) throws {
+        try batchDeleteEntitiesByID(
+            fetchRequest: { TouchEventEntity.fetchRequest() },
+            ids: ids,
+            entityLabel: "TouchEvent",
+            in: context
+        )
+    }
 }

--- a/StayInTouch/StayInTouch/Domain/Protocols/TouchEventRepository.swift
+++ b/StayInTouch/StayInTouch/Domain/Protocols/TouchEventRepository.swift
@@ -15,4 +15,9 @@ protocol TouchEventRepository {
     func save(_ touchEvent: TouchEvent) throws
     func batchSave(_ touchEvents: [TouchEvent]) throws
     func delete(id: UUID) throws
+    /// Deletes all events whose `id` is in the supplied list inside a single
+    /// `context.save()` and triggers exactly one widget refresh. A missing id
+    /// is a no-op (matches the singular `delete(id:)` contract). Empty input
+    /// is a no-op — no save, no refresh.
+    func batchDelete(ids: [UUID]) throws
 }

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -180,10 +180,26 @@ final class NotificationScheduler {
 
         await clearAll()
 
-        // Birthday notifications are independent of daily reminders
-        await scheduleBirthdays(settings: settings)
+        // E6: build the entire batch of UNNotificationRequests synchronously
+        // (cheap — random template selection + content/trigger construction),
+        // then issue all `notificationCenter.add(_:)` calls in a single
+        // TaskGroup. Previously each `add` was awaited sequentially even
+        // though every request is independent. The synchronous build phase
+        // preserves the existing relative-order semantics of
+        // `randomElement()` template picks across notification kinds, so the
+        // *set* of scheduled requests is identical to the pre-E6 behavior —
+        // only the I/O issuance overlaps.
+
+        var requests: [UNNotificationRequest] = []
+
+        // Birthday notifications are independent of daily reminders and fire
+        // even when notificationsEnabled is false.
+        requests.append(contentsOf: birthdayRequests(settings: settings))
 
         if !settings.notificationsEnabled {
+            // Still issue any birthday requests built above before resetting
+            // the badge — birthdays are gated on their own setting.
+            await addAll(requests)
             try? await notificationCenter.setBadgeCount(0)
             return
         }
@@ -205,20 +221,30 @@ final class NotificationScheduler {
         let hideNames = settings.hideContactNamesInNotifications
 
         for custom in classified.customOverrides {
-            await scheduleCustomTime(person: custom.person, type: custom.type, time: custom.time, badgeCount: badgeCount, hideNames: hideNames)
+            if let request = customTimeRequest(
+                person: custom.person,
+                type: custom.type,
+                time: custom.time,
+                badgeCount: badgeCount,
+                hideNames: hideNames
+            ) {
+                requests.append(request)
+            }
         }
 
         switch settings.notificationGrouping {
         case .perType:
-            await scheduleDaily(type: .dueToday, people: classified.dueToday, settings: settings, badgeCount: badgeCount)
-            await scheduleDaily(type: .overdue, people: classified.overdue, settings: settings, badgeCount: badgeCount)
-            await scheduleDaily(type: .dueSoon, people: classified.dueSoon, settings: settings, badgeCount: badgeCount)
+            if let r = dailyRequest(type: .dueToday, people: classified.dueToday, settings: settings, badgeCount: badgeCount) { requests.append(r) }
+            if let r = dailyRequest(type: .overdue, people: classified.overdue, settings: settings, badgeCount: badgeCount) { requests.append(r) }
+            if let r = dailyRequest(type: .dueSoon, people: classified.dueSoon, settings: settings, badgeCount: badgeCount) { requests.append(r) }
         case .perDay:
-            await scheduleDailyCombined(people: classified.allNonCustom, settings: settings, badgeCount: badgeCount)
+            if let r = dailyCombinedRequest(people: classified.allNonCustom, settings: settings, badgeCount: badgeCount) {
+                requests.append(r)
+            }
         case .perPerson:
-            await schedulePerPerson(type: .dueToday, people: classified.dueToday, settings: settings, badgeCount: badgeCount)
-            await schedulePerPerson(type: .overdue, people: classified.overdue, settings: settings, badgeCount: badgeCount)
-            await schedulePerPerson(type: .dueSoon, people: classified.dueSoon, settings: settings, badgeCount: badgeCount)
+            requests.append(contentsOf: perPersonRequests(type: .dueToday, people: classified.dueToday, settings: settings, badgeCount: badgeCount))
+            requests.append(contentsOf: perPersonRequests(type: .overdue, people: classified.overdue, settings: settings, badgeCount: badgeCount))
+            requests.append(contentsOf: perPersonRequests(type: .dueSoon, people: classified.dueSoon, settings: settings, badgeCount: badgeCount))
         }
 
         if settings.digestEnabled {
@@ -229,18 +255,52 @@ final class NotificationScheduler {
             // daily alerts are always active at this point.
             let digestPeople = classified.allForDigest
             if digestPeople.count > 1 {
-                await scheduleWeeklyDigest(
+                if let r = weeklyDigestRequest(
                     overdue: digestPeople,
                     dueSoon: [],
                     settings: settings,
                     badgeCount: badgeCount
-                )
+                ) {
+                    requests.append(r)
+                }
+            }
+        }
+
+        await addAll(requests)
+    }
+
+    /// Submits a batch of UNNotificationRequests concurrently. The real
+    /// `UNUserNotificationCenter` is thread-safe and each add is independent
+    /// (different identifier per request), so a TaskGroup is the natural
+    /// fit. Errors are logged per-request and do not abort siblings —
+    /// matches the prior per-call `try? await` semantics.
+    private func addAll(_ requests: [UNNotificationRequest]) async {
+        guard !requests.isEmpty else { return }
+        let center = notificationCenter
+        await withTaskGroup(of: Void.self) { group in
+            for request in requests {
+                let identifier = request.identifier
+                group.addTask {
+                    do {
+                        try await center.add(request)
+                    } catch {
+                        AppLogger.logError(
+                            error,
+                            category: AppLogger.notifications,
+                            context: "NotificationScheduler.addAll(\(identifier))"
+                        )
+                    }
+                }
             }
         }
     }
 
-    private func scheduleDaily(type: DailyNotificationType, people: [Person], settings: AppSettings, badgeCount: Int) async {
-        guard !people.isEmpty else { return }
+    // E6: each `*Request(...)` builder constructs the UNNotificationRequest
+    // synchronously and returns it. `scheduleAll()` collects all requests
+    // and submits them concurrently via `addAll`. Content/trigger
+    // construction is unchanged — only the I/O issuance is parallelized.
+    private func dailyRequest(type: DailyNotificationType, people: [Person], settings: AppSettings, badgeCount: Int) -> UNNotificationRequest? {
+        guard !people.isEmpty else { return nil }
         let triggerDate = nextDailyDate(for: settings.breachTimeOfDay)
 
         let content = UNMutableNotificationContent()
@@ -254,16 +314,11 @@ final class NotificationScheduler {
         }
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
-        let request = UNNotificationRequest(identifier: type.identifier, content: content, trigger: trigger)
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications, context: "NotificationScheduler.scheduleDaily(\(type.identifier))")
-        }
+        return UNNotificationRequest(identifier: type.identifier, content: content, trigger: trigger)
     }
 
-    private func scheduleDailyCombined(people: [Person], settings: AppSettings, badgeCount: Int) async {
-        guard !people.isEmpty else { return }
+    private func dailyCombinedRequest(people: [Person], settings: AppSettings, badgeCount: Int) -> UNNotificationRequest? {
+        guard !people.isEmpty else { return nil }
         let triggerDate = nextDailyDate(for: settings.breachTimeOfDay)
 
         let content = UNMutableNotificationContent()
@@ -274,21 +329,15 @@ final class NotificationScheduler {
         content.userInfo = ["type": "home", "category": "daily"]
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
-        let request = UNNotificationRequest(identifier: NotificationIdentifier.dailyCombined, content: content, trigger: trigger)
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications, context: "NotificationScheduler.scheduleDailyCombined")
-        }
+        return UNNotificationRequest(identifier: NotificationIdentifier.dailyCombined, content: content, trigger: trigger)
     }
 
-    private func schedulePerPerson(type: DailyNotificationType, people: [Person], settings: AppSettings, badgeCount: Int) async {
-        guard !people.isEmpty else { return }
+    private func perPersonRequests(type: DailyNotificationType, people: [Person], settings: AppSettings, badgeCount: Int) -> [UNNotificationRequest] {
+        guard !people.isEmpty else { return [] }
         let triggerDate = nextDailyDate(for: settings.breachTimeOfDay)
-
         let hideNames = settings.hideContactNamesInNotifications
 
-        for person in people {
+        return people.map { person in
             let content = UNMutableNotificationContent()
             content.title = type.title
             if hideNames {
@@ -302,18 +351,13 @@ final class NotificationScheduler {
             content.categoryIdentifier = NotificationIdentifier.categoryPerson
 
             let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
-            let request = UNNotificationRequest(identifier: "\(type.identifier)_\(person.id.uuidString)", content: content, trigger: trigger)
-            do {
-                try await notificationCenter.add(request)
-            } catch {
-                AppLogger.logError(error, category: AppLogger.notifications, context: "NotificationScheduler.schedulePerPerson(\(type.identifier), \(person.id))")
-            }
+            return UNNotificationRequest(identifier: "\(type.identifier)_\(person.id.uuidString)", content: content, trigger: trigger)
         }
     }
 
-    private func scheduleWeeklyDigest(overdue: [Person], dueSoon: [Person], settings: AppSettings, badgeCount: Int) async {
+    private func weeklyDigestRequest(overdue: [Person], dueSoon: [Person], settings: AppSettings, badgeCount: Int) -> UNNotificationRequest? {
         let all = overdue + dueSoon
-        guard !all.isEmpty else { return }
+        guard !all.isEmpty else { return nil }
 
         let triggerDate = nextWeeklyDate(day: settings.digestDay, time: settings.digestTime)
 
@@ -325,12 +369,7 @@ final class NotificationScheduler {
         content.userInfo = notificationUserInfo(for: all, type: "digest")
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
-        let request = UNNotificationRequest(identifier: NotificationIdentifier.weeklyDigest, content: content, trigger: trigger)
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications, context: "NotificationScheduler.scheduleWeeklyDigest")
-        }
+        return UNNotificationRequest(identifier: NotificationIdentifier.weeklyDigest, content: content, trigger: trigger)
     }
 
     private func notificationBody(for people: [Person], hideNames: Bool) -> String {
@@ -388,7 +427,7 @@ final class NotificationScheduler {
 }
 
 private extension NotificationScheduler {
-    func scheduleCustomTime(person: Person, type: DailyNotificationType, time: LocalTime, badgeCount: Int, hideNames: Bool) async {
+    func customTimeRequest(person: Person, type: DailyNotificationType, time: LocalTime, badgeCount: Int, hideNames: Bool) -> UNNotificationRequest? {
         let triggerDate = nextDailyDate(for: time)
         let content = UNMutableNotificationContent()
         content.title = type.title
@@ -403,16 +442,11 @@ private extension NotificationScheduler {
         content.categoryIdentifier = NotificationIdentifier.categoryPerson
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
-        let request = UNNotificationRequest(identifier: "\(type.identifier)_custom_\(person.id.uuidString)", content: content, trigger: trigger)
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications, context: "NotificationScheduler.scheduleCustomTime(\(type.identifier), \(person.id))")
-        }
+        return UNNotificationRequest(identifier: "\(type.identifier)_custom_\(person.id.uuidString)", content: content, trigger: trigger)
     }
 
-    func scheduleBirthdays(settings: AppSettings) async {
-        guard settings.birthdayNotificationsEnabled else { return }
+    func birthdayRequests(settings: AppSettings) -> [UNNotificationRequest] {
+        guard settings.birthdayNotificationsEnabled else { return [] }
 
         let ignoreSnoozePause = settings.birthdayIgnoreSnoozePause
         let people = personRepository.fetchTracked(includePaused: ignoreSnoozePause)
@@ -456,16 +490,18 @@ private extension NotificationScheduler {
             groups[key, default: []].append((person, birthday))
         }
 
+        var requests: [UNNotificationRequest] = []
         for (key, pairs) in groups {
             if pairs.count == 1, let (person, birthday) = pairs.first {
-                await scheduleSingleBirthday(person: person, birthday: birthday, time: time, hideNames: hideNames)
+                requests.append(singleBirthdayRequest(person: person, birthday: birthday, time: time, hideNames: hideNames))
             } else {
-                await scheduleGroupedBirthday(people: pairs.map(\.0), month: key.month, day: key.day, time: time, hideNames: hideNames)
+                requests.append(groupedBirthdayRequest(people: pairs.map(\.0), month: key.month, day: key.day, time: time, hideNames: hideNames))
             }
         }
+        return requests
     }
 
-    private func scheduleSingleBirthday(person: Person, birthday: Birthday, time: LocalTime, hideNames: Bool) async {
+    private func singleBirthdayRequest(person: Person, birthday: Birthday, time: LocalTime, hideNames: Bool) -> UNNotificationRequest {
         let content = UNMutableNotificationContent()
         content.title = "Birthday Today 🎂"
         if hideNames {
@@ -494,21 +530,14 @@ private extension NotificationScheduler {
         dateComponents.minute = time.minute
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-        let request = UNNotificationRequest(
+        return UNNotificationRequest(
             identifier: "\(NotificationIdentifier.birthdayPrefix)\(person.id.uuidString)",
             content: content,
             trigger: trigger
         )
-
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications,
-                context: "NotificationScheduler.scheduleSingleBirthday(\(person.id))")
-        }
     }
 
-    private func scheduleGroupedBirthday(people: [Person], month: Int, day: Int, time: LocalTime, hideNames: Bool) async {
+    private func groupedBirthdayRequest(people: [Person], month: Int, day: Int, time: LocalTime, hideNames: Bool) -> UNNotificationRequest {
         let content = UNMutableNotificationContent()
         content.title = "Birthdays Today 🎂"
         content.body = groupedBirthdayBody(for: people, hideNames: hideNames)
@@ -527,18 +556,11 @@ private extension NotificationScheduler {
         dateComponents.minute = time.minute
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-        let request = UNNotificationRequest(
+        return UNNotificationRequest(
             identifier: "\(NotificationIdentifier.birthdayGroupedPrefix)\(month)_\(day)",
             content: content,
             trigger: trigger
         )
-
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.notifications,
-                context: "NotificationScheduler.scheduleGroupedBirthday(\(month)/\(day))")
-        }
     }
 
     private func groupedBirthdayBody(for people: [Person], hideNames: Bool) -> String {

--- a/StayInTouch/StayInTouch/Notifications/UserNotificationCenterProtocol.swift
+++ b/StayInTouch/StayInTouch/Notifications/UserNotificationCenterProtocol.swift
@@ -5,7 +5,11 @@
 
 import UserNotifications
 
-protocol UserNotificationCenterProtocol {
+// Sendable so concrete implementations can be captured by Swift concurrency
+// constructs (TaskGroup, async let). `UNUserNotificationCenter` is documented
+// thread-safe; `MockUserNotificationCenter` is `@unchecked Sendable` with an
+// internal lock guarding all mutable state.
+protocol UserNotificationCenterProtocol: Sendable {
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
     func add(_ request: UNNotificationRequest) async throws
     func setBadgeCount(_ newBadgeCount: Int) async throws

--- a/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
@@ -66,16 +66,30 @@ final class CadenceContactsViewModel: ObservableObject {
 
     func addPeople(_ personIds: [UUID]) {
         let useCase = AssignCadenceUseCase()
-        for person in allPeople where personIds.contains(person.id) {
-            let updated = useCase.assign(person: person, to: cadence.id)
-            do {
-                try personRepository.save(updated)
-            } catch {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "CadenceContactsViewModel.addPeople")
-                ErrorToastManager.shared.show(.saveFailed("CadenceContacts"))
-            }
-            NotificationCenter.default.post(name: .personDidChange, object: updated.id)
+        // E12: batch the writes into one save + one .personDidChange post.
+        // Prior loop did N saves and posted N notifications — every observer
+        // (HomeView, ContactsListView, SettingsView, StatsView,
+        // NotificationScheduler debouncer) ran N times. All five are "reload
+        // my data" handlers with no per-person dependency, so collapsing to
+        // a single post is safe and strictly fewer reloads. The scheduler's
+        // 1s debouncer would have coalesced anyway; this also covers the
+        // SwiftUI observers that bypass it.
+        let updates = allPeople
+            .filter { personIds.contains($0.id) }
+            .map { useCase.assign(person: $0, to: cadence.id) }
+        guard !updates.isEmpty else {
+            load()
+            return
         }
+        do {
+            try personRepository.batchSave(updates)
+        } catch {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: "CadenceContactsViewModel.addPeople")
+            ErrorToastManager.shared.show(.saveFailed("CadenceContacts"))
+        }
+        // Pass nil as object since the post covers a set of people; observers
+        // ignore the object payload (they reload everything anyway).
+        NotificationCenter.default.post(name: .personDidChange, object: nil)
         load()
     }
 }

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -420,11 +420,13 @@ final class PersonDetailViewModel: ObservableObject {
         if isPreview { return }
         AnalyticsService.track("person.deleted")
         do {
-            // Cascade: delete all TouchEvents for this person first
+            // E8: cascade-delete all TouchEvents for this person in one save
+            // + one widget refresh instead of N transactions / N refreshes.
+            // batchDelete is a no-op when events is empty, matching the
+            // prior loop-with-empty-array behavior.
             let events = touchRepository.fetchAll(for: person.id)
-            for event in events {
-                try touchRepository.delete(id: event.id)
-            }
+            let eventIds = events.map(\.id)
+            try touchRepository.batchDelete(ids: eventIds)
             try personRepository.delete(id: person.id)
             NotificationCenter.default.post(name: .personDidChange, object: person.id)
         } catch let error as RepositoryError {

--- a/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
+++ b/StayInTouch/StayInTouch/Utilities/Helpers/ContactsSyncService.swift
@@ -21,10 +21,17 @@ enum ContactsSyncService {
         let byId = Dictionary(uniqueKeysWithValues: summaries.map { ($0.identifier, $0) })
         let backgroundContext = CoreDataStack.shared.newBackgroundContext()
 
-        await backgroundContext.perform {
+        // E4: collect all per-row updates and issue a single batchSave + one
+        // widget refresh. Previously 100 contacts on refresh = 100 Core Data
+        // transactions + 100 WidgetRefresher.reloadAllTimelines() calls. We
+        // preserve the existing skip-if-already-marked behavior so the set
+        // of rows that change is identical to the per-row version.
+        let updates: [Person] = await backgroundContext.perform {
             let repo = CoreDataPersonRepository(context: backgroundContext)
             let people = repo.fetchTracked(includePaused: true)
             let now = Date()
+            var changed: [Person] = []
+            changed.reserveCapacity(people.count)
 
             for person in people {
                 guard let cnId = person.cnIdentifier else { continue }
@@ -52,12 +59,26 @@ enum ContactsSyncService {
                 }
 
                 updated.modifiedAt = now
-                do {
-                    try repo.save(updated)
-                } catch {
-                    AppLogger.logError(error, category: AppLogger.coreData, context: "ContactsSyncService.syncExistingContacts")
-                }
+                changed.append(updated)
             }
+            return changed
+        }
+
+        guard !updates.isEmpty else {
+            await MainActor.run {
+                NotificationCenter.default.post(name: .contactsDidSync, object: nil)
+            }
+            return
+        }
+
+        do {
+            // batchUpsertEntities runs inside its own performAndWait on the
+            // background context, executes a single context.save(), and fires
+            // one WidgetRefresher.reloadAllTimelines() at the end.
+            let repo = CoreDataPersonRepository(context: backgroundContext)
+            try repo.batchSave(updates)
+        } catch {
+            AppLogger.logError(error, category: AppLogger.coreData, context: "ContactsSyncService.syncExistingContacts")
         }
 
         await MainActor.run {

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
@@ -142,6 +142,14 @@ class MockTouchEventRepository: TouchEventRepository {
         deletedIds.append(id)
         events.removeAll { $0.id == id }
     }
+    var batchDeleteCallCount = 0
+    func batchDelete(ids: [UUID]) throws {
+        batchDeleteCallCount += 1
+        for id in ids {
+            deletedIds.append(id)
+        }
+        events.removeAll { ids.contains($0.id) }
+    }
 }
 
 // MARK: - MockSettingsRepository

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockUserNotificationCenter.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockUserNotificationCenter.swift
@@ -14,30 +14,56 @@ final class MockUserNotificationCenter: UserNotificationCenterProtocol, @uncheck
         case setCategories
     }
 
-    var addedRequests: [UNNotificationRequest] = []
-    var categoriesSet: Set<UNNotificationCategory> = []
-    var badgeCounts: [Int] = []
-    var removeAllCallCount = 0
-    private(set) var operations: [Operation] = []
+    // E6 added concurrent `notificationCenter.add` calls via TaskGroup
+    // inside the scheduler. Real `UNUserNotificationCenter` is documented
+    // thread-safe; this mock must be too. Guard all mutable state behind
+    // a lock so parallel `add(_:)` calls cannot race on `Array.append`.
+    private let lock = NSLock()
+    private var _addedRequests: [UNNotificationRequest] = []
+    private var _categoriesSet: Set<UNNotificationCategory> = []
+    private var _badgeCounts: [Int] = []
+    private var _removeAllCallCount = 0
+    private var _operations: [Operation] = []
+
+    var addedRequests: [UNNotificationRequest] {
+        get { lock.lock(); defer { lock.unlock() }; return _addedRequests }
+        set { lock.lock(); defer { lock.unlock() }; _addedRequests = newValue }
+    }
+    var categoriesSet: Set<UNNotificationCategory> {
+        get { lock.lock(); defer { lock.unlock() }; return _categoriesSet }
+    }
+    var badgeCounts: [Int] {
+        get { lock.lock(); defer { lock.unlock() }; return _badgeCounts }
+    }
+    var removeAllCallCount: Int {
+        get { lock.lock(); defer { lock.unlock() }; return _removeAllCallCount }
+    }
+    var operations: [Operation] {
+        get { lock.lock(); defer { lock.unlock() }; return _operations }
+    }
 
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {
-        categoriesSet = categories
-        operations.append(.setCategories)
+        lock.lock(); defer { lock.unlock() }
+        _categoriesSet = categories
+        _operations.append(.setCategories)
     }
 
     func add(_ request: UNNotificationRequest) async throws {
-        addedRequests.append(request)
-        operations.append(.add(request))
+        lock.lock(); defer { lock.unlock() }
+        _addedRequests.append(request)
+        _operations.append(.add(request))
     }
 
     func setBadgeCount(_ newBadgeCount: Int) async throws {
-        badgeCounts.append(newBadgeCount)
-        operations.append(.setBadge(newBadgeCount))
+        lock.lock(); defer { lock.unlock() }
+        _badgeCounts.append(newBadgeCount)
+        _operations.append(.setBadge(newBadgeCount))
     }
 
     func removeAllPendingNotificationRequests() {
-        removeAllCallCount += 1
-        addedRequests = []
-        operations.append(.removeAll)
+        lock.lock(); defer { lock.unlock() }
+        _removeAllCallCount += 1
+        _addedRequests = []
+        _operations.append(.removeAll)
     }
 }


### PR DESCRIPTION
PR 4 of the 13-PR tech-debt refactor (parent audit #302). Four independent batch/concurrency efficiency wins. Zero observable behavior change — same writes, same notifications, same widget state — just fewer transactions, fewer widget refreshes, fewer round-trips to the user-notifications daemon.

Closes #316.

## Findings addressed

| ID  | File | Before | After |
|-----|------|--------|-------|
| E4  | ContactsSyncService.swift | N saves, N widget refreshes per sync | 1 batchSave, 1 widget refresh |
| E8  | PersonDetailViewModel.deletePerson | N+1 transactions (per touch event + person) | 2 transactions (batch touches, then person) |
| E12 | CadenceContactsViewModel.addPeople | N saves, N \`.personDidChange\` posts | 1 batchSave, 1 post |
| E6  | NotificationScheduler.scheduleAll | Sequential awaits on each \`UNNotificationCenter.add\` | All adds submitted concurrently via TaskGroup |

## Approach

Re-uses Wave A helpers established in PRs #321-#323:
- E4 and E12 go through \`CoreDataRepositoryHelpers.batchUpsertEntities\` via \`PersonRepository.batchSave\`.
- E8 adds a parallel free helper \`batchDeleteEntitiesByID\` (same shape as the existing batch upsert: IN-predicate fetch, \`context.delete\` each, single \`context.save\`, one widget refresh). Adds \`TouchEventRepository.batchDelete(ids:)\` to the protocol. Considered \`NSBatchDeleteRequest\` — comment in the helper explains why a regular fetch+delete is the right call for our bounded cascade size.
- E6 splits each \`schedule*\` method into a synchronous \`*Request\` builder + a shared \`addAll(_:)\` that wraps all additions in \`withTaskGroup\`. The synchronous build phase preserves the existing random-template-selection order across notification kinds, so the *set* of scheduled requests is identical to pre-change behavior — only the I/O issuance overlaps.

## Behavior preservation

| Concern | Verification |
|---------|--------------|
| Same contacts get synced | Filter logic preserved (cnIdentifier present, then found-in-summary or already-unavailable skip) |
| Same touch events get deleted on person delete | Same \`touchRepository.fetchAll(for: person.id)\` source; empty case is a no-op |
| Same people end up in cadence | Same \`AssignCadenceUseCase\` calls, just collected and batched |
| \`.personDidChange\` collapse N→1 safe | Audited all 5 observers (HomeView, ContactsListView, SettingsView, StatsView, NotificationScheduler debouncer) — all are full-reload handlers with no per-person dependency. The scheduler's 1s debouncer would have coalesced anyway. |
| Same notification identifiers/content/triggers | Builder methods construct identical requests; tests assert identifier set membership which is unchanged |
| \`removeAll\` still precedes any \`add\` | \`clearAll\` runs before any builder; \`addAll\` runs after all builders |
| \`setBadgeCount(0)\` in notificationsEnabled=false path | Still issued after addAll (which may have added birthday requests gated on the separate \`birthdayNotificationsEnabled\` setting) |

## Concurrency

- \`UserNotificationCenterProtocol\` declared \`Sendable\` so concrete implementations can be captured by TaskGroup. \`UNUserNotificationCenter\` is documented thread-safe.
- \`MockUserNotificationCenter\`: guard all mutable state behind an \`NSLock\` so concurrent \`add(_:)\` calls cannot race on \`Array.append\`. Public properties keep the same shape (gettable arrays/counts) so existing tests need no changes.

## Tests

Full suite passes (610+ test cases, 0 failures, 0 skips beyond pre-existing). No tests added — the changes preserve behavior asserted by the existing suite (\`PersonDetailViewModelTests.testDeletePersonCascadesDeletesTouchEvents\`, \`CadenceContactsViewModelTests.testAddPeopleSavesEachPerson\`, the entire NotificationSchedulerTests battery including identifier-membership and removeAll-before-add ordering).

## Files changed

- \`StayInTouch/Utilities/Helpers/ContactsSyncService.swift\` (E4)
- \`StayInTouch/Domain/Protocols/TouchEventRepository.swift\` (E8)
- \`StayInTouch/Data/CoreData/Repositories/CoreDataRepositoryHelpers.swift\` (E8 helper)
- \`StayInTouch/Data/CoreData/Repositories/CoreDataTouchEventRepository.swift\` (E8 wire-up)
- \`StayInTouch/UI/ViewModels/PersonDetailViewModel.swift\` (E8)
- \`StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift\` (E12)
- \`StayInTouch/Notifications/NotificationScheduler.swift\` (E6)
- \`StayInTouch/Notifications/UserNotificationCenterProtocol.swift\` (E6 Sendable)
- \`StayInTouchTests/TestHelpers/MockRepositories.swift\` (E8 mock)
- \`StayInTouchTests/TestHelpers/MockUserNotificationCenter.swift\` (E6 lock guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)