### PR TITLE
[#312] Tech debt: Stringly cleanup + magic numbers (Q13, Q10-12, R7, R9, R12)

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDelegate.swift
+++ b/StayInTouch/StayInTouch/App/AppDelegate.swift
@@ -47,7 +47,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let userInfo = response.notification.request.content.userInfo
 
         if response.actionIdentifier == NotificationIdentifier.actionLogConnection,
-           let personIdString = userInfo["personId"] as? String,
+           let personIdString = userInfo[NotificationIdentifier.UserInfoKey.personId.rawValue] as? String,
            let personId = UUID(uuidString: personIdString) {
             logConnectionFromNotification(personId: personId)
             completionHandler()
@@ -56,9 +56,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
         // Only forward known fields to prevent untrusted data propagation
         let sanitized: [AnyHashable: Any] = [
-            "type": userInfo["type"] as? String ?? "",
-            "personId": userInfo["personId"] as? String ?? "",
-            "category": userInfo["category"] as? String ?? ""
+            NotificationIdentifier.UserInfoKey.type.rawValue: userInfo[NotificationIdentifier.UserInfoKey.type.rawValue] as? String ?? "",
+            NotificationIdentifier.UserInfoKey.personId.rawValue: userInfo[NotificationIdentifier.UserInfoKey.personId.rawValue] as? String ?? "",
+            NotificationIdentifier.UserInfoKey.category.rawValue: userInfo[NotificationIdentifier.UserInfoKey.category.rawValue] as? String ?? ""
         ]
         DeepLinkRouter.shared.handleNotification(userInfo: sanitized)
         completionHandler()

--- a/StayInTouch/StayInTouch/App/DeepLinkRouter.swift
+++ b/StayInTouch/StayInTouch/App/DeepLinkRouter.swift
@@ -19,12 +19,12 @@ final class DeepLinkRouter: ObservableObject {
 
     /// Parse notification userInfo and set the pending destination.
     nonisolated func handleNotification(userInfo: [AnyHashable: Any]) {
-        let type = userInfo["type"] as? String
-        if type == "person",
-           let idString = userInfo["personId"] as? String,
+        let type = userInfo[NotificationIdentifier.UserInfoKey.type.rawValue] as? String
+        if type == NotificationIdentifier.UserInfoValue.person.rawValue,
+           let idString = userInfo[NotificationIdentifier.UserInfoKey.personId.rawValue] as? String,
            let id = UUID(uuidString: idString) {
             Task { @MainActor in self.pending = .person(id) }
-        } else if type == "home" {
+        } else if type == NotificationIdentifier.UserInfoValue.home.rawValue {
             Task { @MainActor in self.pending = .home }
         }
     }

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -326,7 +326,10 @@ final class NotificationScheduler {
         content.body = notificationBody(for: people, hideNames: settings.hideContactNamesInNotifications)
         content.sound = .default
         content.badge = NSNumber(value: badgeCount)
-        content.userInfo = ["type": "home", "category": "daily"]
+        content.userInfo = [
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.home.rawValue,
+            NotificationIdentifier.UserInfoKey.category.rawValue: NotificationIdentifier.UserInfoValue.daily.rawValue
+        ]
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
         return UNNotificationRequest(identifier: NotificationIdentifier.dailyCombined, content: content, trigger: trigger)
@@ -347,7 +350,11 @@ final class NotificationScheduler {
             }
             content.sound = .default
             content.badge = NSNumber(value: badgeCount)
-            content.userInfo = ["type": "person", "personId": person.id.uuidString, "category": type.userInfoType]
+            content.userInfo = [
+                NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.person.rawValue,
+                NotificationIdentifier.UserInfoKey.personId.rawValue: person.id.uuidString,
+                NotificationIdentifier.UserInfoKey.category.rawValue: type.userInfoType
+            ]
             content.categoryIdentifier = NotificationIdentifier.categoryPerson
 
             let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
@@ -366,7 +373,7 @@ final class NotificationScheduler {
         content.body = notificationBody(for: all, hideNames: settings.hideContactNamesInNotifications)
         content.sound = .default
         content.badge = NSNumber(value: badgeCount)
-        content.userInfo = notificationUserInfo(for: all, type: "digest")
+        content.userInfo = notificationUserInfo(for: all, type: NotificationIdentifier.UserInfoValue.digest.rawValue)
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
         return UNNotificationRequest(identifier: NotificationIdentifier.weeklyDigest, content: content, trigger: trigger)
@@ -393,9 +400,16 @@ final class NotificationScheduler {
 
     private func notificationUserInfo(for people: [Person], type: String) -> [AnyHashable: Any] {
         if people.count == 1, let person = people.first {
-            return ["type": "person", "personId": person.id.uuidString, "category": type]
+            return [
+                NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.person.rawValue,
+                NotificationIdentifier.UserInfoKey.personId.rawValue: person.id.uuidString,
+                NotificationIdentifier.UserInfoKey.category.rawValue: type
+            ]
         }
-        return ["type": "home", "category": type]
+        return [
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.home.rawValue,
+            NotificationIdentifier.UserInfoKey.category.rawValue: type
+        ]
     }
 
     private func firstName(from displayName: String) -> String {
@@ -438,7 +452,11 @@ private extension NotificationScheduler {
         }
         content.sound = .default
         content.badge = NSNumber(value: badgeCount)
-        content.userInfo = ["type": "person", "personId": person.id.uuidString, "category": type.userInfoType]
+        content.userInfo = [
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.person.rawValue,
+            NotificationIdentifier.UserInfoKey.personId.rawValue: person.id.uuidString,
+            NotificationIdentifier.UserInfoKey.category.rawValue: type.userInfoType
+        ]
         content.categoryIdentifier = NotificationIdentifier.categoryPerson
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: true)
@@ -518,9 +536,9 @@ private extension NotificationScheduler {
         content.threadIdentifier = "birthday"
         content.categoryIdentifier = NotificationIdentifier.categoryBirthday
         content.userInfo = [
-            "type": "person",
-            "personId": person.id.uuidString,
-            "category": "birthday"
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.person.rawValue,
+            NotificationIdentifier.UserInfoKey.personId.rawValue: person.id.uuidString,
+            NotificationIdentifier.UserInfoKey.category.rawValue: NotificationIdentifier.UserInfoValue.birthday.rawValue
         ]
 
         var dateComponents = DateComponents()
@@ -547,7 +565,10 @@ private extension NotificationScheduler {
         // attaching the BIRTHDAY_REMINDER category (which includes a "Log Connection"
         // action) would silently do nothing when tapped. Leave unset so no action
         // button appears.
-        content.userInfo = ["type": "home", "category": "birthday"]
+        content.userInfo = [
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.home.rawValue,
+            NotificationIdentifier.UserInfoKey.category.rawValue: NotificationIdentifier.UserInfoValue.birthday.rawValue
+        ]
 
         var dateComponents = DateComponents()
         dateComponents.month = month
@@ -621,6 +642,30 @@ enum NotificationIdentifier {
     static let birthdayPrefix = "birthday_"
     static let birthdayGroupedPrefix = "birthday_grouped_"
     static let categoryBirthday = "BIRTHDAY_REMINDER"
+
+    /// Typed keys for `UNNotificationContent.userInfo`. Raw values are the
+    /// stringly-typed keys preserved byte-identical from prior call sites so
+    /// in-flight notifications and DeepLinkRouter parsing keep working.
+    enum UserInfoKey: String {
+        case type
+        case personId
+        case category
+    }
+
+    /// Typed values used under `UserInfoKey.type` (the "kind" of notification)
+    /// and `UserInfoKey.category` (the bucket it belongs to). Raw values match
+    /// the prior string literals byte-identical.
+    enum UserInfoValue: String {
+        // type values
+        case home
+        case person
+        // category values
+        case daily
+        case digest
+        case birthday
+        // SettingsViewModel.sendTestNotification uses this category
+        case test
+    }
 }
 
 private extension DayOfWeek {

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -472,6 +472,27 @@ enum DS {
         static let cardY: CGFloat = 1
     }
 
+    // MARK: - Timing
+
+    /// Timeouts for transient UI affordances (undo windows, auto-dismiss
+    /// banners). Values are seconds. **Byte-identical** to the literals they
+    /// replace — do not change without a UX review.
+    enum Timing {
+        /// Grace period for undoable destructive actions (remove contact,
+        /// pending quick action, post-import success banner). 5 s.
+        static let undoBannerSeconds: TimeInterval = 5.0
+
+        /// Auto-dismiss for the error toast. Intentionally shorter than
+        /// `undoBannerSeconds` — error toasts don't need user action, just
+        /// surface failure briefly. 4 s.
+        static let errorToastSeconds: TimeInterval = 4.0
+    }
+
+    /// Convenience: nanoseconds for `Task.sleep(nanoseconds:)`.
+    static func nanoseconds(_ seconds: TimeInterval) -> UInt64 {
+        UInt64(seconds * 1_000_000_000)
+    }
+
     // MARK: - Touch Method Icons
 
     static func touchMethodIcon(_ method: TouchMethod) -> String {

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -472,6 +472,24 @@ enum DS {
         static let cardY: CGFloat = 1
     }
 
+    // MARK: - Motion
+
+    /// Animation durations for SwiftUI transitions. Values are seconds.
+    /// **Byte-identical** to the literals they replace — see callsite audit
+    /// in PR #312. Names describe usage, not aesthetic intent: `standard`
+    /// is the most common (settings expand, filter pills, etc.); `expressive`
+    /// is reserved for transient banners; `emphasized` is the long pull-to-
+    /// reveal action.
+    enum Motion {
+        /// Most common — 0.25s. Settings expand/collapse, filter pills.
+        static let standard: TimeInterval = 0.25
+        /// Slightly longer — 0.3s. Undo/quick-action banners and any
+        /// transition where the user benefits from a moment to react.
+        static let expressive: TimeInterval = 0.3
+        /// Longest — 0.35s. PersonDetailView's pull-to-reveal action.
+        static let emphasized: TimeInterval = 0.35
+    }
+
     // MARK: - Timing
 
     /// Timeouts for transient UI affordances (undo windows, auto-dismiss

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -432,6 +432,11 @@ enum DS {
         static let xxl: CGFloat = 24
         static let xxxl: CGFloat = 32
         static let tapTarget: CGFloat = 44  // Apple HIG minimum tap target
+        /// Settings menu row height — slightly taller than `tapTarget` so the
+        /// row has visual breathing room around its content. **48px is
+        /// intentional and not the same as `tapTarget` (44)** — see PR #312
+        /// Q12 trade-off. Used across PersonSettingsSection rows.
+        static let menuRowHeight: CGFloat = 48
 
         // MARK: Adaptive Layout Values
         // Font sizes and CGFloat values cannot use UIColor trait-based adaptation,

--- a/StayInTouch/StayInTouch/UI/DesignSystem.swift
+++ b/StayInTouch/StayInTouch/UI/DesignSystem.swift
@@ -344,34 +344,19 @@ enum DS {
 
         /// Returns muted background and text colors for avatars based on color scheme.
         /// Light mode: stored hex as background, white text.
-        /// Dark mode: muted variants per dark mode addendum spec.
+        /// Dark mode: muted variants per dark mode addendum spec, sourced
+        /// from `AvatarColors.entries` so a new palette color resolves in
+        /// both modes without a parallel edit here. Unknown hexes fall
+        /// back to accent green.
         static func avatarColors(for hex: String, scheme: ColorScheme) -> (background: Color, text: Color) {
             guard scheme == .dark else {
                 return (Color(hex: hex), .white)
             }
-
-            let normalized = Color.normalize(hex: hex).uppercased()
-            switch normalized {
-            case "6BCB77":  // Green
-                return (Color(hex: "2D5040"), Color(hex: "4ADE80"))
-            case "4ECDC4":  // Teal
-                return (Color(hex: "0D3D3D"), Color(hex: "5EEAD4"))
-            case "FF6B6B":  // Red / Orange-ish
-                return (Color(hex: "3D2010"), Color(hex: "FDBA74"))
-            case "F38181":  // Pink-Red
-                return (Color(hex: "3D2010"), Color(hex: "FDBA74"))
-            case "AA96DA":  // Purple
-                return (Color(hex: "2D1B4E"), Color(hex: "D8B4FE"))
-            case "FFD93D":  // Yellow / Amber
-                return (Color(hex: "3D2E10"), Color(hex: "FCD34D"))
-            case "95E1D3":  // Mint
-                return (Color(hex: "0D3D3D"), Color(hex: "5EEAD4"))
-            case "FCBAD3":  // Light Pink
-                return (Color(hex: "2D1B4E"), Color(hex: "D8B4FE"))
-            default:
+            guard let entry = AvatarColors.entry(forLightHex: hex) else {
                 // Accent green fallback
                 return (BrandColors.heroAccentGreen, .white)
             }
+            return (Color(hex: entry.darkBackgroundHex), Color(hex: entry.darkTextHex))
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -249,7 +249,10 @@ final class SettingsViewModel: ObservableObject {
         content.title = "Test Notification"
         content.body = "Keep In Touch test notification."
         content.sound = .default
-        content.userInfo = ["type": "home", "category": "test"]
+        content.userInfo = [
+            NotificationIdentifier.UserInfoKey.type.rawValue: NotificationIdentifier.UserInfoValue.home.rawValue,
+            NotificationIdentifier.UserInfoKey.category.rawValue: NotificationIdentifier.UserInfoValue.test.rawValue
+        ]
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 10, repeats: false)
         let request = UNNotificationRequest(identifier: "test_notification", content: content, trigger: trigger)

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
             if newValue != nil {
                 AnalyticsService.track("filter.applied", parameters: ["type": "cadence"])
             }
-            withAnimation(.easeInOut(duration: 0.25)) {
+            withAnimation(.easeInOut(duration: DS.Motion.standard)) {
                 viewModel.applyFilters()
             }
         }
@@ -48,7 +48,7 @@ struct HomeView: View {
             if newValue != nil {
                 AnalyticsService.track("filter.applied", parameters: ["type": "group"])
             }
-            withAnimation(.easeInOut(duration: 0.25)) {
+            withAnimation(.easeInOut(duration: DS.Motion.standard)) {
                 viewModel.applyFilters()
             }
         }
@@ -56,11 +56,11 @@ struct HomeView: View {
             let isSearching = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             if isSearching && savedCollapsedSections == nil {
                 savedCollapsedSections = collapsedSections
-                withAnimation(.easeInOut(duration: 0.25)) {
+                withAnimation(.easeInOut(duration: DS.Motion.standard)) {
                     collapsedSections = []
                 }
             } else if !isSearching, let saved = savedCollapsedSections {
-                withAnimation(.easeInOut(duration: 0.25)) {
+                withAnimation(.easeInOut(duration: DS.Motion.standard)) {
                     collapsedSections = saved
                 }
                 savedCollapsedSections = nil
@@ -405,7 +405,7 @@ struct HomeView: View {
     // MARK: - Helpers
 
     private func toggleSection(_ key: String) {
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(.easeInOut(duration: DS.Motion.expressive)) {
             if collapsedSections.contains(key) {
                 collapsedSections.remove(key)
             } else {

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -183,7 +183,7 @@ struct PersonDetailView: View {
             if newPhase == .active, pendingQuickActionMethod != nil {
                 showQuickActionUndo = true
                 Task {
-                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    try? await Task.sleep(nanoseconds: DS.nanoseconds(DS.Timing.undoBannerSeconds))
                     dismissQuickActionUndo()
                 }
             }
@@ -485,7 +485,7 @@ struct PersonDetailView: View {
         Haptics.medium()
         showRemoveUndo = true
         pendingRemoveTask = Task {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            try? await Task.sleep(nanoseconds: DS.nanoseconds(DS.Timing.undoBannerSeconds))
             guard !Task.isCancelled else { return }
             showRemoveUndo = false
             viewModel.deletePerson()

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -106,7 +106,7 @@ struct PersonDetailView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .tutorialScrollToAnchor)) { note in
                 guard viewModel.isPreview, let anchor = note.object as? String else { return }
-                withAnimation(.easeInOut(duration: 0.35)) {
+                withAnimation(.easeInOut(duration: DS.Motion.emphasized)) {
                     scrollProxy.scrollTo(anchor, anchor: .center)
                 }
             }
@@ -164,8 +164,8 @@ struct PersonDetailView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .animation(.easeInOut(duration: 0.3), value: showQuickActionUndo)
-        .animation(.easeInOut(duration: 0.3), value: showRemoveUndo)
+        .animation(.easeInOut(duration: DS.Motion.expressive), value: showQuickActionUndo)
+        .animation(.easeInOut(duration: DS.Motion.expressive), value: showRemoveUndo)
         .onAppear {
             viewModel.load()
         }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -122,8 +122,7 @@ struct PersonSettingsSection: View {
                     .font(DS.Typography.caption)
             } else {
                 Button {
-                    let initialDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
-                    onAction(.customDueDatePicker(initialDate: initialDate))
+                    onAction(.customDueDatePicker(initialDate: .defaultSnoozeStartDate))
                 } label: {
                     HStack(spacing: DS.Spacing.xs) {
                         Text("Not set")
@@ -166,8 +165,7 @@ struct PersonSettingsSection: View {
                     snoozePill("7d") { snooze(days: 7) }
                     snoozePill("14d") { snooze(days: 14) }
                     snoozePill("Pick date") {
-                        let initialDate = Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
-                        onAction(.snoozeDatePicker(initialDate: initialDate))
+                        onAction(.snoozeDatePicker(initialDate: .defaultSnoozeStartDate))
                     }
                 }
             }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -102,7 +102,7 @@ struct PersonSettingsSection: View {
                     .font(.caption)
                     .foregroundStyle(DS.Colors.settingsChevron)
             }
-            .frame(minHeight: 48)
+            .frame(minHeight: DS.Spacing.menuRowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -137,7 +137,7 @@ struct PersonSettingsSection: View {
                 .buttonStyle(.plain)
             }
         }
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
     private var settingsRowSnooze: some View {
@@ -172,7 +172,7 @@ struct PersonSettingsSection: View {
                 }
             }
         }
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
         .padding(.vertical, DS.Spacing.xs)
     }
 
@@ -198,7 +198,7 @@ struct PersonSettingsSection: View {
                     .font(.caption)
                     .foregroundStyle(DS.Colors.settingsChevron)
             }
-            .frame(minHeight: 48)
+            .frame(minHeight: DS.Spacing.menuRowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -215,7 +215,7 @@ struct PersonSettingsSection: View {
         }
         .accessibilityLabel("Birthday Notifications for \(viewModel.person.displayName)")
         .accessibilityHint("Sends a reminder on this contact's birthday")
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
     private var settingsRowCadencesGroups: some View {
@@ -253,7 +253,7 @@ struct PersonSettingsSection: View {
                 .accessibilityHint("Opens group manager")
             }
         }
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
     private var settingsRowNotificationTime: some View {
@@ -273,7 +273,7 @@ struct PersonSettingsSection: View {
                         .font(.caption)
                         .foregroundStyle(DS.Colors.settingsChevron)
                 }
-                .frame(minHeight: 48)
+                .frame(minHeight: DS.Spacing.menuRowHeight)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -298,7 +298,7 @@ struct PersonSettingsSection: View {
                 .font(DS.Typography.settingsRowLabel)
                 .foregroundStyle(DS.Colors.settingsItemLabel)
         }
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
     private var settingsRowPauseTracking: some View {
@@ -316,7 +316,7 @@ struct PersonSettingsSection: View {
                 .font(DS.Typography.settingsRowLabel)
                 .foregroundStyle(DS.Colors.settingsItemLabel)
         }
-        .frame(minHeight: 48)
+        .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
     private var settingsRowRemoveContact: some View {
@@ -325,7 +325,7 @@ struct PersonSettingsSection: View {
                 .font(DS.Typography.settingsRowLabel)
                 .foregroundStyle(DS.Colors.settingsRemoveText)
                 .frame(maxWidth: .infinity, alignment: .center)
-                .frame(minHeight: 48)
+                .frame(minHeight: DS.Spacing.menuRowHeight)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -14,7 +14,7 @@ struct PersonSettingsSection: View {
         VStack(alignment: .leading, spacing: 0) {
             // Collapsible header
             Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
+                withAnimation(.easeInOut(duration: DS.Motion.standard)) {
                     settingsExpanded.toggle()
                 }
             } label: {
@@ -29,7 +29,7 @@ struct PersonSettingsSection: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(DS.Colors.settingsChevron)
                         .rotationEffect(.degrees(settingsExpanded ? 0 : -90))
-                        .animation(.easeInOut(duration: 0.25), value: settingsExpanded)
+                        .animation(.easeInOut(duration: DS.Motion.standard), value: settingsExpanded)
                 }
                 .padding(.vertical, DS.Spacing.md)
                 .contentShape(Rectangle())

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -78,7 +78,7 @@ struct SettingsView: View {
                 showImportSuccessBanner = true
                 importBannerTask?.cancel()
                 importBannerTask = Task {
-                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    try? await Task.sleep(nanoseconds: DS.nanoseconds(DS.Timing.undoBannerSeconds))
                     guard !Task.isCancelled else { return }
                     showImportSuccessBanner = false
                     importSuccessCount = 0

--- a/StayInTouch/StayInTouch/UseCases/CallerRouter.swift
+++ b/StayInTouch/StayInTouch/UseCases/CallerRouter.swift
@@ -14,8 +14,7 @@ import Foundation
 enum CallerRouter {
     /// Builds a `tel:<digits>` URL for the native phone dialer.
     static func telURL(phone: String) -> URL? {
-        let digits = phone.filter { $0.isNumber || $0 == "+" }
-        guard !digits.isEmpty,
+        guard let digits = PhoneNormalizer.dialableDigits(phone),
               let encoded = digits.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             return nil
         }

--- a/StayInTouch/StayInTouch/UseCases/MessengerRouter.swift
+++ b/StayInTouch/StayInTouch/UseCases/MessengerRouter.swift
@@ -30,8 +30,7 @@ enum MessengerRouter {
         switch messenger {
         case .iMessage:
             // Native sms: tolerates loose formatting; no E.164 normalization.
-            let digits = phone.filter { $0.isNumber || $0 == "+" }
-            guard !digits.isEmpty,
+            guard let digits = PhoneNormalizer.dialableDigits(phone),
                   let encoded = digits.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
                 return nil
             }

--- a/StayInTouch/StayInTouch/UseCases/PhoneNormalizer.swift
+++ b/StayInTouch/StayInTouch/UseCases/PhoneNormalizer.swift
@@ -42,6 +42,19 @@ enum PhoneNormalizer {
         return dialingCode + digits
     }
 
+    /// Permissive phone filter that keeps digits and the leading `+`. Used by
+    /// `tel:` and `sms:` URL builders — the native dialer/Messages tolerate
+    /// loose formatting and don't require full E.164 normalization. Returns
+    /// `nil` for inputs that contain no dialable characters at all (so the
+    /// caller can short-circuit URL construction).
+    ///
+    /// **Byte-identical** to the prior inline `phone.filter { $0.isNumber
+    /// || $0 == "+" }` at CallerRouter.telURL and MessengerRouter.url(.iMessage).
+    static func dialableDigits(_ phone: String) -> String? {
+        let digits = phone.filter { $0.isNumber || $0 == "+" }
+        return digits.isEmpty ? nil : digits
+    }
+
     /// Minimal map of common region codes to dialing codes. Add entries as needed.
     private static func dialingCode(forRegion region: String) -> String? {
         switch region {

--- a/StayInTouch/StayInTouch/Utilities/Extensions/Date+Snooze.swift
+++ b/StayInTouch/StayInTouch/Utilities/Extensions/Date+Snooze.swift
@@ -1,0 +1,23 @@
+//
+//  Date+Snooze.swift
+//  KeepInTouch
+//
+
+import Foundation
+
+extension Date {
+    /// Initial date offered when the user opens the custom-due-date or
+    /// snooze-date picker — 3 days from now. Computed (not stored) so the
+    /// offset re-evaluates against `Date()` each time the picker opens.
+    ///
+    /// Falls back to `Date()` if the calendar math fails (it never does in
+    /// practice — matches prior inline `?? Date()` behavior).
+    ///
+    /// **Byte-identical** to the prior inline:
+    ///     Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
+    /// at PersonSettingsSection.swift:125 (custom due date picker) and :169
+    /// (snooze date picker).
+    static var defaultSnoozeStartDate: Date {
+        Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()
+    }
+}

--- a/StayInTouch/StayInTouch/Utilities/Helpers/AvatarColors.swift
+++ b/StayInTouch/StayInTouch/Utilities/Helpers/AvatarColors.swift
@@ -5,21 +5,67 @@
 //  Created by Codex on 2/2/26.
 //
 
-import Foundation
+import SwiftUI
 
+/// Avatar color palette. Single source of truth for both:
+///   1. Random hex assignment (`AvatarColors.randomHex()`)
+///   2. Light/dark-mode resolution (`DS.Colors.avatarColors(for:scheme:)`)
+///
+/// Adding a 9th color is now a single edit here — both light AND dark
+/// resolve correctly without touching DesignSystem.swift. Prior to PR
+/// #312 the palette lived in two places: a `[String]` of 8 light hexes
+/// here and a parallel `switch` over the same 8 normalized hexes in
+/// DesignSystem.swift. A new color silently fell through to "accent
+/// green fallback" in dark mode.
 enum AvatarColors {
-    static let palette: [String] = [
-        "#FF6B6B",
-        "#4ECDC4",
-        "#95E1D3",
-        "#F38181",
-        "#AA96DA",
-        "#FCBAD3",
-        "#FFD93D",
-        "#6BCB77"
+    /// One palette entry. `lightHex` is the stored avatar color (still
+    /// written to `Person.avatarColor` and used as the light-mode
+    /// background, white text on top). `darkBackgroundHex` and
+    /// `darkTextHex` are the muted variants the dark mode addendum spec
+    /// prescribes.
+    struct PaletteEntry {
+        /// Hex stored on `Person.avatarColor`. Light-mode background.
+        /// Includes `#` prefix to match the prior `palette: [String]` format
+        /// that callers serialized verbatim.
+        let lightHex: String
+        /// Dark-mode background (no `#` — passed directly to `Color(hex:)`).
+        let darkBackgroundHex: String
+        /// Dark-mode text color on the dark background.
+        let darkTextHex: String
+    }
+
+    /// Palette entries. Values **byte-identical** to the prior
+    /// `palette: [String]` and the prior `DS.Colors.avatarColors(for:scheme:)`
+    /// switch. See `Color.normalize(hex:)` for the normalization used to
+    /// match a stored hex against an entry.
+    static let entries: [PaletteEntry] = [
+        PaletteEntry(lightHex: "#FF6B6B", darkBackgroundHex: "3D2010", darkTextHex: "FDBA74"),  // Red / Orange-ish
+        PaletteEntry(lightHex: "#4ECDC4", darkBackgroundHex: "0D3D3D", darkTextHex: "5EEAD4"),  // Teal
+        PaletteEntry(lightHex: "#95E1D3", darkBackgroundHex: "0D3D3D", darkTextHex: "5EEAD4"),  // Mint
+        PaletteEntry(lightHex: "#F38181", darkBackgroundHex: "3D2010", darkTextHex: "FDBA74"),  // Pink-Red
+        PaletteEntry(lightHex: "#AA96DA", darkBackgroundHex: "2D1B4E", darkTextHex: "D8B4FE"),  // Purple
+        PaletteEntry(lightHex: "#FCBAD3", darkBackgroundHex: "2D1B4E", darkTextHex: "D8B4FE"),  // Light Pink
+        PaletteEntry(lightHex: "#FFD93D", darkBackgroundHex: "3D2E10", darkTextHex: "FCD34D"),  // Yellow / Amber
+        PaletteEntry(lightHex: "#6BCB77", darkBackgroundHex: "2D5040", darkTextHex: "4ADE80")   // Green
     ]
+
+    /// Hexes the legacy `palette: [String]` exposed — retained for
+    /// callers that just want a random light-mode hex.
+    static var palette: [String] {
+        entries.map(\.lightHex)
+    }
 
     static func randomHex() -> String {
         palette.randomElement() ?? "#FF6B6B"
+    }
+
+    /// Looks up a palette entry whose `lightHex` matches the supplied
+    /// hex (after normalization). Returns `nil` when no entry matches —
+    /// callers should fall back to the accent-green default.
+    static func entry(forLightHex hex: String) -> PaletteEntry? {
+        let target = Color.normalize(hex: hex).uppercased()
+        return entries.first { entry in
+            Color.normalize(hex: entry.lightHex).uppercased() == target
+        }
     }
 }

--- a/StayInTouch/StayInTouch/Utilities/Views/ErrorToast.swift
+++ b/StayInTouch/StayInTouch/Utilities/Views/ErrorToast.swift
@@ -16,7 +16,7 @@ final class ErrorToastManager: ObservableObject {
     func show(_ error: AppError) {
         currentError = error
         Task {
-            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            try? await Task.sleep(nanoseconds: DS.nanoseconds(DS.Timing.errorToastSeconds))
             if currentError?.id == error.id {
                 currentError = nil
             }


### PR DESCRIPTION
Closes #312. Part of the audit kickoff at #302 (PR 9 of 13).

## Scope

Seven mechanical "consolidate scattered constants/strings" findings. Each is independent and self-contained, hence one commit per finding. **All token values are byte-identical to the literals they replace** — the point of this PR is to centralize constants, not to fix design inconsistencies.

| Finding | Site | Before | After |
|---|---|---|---|
| Q13 | NotificationCenter userInfo (11+ keys/values across 7 sites in `NotificationScheduler.swift` + 5 reader sites in AppDelegate / DeepLinkRouter / SettingsViewModel + 5 test assertions) | Raw `"type"` / `"personId"` / `"category"` keys, raw `"home"` / `"person"` / `"daily"` / `"digest"` / `"birthday"` / `"test"` values | `NotificationIdentifier.UserInfoKey` / `UserInfoValue` enums |
| Q10 | Undo delays (3 × 5s, 1 × 4s) | `Task.sleep(nanoseconds: 5_000_000_000)` etc. | `DS.Timing.undoBannerSeconds` (5.0) + `DS.Timing.errorToastSeconds` (4.0) |
| Q11 | Animation durations (10 sites: 6 × 0.25, 3 × 0.3, 1 × 0.35) | `easeInOut(duration: 0.25)` etc. | `DS.Motion.standard` (0.25), `DS.Motion.expressive` (0.3), `DS.Motion.emphasized` (0.35) |
| Q12 | `frame(minHeight: 48)` × 10 in `PersonSettingsSection.swift` | inline `48` | `DS.Spacing.menuRowHeight = 48` |
| R7 | `phone.filter { \$0.isNumber \|\| \$0 == "+" }` × 2 | inline filter in `MessengerRouter` and `CallerRouter` | `PhoneNormalizer.dialableDigits(_:)` |
| R9 | `+3 day` snooze offset × 2 in `PersonSettingsSection.swift` | inline `Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date()` | `Date.defaultSnoozeStartDate` |
| R12 | Avatar palette (light hexes in `AvatarColors`, dark pairs in `DesignSystem`) | Two parallel lists; adding a 9th color silently fell through to accent green in dark mode | Single source of truth: `AvatarColors.entries: [PaletteEntry]` of `(lightHex, darkBackgroundHex, darkTextHex)`; `DS.Colors.avatarColors(for:scheme:)` reads from it |

## Q12 trade-off (worth surfacing)

`DS.Spacing.tapTarget = 44` already existed (Apple HIG minimum). The `48` literal in `PersonSettingsSection` is **different from `tapTarget`** — 4px taller for visual breathing room around settings row content. Three options:

- (a) collapse 48 → 44 = behavior change, needs design review (deferred — left for a separate ticket)
- (b) add new token at 48 = mechanical, preserves visual output (**chosen**)
- (c) leave literal inline (rejected — 10 repeats hurts maintenance)

If a future designer wants to collapse menu rows to 44 for consistency with the HIG minimum, that's now a single-line change.

## Behavior preservation

- All token values verified byte-identical to prior literals (greps confirm zero inline 0.25 / 0.3 / 0.35 / `minHeight: 48` / 3-day calendar offset / dialable-digits filter / raw `userInfo` keys in target files).
- `NotificationSchedulerTests` keep raw-string assertions intentionally — they independently verify the typed enum raw values still match the wire format, so a typo in the enum definition would fail tests rather than silently change notification routing.
- The avatar palette entries were spot-checked: every prior dark-mode `(background, text)` pair in the `DS.Colors.avatarColors` switch maps to the same `(darkBackgroundHex, darkTextHex)` in `AvatarColors.entries`.

## Verification

- Build: passes
- Tests: 610 passing (baseline ~340 at PR #305, no regressions vs current main)
- Verification greps (zero hits in target files):
  - Raw `"type"` / `"personId"` / `"category"` / `"home"` / `"person"` / `"daily"` / `"digest"` / `"birthday"` userInfo references in `NotificationScheduler.swift` — clean
  - Inline `duration: 0.25` / `0.3` / `0.35` in HomeView / PersonDetailView / PersonSettingsSection — clean
  - `frame(minHeight: 48)` in `PersonSettingsSection.swift` — clean
  - Inline `isNumber || == "+"` filter in `MessengerRouter` / `CallerRouter` — clean
  - `byAdding: .day, value: 3` in `PersonSettingsSection.swift` — clean
  - Avatar palette hexes outside `AvatarColors.swift` — only remaining hits are in `TutorialDemoData.swift` where they're sample preset colors for tutorial cards (not the palette itself)

## Files changed

15 files, +237 / -82.

## Out of scope (preserved untouched)

- `threadIdentifier = "birthday"` in `NotificationScheduler.swift` (different concept from userInfo)
- Tutorial demo avatar hex strings in `TutorialDemoData.swift` (sample preset data, not part of the palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)