### PR TITLE
[#317] Tech debt: List-render efficiency (E2, E3, E9, E13)

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataGroupRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataGroupRepository.swift
@@ -63,4 +63,17 @@ final class CoreDataGroupRepository: GroupRepository {
             in: context
         )
     }
+
+    func count() -> Int {
+        var count = 0
+        context.performAndWait {
+            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
+            // `count(for:)` returns the row count without faulting any
+            // managed objects into memory — used by Settings to render
+            // the group count badge without loading every Group (audit
+            // E9, #317).
+            count = (try? context.count(for: request)) ?? 0
+        }
+        return count
+    }
 }

--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
@@ -155,6 +155,20 @@ final class CoreDataPersonRepository: PersonRepository {
         )
     }
 
+    func pausedCount() -> Int {
+        var count = 0
+        context.performAndWait {
+            let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "isTracked == YES AND isPaused == YES")
+            // `count(for:)` returns the row count from the underlying store
+            // without faulting the matching managed objects into memory.
+            // Equivalent to `fetchTracked(includePaused: true).filter(isPaused).count`
+            // but without the materialization cost (audit E9, #317).
+            count = (try? context.count(for: request)) ?? 0
+        }
+        return count
+    }
+
     private func basePredicate(includePaused: Bool) -> NSPredicate {
         if includePaused {
             return NSPredicate(format: "isTracked == YES")

--- a/StayInTouch/StayInTouch/Domain/Protocols/GroupRepository.swift
+++ b/StayInTouch/StayInTouch/Domain/Protocols/GroupRepository.swift
@@ -13,4 +13,8 @@ protocol GroupRepository {
     func save(_ group: Group) throws
     func batchSave(_ groups: [Group]) throws
     func delete(id: UUID) throws
+
+    /// Returns the total number of groups without faulting any rows into
+    /// memory. Backed by Core Data's `count(for:)` (audit E9, #317).
+    func count() -> Int
 }

--- a/StayInTouch/StayInTouch/Domain/Protocols/PersonRepository.swift
+++ b/StayInTouch/StayInTouch/Domain/Protocols/PersonRepository.swift
@@ -18,4 +18,11 @@ protocol PersonRepository {
     func save(_ person: Person) throws
     func batchSave(_ persons: [Person]) throws
     func delete(id: UUID) throws
+
+    /// Returns the number of currently-paused tracked people without
+    /// faulting the matching rows into memory. Backed by Core Data's
+    /// `count(for:)` (audit E9, #317) — orders of magnitude cheaper than
+    /// fetching every tracked person and filtering in Swift just to read
+    /// a display count.
+    func pausedCount() -> Int
 }

--- a/StayInTouch/StayInTouch/Notifications/NotificationClassifier.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationClassifier.swift
@@ -36,10 +36,13 @@ enum NotificationClassifier {
         var customOverrides: [CustomNotification] = []
 
         let calc = FrequencyCalculator(referenceDate: referenceDate)
+        // Build id→cadence once so per-person lookups are O(1) instead of
+        // O(M) (audit E3, #317). Behavior identical — same cadence resolves.
+        let cadencesById = Dictionary(uniqueKeysWithValues: cadences.map { ($0.id, $0) })
 
         for person in people where !person.isPaused && !person.notificationsMuted && !person.isSnoozed(at: referenceDate) {
-            guard let cadence = cadences.first(where: { $0.id == person.cadenceId }) else { continue }
-            guard let daysUntilDue = calc.daysUntilDue(for: person, in: cadences) else { continue }
+            guard let cadence = cadencesById[person.cadenceId] else { continue }
+            guard let daysUntilDue = calc.daysUntilDue(for: person, cadencesById: cadencesById) else { continue }
 
             let type: DailyNotificationType?
             if daysUntilDue < 0 {

--- a/StayInTouch/StayInTouch/Shared/FrequencyCalculator.swift
+++ b/StayInTouch/StayInTouch/Shared/FrequencyCalculator.swift
@@ -20,13 +20,29 @@ struct FrequencyCalculator {
         for person: P,
         in cadences: [C]
     ) -> ContactStatus {
+        status(for: person, cadence: cadences.first(where: { $0.id == person.cadenceId }))
+    }
+
+    /// Dict-based overload. Avoids the O(N) linear scan that the
+    /// `[C]` overload performs per call — at list-render hot paths (Home,
+    /// Contacts) this turns an O(N×M) sweep into O(N) (audit E3, #317).
+    /// Behavior is identical: the same cadence is resolved by id.
+    func status<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadencesById: [UUID: C]
+    ) -> ContactStatus {
+        status(for: person, cadence: cadencesById[person.cadenceId])
+    }
+
+    private func status<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadence: C?
+    ) -> ContactStatus {
         if person.isPaused { return .onTrack }
         if person.isSnoozed(at: referenceDate) { return .onTrack }
-        guard let cadence = cadences.first(where: { $0.id == person.cadenceId }) else {
-            return .onTrack
-        }
+        guard let cadence else { return .onTrack }
 
-        guard let dueDate = effectiveDueDate(for: person, in: cadences) else {
+        guard let dueDate = effectiveDueDate(for: person, cadence: cadence) else {
             return .unknown
         }
 
@@ -44,13 +60,26 @@ struct FrequencyCalculator {
         for person: P,
         in cadences: [C]
     ) -> Int {
+        daysOverdue(for: person, cadence: cadences.first(where: { $0.id == person.cadenceId }))
+    }
+
+    /// Dict-based overload (see `status(for:cadencesById:)` for rationale).
+    func daysOverdue<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadencesById: [UUID: C]
+    ) -> Int {
+        daysOverdue(for: person, cadence: cadencesById[person.cadenceId])
+    }
+
+    private func daysOverdue<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadence: C?
+    ) -> Int {
         if person.isPaused { return 0 }
         if person.isSnoozed(at: referenceDate) { return 0 }
-        guard cadences.first(where: { $0.id == person.cadenceId }) != nil else {
-            return 0
-        }
+        guard let cadence else { return 0 }
 
-        guard let dueDate = effectiveDueDate(for: person, in: cadences) else {
+        guard let dueDate = effectiveDueDate(for: person, cadence: cadence) else {
             return 0
         }
 
@@ -62,8 +91,23 @@ struct FrequencyCalculator {
         for person: P,
         in cadences: [C]
     ) -> Date? {
+        effectiveDueDate(for: person, cadence: cadences.first(where: { $0.id == person.cadenceId }))
+    }
+
+    /// Dict-based overload (see `status(for:cadencesById:)` for rationale).
+    func effectiveDueDate<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadencesById: [UUID: C]
+    ) -> Date? {
+        effectiveDueDate(for: person, cadence: cadencesById[person.cadenceId])
+    }
+
+    private func effectiveDueDate<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadence: C?
+    ) -> Date? {
         let cal = Calendar.current
-        guard let cadence = cadences.first(where: { $0.id == person.cadenceId }) else { return nil }
+        guard let cadence else { return nil }
 
         let cadenceDueDate: Date?
         if let lastTouch = effectiveLastTouchDate(for: person) {
@@ -120,6 +164,15 @@ struct FrequencyCalculator {
         in cadences: [C]
     ) -> Int? {
         guard let dueDate = effectiveDueDate(for: person, in: cadences) else { return nil }
+        return calendarDaysBetween(from: referenceDate, to: dueDate)
+    }
+
+    /// Dict-based overload (see `status(for:cadencesById:)` for rationale).
+    func daysUntilDue<P: FrequencyCalculatorPerson, C: FrequencyCalculatorCadence>(
+        for person: P,
+        cadencesById: [UUID: C]
+    ) -> Int? {
+        guard let dueDate = effectiveDueDate(for: person, cadencesById: cadencesById) else { return nil }
         return calendarDaysBetween(from: referenceDate, to: dueDate)
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/ContactsListViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ContactsListViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  ContactsListViewModel.swift
+//  KeepInTouch
+//
+//  Owns the derived state for the Contacts tab: the alphabetically-sorted
+//  filtered list, its A–Z section grouping, and the section-letter index.
+//
+//  Previously these lived as plain computed properties on
+//  `ContactsListView`, so every body render walked the full contact list
+//  twice (`filter` + `sort`) and ran `Dictionary(grouping:)` to bucket
+//  into sections. With `HomeViewModel` published changes churning at
+//  high frequency, that turned the Contacts tab into an O(N log N) hot
+//  path on every render (audit E2, #317).
+//
+//  Per Apple's "Managing model data in your app" guidance, derived state
+//  belongs in the view model, not in `body`. Inputs are:
+//    1. `HomeViewModel.allPeople` (observed via Combine `sink`)
+//    2. local `searchText` (assigned via `updateSearchText`)
+//  Any other input that begins to feed the list MUST be wired here or
+//  the displayed contacts will go stale.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class ContactsListViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var filteredPeople: [Person] = []
+    @Published private(set) var sections: [ContactsSection] = []
+    @Published private(set) var sectionLetters: [String] = []
+
+    private weak var homeViewModel: HomeViewModel?
+    private var cancellables: Set<AnyCancellable> = []
+
+    struct ContactsSection: Equatable, Identifiable {
+        let letter: String
+        let people: [Person]
+        var id: String { letter }
+    }
+
+    init() {}
+
+    /// Wires the upstream `HomeViewModel.allPeople` and local `searchText`
+    /// publishers so the derived list stays in sync. Idempotent — calling
+    /// twice with the same instance re-subscribes (safe: the prior
+    /// `cancellables` set is replaced).
+    func bind(to homeViewModel: HomeViewModel) {
+        self.homeViewModel = homeViewModel
+        cancellables = []
+
+        // CombineLatest keeps both inputs in scope so the first emission
+        // (after subscription) carries the current allPeople and the
+        // current searchText, not a default empty value.
+        homeViewModel.$allPeople
+            .combineLatest($searchText)
+            .sink { [weak self] people, query in
+                self?.recompute(from: people, query: query)
+            }
+            .store(in: &cancellables)
+    }
+
+    func updateSearchText(_ text: String) {
+        searchText = text
+    }
+
+    // MARK: - Private
+
+    private func recompute(from people: [Person], query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let filtered: [Person]
+        if trimmed.isEmpty {
+            filtered = people
+        } else {
+            filtered = people.filter {
+                $0.displayName.lowercased().contains(trimmed) ||
+                ($0.nickname?.lowercased().contains(trimmed) ?? false)
+            }
+        }
+        let sorted = filtered.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+
+        let grouped = Dictionary(grouping: sorted) { person -> String in
+            let first = person.displayName.prefix(1).uppercased()
+            return first.rangeOfCharacter(from: .letters) != nil ? first : "#"
+        }
+        let newSections = grouped
+            .sorted { $0.key < $1.key }
+            .map { ContactsSection(letter: $0.key, people: $0.value) }
+
+        filteredPeople = sorted
+        sections = newSections
+        sectionLetters = newSections.map(\.letter)
+    }
+}

--- a/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
@@ -18,6 +18,15 @@ final class HomeViewModel: ObservableObject {
     @Published private(set) var groups: [Group] = []
     @Published private(set) var settings: AppSettings?
 
+    /// Derived id→entity dictionaries kept in sync with `cadences`/`groups`
+    /// in `load()`. Previously HomeView built these inside `body` on every
+    /// render, which is wasteful on a 60-FPS hot path with 100+ contacts
+    /// (audit E13, #317). The only inputs are `cadences` and `groups`, both
+    /// of which are only mutated by `load()`, so rebuilding there is
+    /// behavior-preserving — the dicts cannot drift from their source arrays.
+    @Published private(set) var cadencesById: [UUID: Cadence] = [:]
+    @Published private(set) var groupsById: [UUID: Group] = [:]
+
     @Published private(set) var overduePeople: [Person] = []
     @Published private(set) var dueSoonPeople: [Person] = []
     @Published private(set) var allGoodPeople: [Person] = []
@@ -79,6 +88,12 @@ final class HomeViewModel: ObservableObject {
         cadences = cadenceRepository.fetchAll()
         groups = groupRepository.fetchAll()
         allPeople = personRepository.fetchTracked(includePaused: true)
+
+        // Rebuild derived id→entity dicts whenever their inputs change.
+        // `cadences`/`groups` are only mutated here, so this is the
+        // single sync point (audit E13, #317).
+        cadencesById = Dictionary(uniqueKeysWithValues: cadences.map { ($0.id, $0) })
+        groupsById = Dictionary(uniqueKeysWithValues: groups.map { ($0.id, $0) })
 
         applyFilters()
         refreshToken = UUID()

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -83,10 +83,18 @@ final class SettingsViewModel: ObservableObject {
 
     func load() {
         settings = settingsRepository.fetch() ?? AppSettingsDefaults.defaultSettings()
+        // `allCadences` is needed downstream (Settings passes it into the
+        // cadence manager), so we still materialize the list. `cadencesCount`
+        // is derived from it for free.
         allCadences = cadenceRepository.fetchAll()
         cadencesCount = allCadences.count
-        groupsCount = groupRepository.fetchAll().count
-        pausedCount = personRepository.fetchTracked(includePaused: true).filter { $0.isPaused }.count
+        // Groups and paused-people counts are display-only — read them via
+        // `count(for:)` instead of fetching every row and counting in
+        // Swift (audit E9, #317). For typical cellars this is the same
+        // value; for large datasets it avoids loading hundreds of
+        // managed objects just to render two badges.
+        groupsCount = groupRepository.count()
+        pausedCount = personRepository.pausedCount()
     }
 
     func setTheme(_ theme: Theme) {

--- a/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
@@ -30,7 +30,11 @@ struct ContactsListView: View {
                     systemImage: "person.2.slash"
                 )
                 Spacer()
-            } else if listViewModel.filteredPeople.isEmpty {
+            } else if listViewModel.filteredPeople.isEmpty && !listViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                // "No contacts found" message only makes sense when actively
+                // searching. Otherwise an empty `filteredPeople` is just the
+                // one-frame gap before `.onAppear` wires the Combine binding
+                // — render the list (which will populate momentarily).
                 Spacer()
                 EmptyStateView(
                     title: "No contacts found",
@@ -63,8 +67,17 @@ struct ContactsListView: View {
     // MARK: - Header
 
     private var contactsHeader: some View {
-        HStack {
-            Text("\(listViewModel.filteredPeople.count) Contacts")
+        // Until the Combine binding wires up (`.onAppear` runs after the
+        // first body render), `listViewModel.filteredPeople` is empty
+        // even though `viewModel.allPeople` has items. Fall back to the
+        // upstream count when there's no active search — same value the
+        // user expects post-bind, just available a frame earlier.
+        let trimmedQuery = listViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let count = trimmedQuery.isEmpty && listViewModel.filteredPeople.isEmpty
+            ? viewModel.allPeople.count
+            : listViewModel.filteredPeople.count
+        return HStack {
+            Text("\(count) Contacts")
                 .font(DS.Typography.homeSubtitle)
                 .foregroundStyle(Color(.secondaryLabel))
             Spacer()

--- a/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Contacts/ContactsListView.swift
@@ -10,38 +10,11 @@ struct ContactsListView: View {
     @ObservedObject var selectionCoordinator: SelectionCoordinator
     var recentGroups: [RecentGroup]
     var selectPerson: (Person) -> Void
-    @State private var searchText = ""
 
-    // MARK: - Computed Data
-
-    private var filteredPeople: [Person] {
-        let people = viewModel.allPeople
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else {
-            return people.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-            }
-        }
-        return people.filter {
-            $0.displayName.lowercased().contains(query) ||
-            ($0.nickname?.lowercased().contains(query) ?? false)
-        }.sorted {
-            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-        }
-    }
-
-    private var sections: [(letter: String, people: [Person])] {
-        let grouped = Dictionary(grouping: filteredPeople) { person -> String in
-            let first = person.displayName.prefix(1).uppercased()
-            return first.rangeOfCharacter(from: .letters) != nil ? first : "#"
-        }
-        return grouped.sorted { $0.key < $1.key }
-            .map { (letter: $0.key, people: $0.value) }
-    }
-
-    private var sectionLetters: [String] {
-        sections.map(\.letter)
-    }
+    // Derived list state (filteredPeople, sections, sectionLetters) lives on
+    // the view model so it only recomputes when its inputs (allPeople,
+    // searchText) actually change — not on every body render (audit E2, #317).
+    @StateObject private var listViewModel = ContactsListViewModel()
 
     // MARK: - Body
 
@@ -57,7 +30,7 @@ struct ContactsListView: View {
                     systemImage: "person.2.slash"
                 )
                 Spacer()
-            } else if filteredPeople.isEmpty {
+            } else if listViewModel.filteredPeople.isEmpty {
                 Spacer()
                 EmptyStateView(
                     title: "No contacts found",
@@ -73,6 +46,12 @@ struct ContactsListView: View {
                     }
             }
         }
+        .onAppear {
+            // Subscribing here (rather than in `init`) lets the view model
+            // bind to the injected `HomeViewModel` once the view is mounted.
+            // Safe to call repeatedly — `bind` replaces its prior cancellables.
+            listViewModel.bind(to: viewModel)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .personDidChange)) { _ in
             viewModel.load()
         }
@@ -85,7 +64,7 @@ struct ContactsListView: View {
 
     private var contactsHeader: some View {
         HStack {
-            Text("\(filteredPeople.count) Contacts")
+            Text("\(listViewModel.filteredPeople.count) Contacts")
                 .font(DS.Typography.homeSubtitle)
                 .foregroundStyle(Color(.secondaryLabel))
             Spacer()
@@ -114,8 +93,10 @@ struct ContactsListView: View {
 
     private var contactsList: some View {
         let calculator = FrequencyCalculator()
-        let cadencesById = Dictionary(uniqueKeysWithValues: viewModel.cadences.map { ($0.id, $0) })
-        let groupsById = Dictionary(uniqueKeysWithValues: viewModel.groups.map { ($0.id, $0) })
+        // Dict lookups: O(1) per row instead of the previous O(M) linear
+        // scan through `viewModel.cadences`/`groups` per row (audit E3, #317).
+        let cadencesById = viewModel.cadencesById
+        let groupsById = viewModel.groupsById
 
         return ScrollViewReader { proxy in
             ScrollView {
@@ -128,7 +109,7 @@ struct ContactsListView: View {
                         )
                     }
 
-                    ForEach(sections, id: \.letter) { section in
+                    ForEach(listViewModel.sections) { section in
                         Section {
                             ForEach(Array(section.people.enumerated()), id: \.element.id) { index, person in
                                 let frequencyName = cadencesById[person.cadenceId]?.name ?? "Frequency"
@@ -144,8 +125,8 @@ struct ContactsListView: View {
                                     ContactCard(
                                         person: person,
                                         frequencyName: frequencyName,
-                                        status: calculator.status(for: person, in: viewModel.cadences),
-                                        daysOverdue: calculator.daysOverdue(for: person, in: viewModel.cadences),
+                                        status: calculator.status(for: person, cadencesById: cadencesById),
+                                        daysOverdue: calculator.daysOverdue(for: person, cadencesById: cadencesById),
                                         timeAgo: calculator.timeAgoText(for: person),
                                         lastMethod: person.lastTouchMethod,
                                         groups: personGroups,
@@ -187,7 +168,7 @@ struct ContactsListView: View {
             .background(DS.Colors.pageBg)
             .overlay(alignment: .trailing) {
                 if !selectionCoordinator.isSelectMode {
-                    SectionIndexView(sections: sectionLetters) { letter in
+                    SectionIndexView(sections: listViewModel.sectionLetters) { letter in
                         withAnimation {
                             proxy.scrollTo(letter, anchor: .top)
                         }
@@ -222,7 +203,10 @@ struct ContactsListView: View {
     // MARK: - Search Bar
 
     private var contactsSearchBar: some View {
-        FloatingSearchBar(text: $searchText)
+        FloatingSearchBar(text: Binding(
+            get: { listViewModel.searchText },
+            set: { listViewModel.updateSearchText($0) }
+        ))
     }
 
 }

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -306,8 +306,12 @@ struct HomeView: View {
 
     private var content: some View {
         let calculator = FrequencyCalculator()
-        let cadencesById = Dictionary(uniqueKeysWithValues: viewModel.cadences.map { ($0.id, $0) })
-        let groupsById = Dictionary(uniqueKeysWithValues: viewModel.groups.map { ($0.id, $0) })
+        // Dicts now live on the view model as `@Published` derived state
+        // synced inside `load()`. Reading them here is O(1) instead of
+        // rebuilding two `Dictionary(uniqueKeysWithValues:)` walks per
+        // body render (audit E13, #317).
+        let cadencesById = viewModel.cadencesById
+        let groupsById = viewModel.groupsById
 
         return ScrollView {
             LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
@@ -348,7 +352,7 @@ struct HomeView: View {
                             cadencesById: cadencesById,
                             groupsById: groupsById,
                             statusForPerson: { _ in .overdue },
-                            daysOverdueForPerson: { calculator.daysOverdue(for: $0, in: viewModel.cadences) },
+                            daysOverdueForPerson: { calculator.daysOverdue(for: $0, cadencesById: cadencesById) },
                             timeAgoForPerson: { calculator.timeAgoText(for: $0) },
                             selectPerson: selectPerson,
                             coordinator: selectionCoordinator
@@ -362,7 +366,7 @@ struct HomeView: View {
                             cadencesById: cadencesById,
                             groupsById: groupsById,
                             statusForPerson: { _ in .dueSoon },
-                            daysOverdueForPerson: { calculator.daysOverdue(for: $0, in: viewModel.cadences) },
+                            daysOverdueForPerson: { calculator.daysOverdue(for: $0, cadencesById: cadencesById) },
                             timeAgoForPerson: { calculator.timeAgoText(for: $0) },
                             selectPerson: selectPerson,
                             coordinator: selectionCoordinator
@@ -377,7 +381,7 @@ struct HomeView: View {
                         cadencesById: cadencesById,
                         groupsById: groupsById,
                         statusForPerson: { _ in .onTrack },
-                        daysOverdueForPerson: { calculator.daysOverdue(for: $0, in: viewModel.cadences) },
+                        daysOverdueForPerson: { calculator.daysOverdue(for: $0, cadencesById: cadencesById) },
                         timeAgoForPerson: { calculator.timeAgoText(for: $0) },
                         selectPerson: selectPerson,
                         coordinator: selectionCoordinator

--- a/StayInTouch/StayInTouch/UseCases/PersonStatusService.swift
+++ b/StayInTouch/StayInTouch/UseCases/PersonStatusService.swift
@@ -15,19 +15,21 @@ struct PersonStatusService {
     }
 
     func overduePeople(_ people: [Person], cadences: [Cadence]) -> [Person] {
+        let cadencesById = Dictionary(uniqueKeysWithValues: cadences.map { ($0.id, $0) })
         let filtered = people.filter { !($0.isPaused) }
-        let overdue = filtered.filter { calculator.status(for: $0, in: cadences) == .overdue }
+        let overdue = filtered.filter { calculator.status(for: $0, cadencesById: cadencesById) == .overdue }
         return overdue.sorted { lhs, rhs in
-            sortOverdue(lhs, rhs, cadences: cadences)
+            sortOverdue(lhs, rhs, cadencesById: cadencesById)
         }
     }
 
     func dueSoonPeople(_ people: [Person], cadences: [Cadence]) -> [Person] {
+        let cadencesById = Dictionary(uniqueKeysWithValues: cadences.map { ($0.id, $0) })
         let filtered = people.filter { !($0.isPaused) }
-        let dueSoon = filtered.filter { calculator.status(for: $0, in: cadences) == .dueSoon }
+        let dueSoon = filtered.filter { calculator.status(for: $0, cadencesById: cadencesById) == .dueSoon }
 
         return dueSoon.sorted { lhs, rhs in
-            sortDueSoon(lhs, rhs, cadences: cadences)
+            sortDueSoon(lhs, rhs, cadencesById: cadencesById)
         }
     }
 
@@ -51,12 +53,17 @@ struct PersonStatusService {
         _ people: [Person],
         cadences: [Cadence]
     ) -> (overdue: [Person], dueSoon: [Person], onTrack: [Person]) {
+        // Build the id→cadence dict once so per-person status / sort lookups
+        // are O(1) instead of O(N) (audit E3, #317). All downstream paths
+        // (status, sort comparators) route through the dict-based overloads.
+        let cadencesById = Dictionary(uniqueKeysWithValues: cadences.map { ($0.id, $0) })
+
         var overdue: [Person] = []
         var dueSoon: [Person] = []
         var onTrack: [Person] = []
 
         for person in people where !person.isPaused {
-            switch calculator.status(for: person, in: cadences) {
+            switch calculator.status(for: person, cadencesById: cadencesById) {
             case .overdue:
                 overdue.append(person)
             case .dueSoon:
@@ -68,8 +75,8 @@ struct PersonStatusService {
             }
         }
 
-        overdue.sort { sortOverdue($0, $1, cadences: cadences) }
-        dueSoon.sort { sortDueSoon($0, $1, cadences: cadences) }
+        overdue.sort { sortOverdue($0, $1, cadencesById: cadencesById) }
+        dueSoon.sort { sortDueSoon($0, $1, cadencesById: cadencesById) }
         onTrack.sort { ($0.lastTouchAt ?? .distantPast) > ($1.lastTouchAt ?? .distantPast) }
 
         return (overdue, dueSoon, onTrack)
@@ -77,9 +84,9 @@ struct PersonStatusService {
 
     // MARK: - Private
 
-    private func sortOverdue(_ lhs: Person, _ rhs: Person, cadences: [Cadence]) -> Bool {
-        let lhsOverdue = calculator.daysOverdue(for: lhs, in: cadences)
-        let rhsOverdue = calculator.daysOverdue(for: rhs, in: cadences)
+    private func sortOverdue(_ lhs: Person, _ rhs: Person, cadencesById: [UUID: Cadence]) -> Bool {
+        let lhsOverdue = calculator.daysOverdue(for: lhs, cadencesById: cadencesById)
+        let rhsOverdue = calculator.daysOverdue(for: rhs, cadencesById: cadencesById)
         if lhsOverdue != rhsOverdue {
             return lhsOverdue > rhsOverdue
         }
@@ -91,9 +98,9 @@ struct PersonStatusService {
         return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
     }
 
-    private func sortDueSoon(_ lhs: Person, _ rhs: Person, cadences: [Cadence]) -> Bool {
-        let lhsDays = daysUntilDue(for: lhs, cadences: cadences)
-        let rhsDays = daysUntilDue(for: rhs, cadences: cadences)
+    private func sortDueSoon(_ lhs: Person, _ rhs: Person, cadencesById: [UUID: Cadence]) -> Bool {
+        let lhsDays = daysUntilDue(for: lhs, cadencesById: cadencesById)
+        let rhsDays = daysUntilDue(for: rhs, cadencesById: cadencesById)
         if lhsDays != rhsDays {
             return lhsDays < rhsDays
         }
@@ -105,7 +112,7 @@ struct PersonStatusService {
         return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
     }
 
-    private func daysUntilDue(for person: Person, cadences: [Cadence]) -> Int {
-        calculator.daysUntilDue(for: person, in: cadences) ?? Int.max
+    private func daysUntilDue(for person: Person, cadencesById: [UUID: Cadence]) -> Int {
+        calculator.daysUntilDue(for: person, cadencesById: cadencesById) ?? Int.max
     }
 }

--- a/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
@@ -59,6 +59,7 @@ final class IntentTestPersonRepository: PersonRepository {
         deletedIds.append(id)
         people.removeAll { $0.id == id }
     }
+    func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
 }
 
 @MainActor

--- a/StayInTouch/StayInTouchTests/FreshStartIntegrationTests.swift
+++ b/StayInTouch/StayInTouchTests/FreshStartIntegrationTests.swift
@@ -310,6 +310,7 @@ private struct StubPersonRepository: PersonRepository {
     func save(_ person: Person) throws {}
     func batchSave(_ persons: [Person]) throws {}
     func delete(id: UUID) throws {}
+    func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
 }
 
 private struct StubCadenceRepository: CadenceRepository {
@@ -329,6 +330,7 @@ private struct StubGroupRepository: GroupRepository {
     func save(_ group: Group) throws {}
     func batchSave(_ groups: [Group]) throws {}
     func delete(id: UUID) throws {}
+    func count() -> Int { groups.count }
 }
 
 private struct StubSettingsRepository: AppSettingsRepository {

--- a/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
@@ -332,6 +332,7 @@ final class HomeViewModelTests: XCTestCase {
         func save(_ person: Person) throws {}
         func batchSave(_ persons: [Person]) throws {}
         func delete(id: UUID) throws {}
+        func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
     }
 
     private struct InMemoryCadenceRepository: CadenceRepository {
@@ -351,6 +352,7 @@ final class HomeViewModelTests: XCTestCase {
         func save(_ group: Group) throws {}
         func batchSave(_ groups: [Group]) throws {}
         func delete(id: UUID) throws {}
+        func count() -> Int { groups.count }
     }
 
     private struct InMemorySettingsRepository: AppSettingsRepository {

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
@@ -52,6 +52,12 @@ final class MockPersonRepository: PersonRepository {
         deletedIds.append(id)
         people.removeAll { $0.id == id }
     }
+
+    var pausedCountCallCount = 0
+    func pausedCount() -> Int {
+        pausedCountCallCount += 1
+        return people.filter { $0.isTracked && $0.isPaused }.count
+    }
 }
 
 // MARK: - MockCadenceRepository
@@ -100,6 +106,12 @@ final class MockGroupRepository: GroupRepository {
     }
     func delete(id: UUID) throws {
         groups.removeAll { $0.id == id }
+    }
+
+    var countCallCount = 0
+    func count() -> Int {
+        countCallCount += 1
+        return groups.count
     }
 }
 


### PR DESCRIPTION
Closes #317. Part of the audit in #302.

## Scope

Four list-render hot-path efficiency wins. Behavior preserved — same contacts displayed, same order, same section grouping, same Settings counts. Just less work per render.

### E2 — ContactsListView derived state → ContactsListViewModel

Previously \`filteredPeople\`, \`sections\`, and \`sectionLetters\` were plain computed properties recomputed on every body render. With \`HomeViewModel\` published changes churning that's an O(N log N) hot path on a 60-FPS surface.

New \`ContactsListViewModel\` owns those as \`@Published\` derived state, wired via Combine \`combineLatest(\$allPeople, \$searchText)\` so recompute only fires when one of those two inputs changes. Per Apple's [Managing model data in your app](https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app), derived state belongs in the view model, not in \`body\`.

Followup commit handles the one-frame gap between first body render and \`.onAppear\` (Combine subscribe).

### E3 — Dict-based FrequencyCalculator overloads

Added \`[UUID: C]\` overloads to \`status\`, \`daysOverdue\`, \`daysUntilDue\`, and \`effectiveDueDate\`. Per-call cadence resolution drops from O(M) linear scan to O(1) dict lookup.

Routes the hot-path callers (ContactsListView rows, HomeView rows, PersonStatusService.partition, NotificationClassifier.classify) through the dict overloads. The array overloads remain (thin shims over the dict path) so out-of-tree callers don't break.

### E9 — \`NSManagedObjectContext.count(for:)\`

\`SettingsViewModel.load\` used to fetch all groups and every tracked person just to read two display counts. Added \`PersonRepository.pausedCount()\` and \`GroupRepository.count()\` backed by \`context.count(for:)\` per [Apple's docs](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/count%28for%3A%29-3r91z) — returns the row count without faulting managed objects into memory.

### E13 — HomeView \`cadencesById\` / \`groupsById\` → \`HomeViewModel\` @Published

Both dicts used to be rebuilt inside HomeView.content's body on every render. Moved to \`@Published\` derived state on \`HomeViewModel\`, rebuilt inside \`load()\` right after \`cadences\` / \`groups\` are assigned. Inputs are only mutated in \`load()\` (verified by grep), so this is the single sync point and the dicts cannot drift from their source arrays.

## Context7 references

- SwiftUI: [Managing model data in your app](https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app) — derived state belongs in the model.
- Core Data: [\`NSManagedObjectContext.count(for:)\`](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/count%28for%3A%29-3r91z) — row count without materialization.

## Before / after performance characterization

Per body render of HomeView's content with N contacts and M cadences:

| Op | Before | After |
|---|---|---|
| Build cadencesById/groupsById | 2 × O(M) | 0 (read from VM) |
| Per-row \`status\` cadence lookup | O(M) × N | O(1) × N |
| Per-row \`daysOverdue\` cadence lookup | O(M) × N | O(1) × N |
| Per-row \`daysUntilDue\` (NotificationClassifier) | O(M) × N | O(1) × N |

ContactsListView body cost:

| Op | Before | After |
|---|---|---|
| \`filteredPeople\` (filter + sort) | O(N log N) per render | O(N log N) per *input change* |
| \`sections\` (Dictionary grouping) | O(N) per render | O(N) per *input change* |
| Per-row cadence/group lookup | O(M) | O(1) |

SettingsViewModel.load:

| Op | Before | After |
|---|---|---|
| Paused count | Fetch all tracked people + filter | \`count(for:)\` |
| Groups count | Fetch all groups | \`count(for:)\` |

## Behavior preservation assertion

- Same contacts displayed (same filter, same sort, same A–Z grouping).
- Same section letter membership.
- Same Settings count values.
- Same HomeView Overdue/Due Soon/All Good bucket membership and sort.
- Visual layout unchanged.

The four refactors change WHERE state is computed (View body → ViewModel \`@Published\`), WHEN it recomputes (every body render → only on input change), and HOW counts are fetched (fetch all + count → \`count(for:)\`). They do not change WHAT the user sees.

## Test count

72 targeted tests across FrequencyCalculator, PersonStatusService, NotificationClassifier, HomeViewModel, SettingsViewModel: all green. Full suite: \`** TEST SUCCEEDED **\`.

## Commits

1. \`a91bbae\` — E3: dict-based FrequencyCalculator overloads
2. \`25fd587\` — E13: HomeView cadencesById/groupsById → HomeViewModel
3. \`5f7aa2c\` — E2: ContactsListView derived state → ContactsListViewModel
4. \`95ad61d\` — E9: SettingsViewModel uses \`count(for:)\`
5. \`8f9592a\` — E2 followup: guard one-frame empty-state flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)