### PR TITLE
[#314] Tech debt: DI / layering cleanup (Q14, Q15, N2)

### DIFF
--- a/StayInTouch/StayInTouch/App/AppDependencies.swift
+++ b/StayInTouch/StayInTouch/App/AppDependencies.swift
@@ -44,10 +44,24 @@ struct AppDependencies {
     }
 }
 
+// MARK: - Production resolver
+
+extension AppDependencies {
+    /// Production resolver — the single place that binds the app's
+    /// repositories to `CoreDataStack.shared.viewContext`. Everything
+    /// else (ViewModels, UseCases, Notifications, Intents) reads from
+    /// this seam so the Core Data dependency is centralized in `App/`.
+    ///
+    /// Tests override by passing explicit repositories to a VM's
+    /// designated initializer; SwiftUI previews and integration tests
+    /// override by injecting `.environment(\.dependencies, ...)`.
+    static let shared = AppDependencies(context: CoreDataStack.shared.viewContext)
+}
+
 // MARK: - SwiftUI Environment
 
 private struct AppDependenciesKey: EnvironmentKey {
-    static let defaultValue = AppDependencies(context: CoreDataStack.shared.viewContext)
+    static let defaultValue = AppDependencies.shared
 }
 
 extension EnvironmentValues {

--- a/StayInTouch/StayInTouch/App/StayInTouchApp.swift
+++ b/StayInTouch/StayInTouch/App/StayInTouchApp.swift
@@ -35,6 +35,10 @@ struct KeepInTouchApp: App {
             ContentView()
                 .environment(\.managedObjectContext, coreDataStack.viewContext)
                 .environment(\.dependencies, AppDependencies(context: coreDataStack.viewContext))
+                // Note: in `-uiTesting` runs the coreDataStack is in-memory,
+                // so we pass it through explicitly here. Outside tests
+                // `AppDependencies.shared` already resolves to the same
+                // `CoreDataStack.shared.viewContext`.
                 .onAppear {
                     if coreDataStack.migrationFailed {
                         showMigrationAlert = true

--- a/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
@@ -19,7 +19,7 @@ final class IntentContainer {
     private let lock = NSLock()
     private var cached: AppDependencies?
 
-    private init(resolver: @escaping () -> AppDependencies = { AppDependencies(context: CoreDataStack.shared.viewContext) }) {
+    private init(resolver: @escaping () -> AppDependencies = { AppDependencies.shared }) {
         self.resolver = resolver
     }
 

--- a/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
+++ b/StayInTouch/StayInTouch/AppIntents/IntentContainer.swift
@@ -9,6 +9,14 @@
 //  Resolution is lazy via a function so the container can be swapped
 //  in tests without touching CoreDataStack.shared at import time.
 //
+//  N2 (audit #302) verification: this container does NOT instantiate a
+//  fresh Core Data stack on each intent invocation. The default resolver
+//  returns `AppDependencies.shared`, a process-wide singleton that
+//  resolves once to `CoreDataStack.shared.viewContext`. The first call to
+//  `dependencies` caches the resolved `AppDependencies`; every later
+//  invocation reuses it. Cold-start cost on Siri/Shortcuts runs is the
+//  one-time Core Data stack boot, identical to the UI cold path.
+//
 
 import Foundation
 

--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataBackgroundWorkScheduler.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataBackgroundWorkScheduler.swift
@@ -1,0 +1,34 @@
+//
+//  CoreDataBackgroundWorkScheduler.swift
+//  KeepInTouch
+//
+//  Core Data implementation of `BackgroundWorkScheduler`. Spins up a
+//  fresh background context (or accepts one for tests), constructs the
+//  full set of Core Data repositories bound to it, and runs the caller's
+//  closure inside `context.perform`.
+//
+
+import CoreData
+
+struct CoreDataBackgroundWorkScheduler: BackgroundWorkScheduler {
+    /// Factory for the background context. Defaults to the shared stack;
+    /// tests inject a stable in-memory context.
+    let contextFactory: () -> NSManagedObjectContext
+
+    init(contextFactory: @escaping () -> NSManagedObjectContext = { CoreDataStack.shared.newBackgroundContext() }) {
+        self.contextFactory = contextFactory
+    }
+
+    func perform(_ work: @escaping (BackgroundRepositoryScope) -> Void) async {
+        let context = contextFactory()
+        await context.perform {
+            let scope = BackgroundRepositoryScope(
+                personRepository: CoreDataPersonRepository(context: context),
+                cadenceRepository: CoreDataCadenceRepository(context: context),
+                groupRepository: CoreDataGroupRepository(context: context),
+                touchEventRepository: CoreDataTouchEventRepository(context: context)
+            )
+            work(scope)
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/Domain/Protocols/BackgroundWorkScheduler.swift
+++ b/StayInTouch/StayInTouch/Domain/Protocols/BackgroundWorkScheduler.swift
@@ -1,0 +1,37 @@
+//
+//  BackgroundWorkScheduler.swift
+//  KeepInTouch
+//
+//  Domain-level abstraction for running batched persistence work off the
+//  main actor. UseCases that need to perform many writes against a single
+//  background scope (e.g. JSON import, contacts sync) depend on this
+//  protocol; the Data layer provides the Core Data-backed implementation.
+//
+//  Domain MUST NOT import CoreData, so the protocol surface is opaque:
+//  the scheduler hands the caller a `BackgroundRepositoryScope` —
+//  repository protocol references bound to a private background context
+//  — and serializes the closure body on that context for the caller.
+//
+
+import Foundation
+
+/// Bundle of repository references scoped to a single background unit
+/// of work. All repositories in the scope share the same private context
+/// so saves coalesce into a single persistent-store write.
+struct BackgroundRepositoryScope {
+    let personRepository: PersonRepository
+    let cadenceRepository: CadenceRepository
+    let groupRepository: GroupRepository
+    let touchEventRepository: TouchEventRepository
+}
+
+/// Schedules work that needs a fresh background persistence scope. The
+/// Data layer implementation wraps `NSManagedObjectContext.perform` and
+/// constructs Core Data-backed repositories bound to that context;
+/// UseCases never see the underlying types.
+protocol BackgroundWorkScheduler {
+    /// Run `work` on a fresh background scope, awaiting completion. The
+    /// closure is serialized on the scope's underlying context, so all
+    /// repository calls inside it are thread-safe.
+    func perform(_ work: @escaping (BackgroundRepositoryScope) -> Void) async
+}

--- a/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
+++ b/StayInTouch/StayInTouch/Notifications/NotificationScheduler.swift
@@ -76,9 +76,9 @@ final class NotificationScheduler {
     private var pendingScheduleTask: Task<Void, Never>?
 
     init(
-        settingsRepository: AppSettingsRepository = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext),
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
+        settingsRepository: AppSettingsRepository = AppDependencies.shared.settingsRepository,
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
         notificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current(),
         debounceInterval: TimeInterval = 1.0
     ) {

--- a/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
@@ -21,8 +21,8 @@ final class CadenceContactsViewModel: ObservableObject {
 
     init(
         cadence: Cadence,
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext)
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository
     ) {
         self.cadence = cadence
         self.personRepository = personRepository

--- a/StayInTouch/StayInTouch/UI/ViewModels/GroupContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/GroupContactsViewModel.swift
@@ -16,7 +16,7 @@ final class GroupContactsViewModel: ObservableObject {
     private let personRepository: PersonRepository
     private var allPeople: [Person] = []
 
-    init(group: Group, personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext)) {
+    init(group: Group, personRepository: PersonRepository = AppDependencies.shared.personRepository) {
         self.group = group
         self.personRepository = personRepository
         load()

--- a/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/HomeViewModel.swift
@@ -60,10 +60,10 @@ final class HomeViewModel: ObservableObject {
     private var searchTask: Task<Void, Never>?
 
     init(
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        groupRepository: GroupRepository = CoreDataGroupRepository(context: CoreDataStack.shared.viewContext),
-        settingsRepository: AppSettingsRepository = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext),
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
+        groupRepository: GroupRepository = AppDependencies.shared.groupRepository,
+        settingsRepository: AppSettingsRepository = AppDependencies.shared.settingsRepository,
         promptStore: FreshStartPromptStore = FreshStartPromptStore()
     ) {
         self.personRepository = personRepository

--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageCadencesViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageCadencesViewModel.swift
@@ -16,8 +16,8 @@ final class ManageCadencesViewModel: ObservableObject {
     private let personRepository: PersonRepository
 
     init(
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext)
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
+        personRepository: PersonRepository = AppDependencies.shared.personRepository
     ) {
         self.cadenceRepository = cadenceRepository
         self.personRepository = personRepository

--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
@@ -16,8 +16,8 @@ final class ManageGroupsViewModel: ObservableObject {
     private let personRepository: PersonRepository
 
     init(
-        groupRepository: GroupRepository = CoreDataGroupRepository(context: CoreDataStack.shared.viewContext),
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext)
+        groupRepository: GroupRepository = AppDependencies.shared.groupRepository,
+        personRepository: PersonRepository = AppDependencies.shared.personRepository
     ) {
         self.groupRepository = groupRepository
         self.personRepository = personRepository

--- a/StayInTouch/StayInTouch/UI/ViewModels/PausedContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PausedContactsViewModel.swift
@@ -13,7 +13,7 @@ final class PausedContactsViewModel: ObservableObject {
 
     private let personRepository: PersonRepository
 
-    init(personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext)) {
+    init(personRepository: PersonRepository = AppDependencies.shared.personRepository) {
         self.personRepository = personRepository
         load()
     }

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -61,10 +61,10 @@ final class PersonDetailViewModel: ObservableObject {
     init(
         person: Person,
         mode: Mode = .normal,
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        groupRepository: GroupRepository = CoreDataGroupRepository(context: CoreDataStack.shared.viewContext),
-        touchRepository: TouchEventRepository = CoreDataTouchEventRepository(context: CoreDataStack.shared.viewContext),
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
+        groupRepository: GroupRepository = AppDependencies.shared.groupRepository,
+        touchRepository: TouchEventRepository = AppDependencies.shared.touchEventRepository,
         messengerAvailability: MessengerAvailabilityChecking = SystemMessengerAvailability()
     ) {
         self.person = person

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -57,7 +57,10 @@ final class SettingsViewModel: ObservableObject {
             personRepository: personRepository,
             cadenceRepository: cadenceRepository,
             groupRepository: groupRepository,
-            touchEventRepository: touchEventRepository
+            touchEventRepository: touchEventRepository,
+            backgroundWorkScheduler: CoreDataBackgroundWorkScheduler(
+                contextFactory: { coreDataStack.newBackgroundContext() }
+            )
         )
         self.contactImportService = ContactImportService(
             personRepository: personRepository,

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -35,11 +35,11 @@ final class SettingsViewModel: ObservableObject {
 
     init(
         coreDataStack: CoreDataStack = .shared,
-        settingsRepository: AppSettingsRepository = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        groupRepository: GroupRepository = CoreDataGroupRepository(context: CoreDataStack.shared.viewContext),
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        touchEventRepository: TouchEventRepository = CoreDataTouchEventRepository(context: CoreDataStack.shared.viewContext)
+        settingsRepository: AppSettingsRepository = AppDependencies.shared.settingsRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
+        groupRepository: GroupRepository = AppDependencies.shared.groupRepository,
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        touchEventRepository: TouchEventRepository = AppDependencies.shared.touchEventRepository
     ) {
         self.settingsRepository = settingsRepository
         self.cadenceRepository = cadenceRepository

--- a/StayInTouch/StayInTouch/UI/ViewModels/StatsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/StatsViewModel.swift
@@ -26,9 +26,9 @@ final class StatsViewModel: ObservableObject {
     private let now: () -> Date
 
     init(
-        personRepository: PersonRepository = CoreDataPersonRepository(context: CoreDataStack.shared.viewContext),
-        cadenceRepository: CadenceRepository = CoreDataCadenceRepository(context: CoreDataStack.shared.viewContext),
-        touchEventRepository: TouchEventRepository = CoreDataTouchEventRepository(context: CoreDataStack.shared.viewContext),
+        personRepository: PersonRepository = AppDependencies.shared.personRepository,
+        cadenceRepository: CadenceRepository = AppDependencies.shared.cadenceRepository,
+        touchEventRepository: TouchEventRepository = AppDependencies.shared.touchEventRepository,
         calculator: StatsCalculator = StatsCalculator(),
         range: StatsRange = .days30,
         now: @escaping () -> Date = Date.init

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -11,6 +11,7 @@ struct PersonDetailView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dependencies) private var dependencies
 
     @StateObject private var viewModel: PersonDetailViewModel
 
@@ -505,7 +506,7 @@ struct PersonDetailView: View {
         if let custom = viewModel.person.customBreachTime {
             return custom.toDate()
         }
-        if let settings = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext).fetch() {
+        if let settings = dependencies.settingsRepository.fetch() {
             return settings.breachTimeOfDay.toDate()
         }
         return Date()

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -9,6 +9,7 @@ struct PersonSettingsSection: View {
     @ObservedObject var viewModel: PersonDetailViewModel
     @Binding var settingsExpanded: Bool
     var onAction: (PersonSettingsAction) -> Void
+    @Environment(\.dependencies) private var dependencies
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -348,7 +349,7 @@ struct PersonSettingsSection: View {
         if let custom = viewModel.person.customBreachTime {
             return custom.formatted
         }
-        if let settings = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext).fetch() {
+        if let settings = dependencies.settingsRepository.fetch() {
             return settings.breachTimeOfDay.formatted
         }
         return "Default"

--- a/StayInTouch/StayInTouch/UseCases/AnalyticsService.swift
+++ b/StayInTouch/StayInTouch/UseCases/AnalyticsService.swift
@@ -17,8 +17,7 @@ enum AnalyticsService {
             let config = TelemetryDeck.Config(appID: "C41D550D-50EA-40BC-9605-584654EE2D5B")
             TelemetryDeck.initialize(config: config)
             // Read initial analytics setting from Core Data
-            let repo = CoreDataAppSettingsRepository(context: CoreDataStack.shared.viewContext)
-            _isEnabled = repo.fetch()?.analyticsEnabled ?? true
+            _isEnabled = AppDependencies.shared.settingsRepository.fetch()?.analyticsEnabled ?? true
             _isInitialized = true
         }
     }

--- a/StayInTouch/StayInTouch/UseCases/DataImportService.swift
+++ b/StayInTouch/StayInTouch/UseCases/DataImportService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CoreData
 import Contacts
 
 struct DataImportService {
@@ -14,7 +13,12 @@ struct DataImportService {
     let cadenceRepository: CadenceRepository
     let groupRepository: GroupRepository
     let touchEventRepository: TouchEventRepository
-    var backgroundContextProvider: (() -> NSManagedObjectContext)? = nil
+    /// Background persistence scope. Production callers wire the Core Data
+    /// implementation from the composition root; tests inject a scheduler
+    /// bound to an in-memory context so the import path can be exercised
+    /// without touching the real store. UseCases never reference Core Data
+    /// types directly — the scheduler protocol is the seam.
+    let backgroundWorkScheduler: BackgroundWorkScheduler
 
     static func touchEventDedupKey(personId: UUID, date: Date, method: TouchMethod, notes: String?, calendar: Calendar) -> String {
         let dayKey = Int(calendar.startOfDay(for: date).timeIntervalSince1970)
@@ -246,12 +250,11 @@ struct DataImportService {
     func executeImport(_ preview: ImportPreview) async -> ImportResult {
         var importedNewPeople: [(id: UUID, displayName: String)] = []
 
-        let backgroundContext = backgroundContextProvider?() ?? CoreDataStack.shared.newBackgroundContext()
-        await backgroundContext.perform {
-            let peopleRepo = CoreDataPersonRepository(context: backgroundContext)
-            let touchRepo = CoreDataTouchEventRepository(context: backgroundContext)
-            let cadenceRepo = CoreDataCadenceRepository(context: backgroundContext)
-            let groupRepo = CoreDataGroupRepository(context: backgroundContext)
+        await backgroundWorkScheduler.perform { scope in
+            let peopleRepo = scope.personRepository
+            let touchRepo = scope.touchEventRepository
+            let cadenceRepo = scope.cadenceRepository
+            let groupRepo = scope.groupRepository
 
             let now = Date()
 

--- a/StayInTouch/StayInTouchTests/DataImportServiceIntegrationTests.swift
+++ b/StayInTouch/StayInTouchTests/DataImportServiceIntegrationTests.swift
@@ -31,7 +31,9 @@ final class DataImportServiceIntegrationTests: XCTestCase {
             cadenceRepository: cadenceRepo,
             groupRepository: groupRepo,
             touchEventRepository: touchRepo,
-            backgroundContextProvider: { [unowned self] in self.context }
+            backgroundWorkScheduler: CoreDataBackgroundWorkScheduler(
+                contextFactory: { [unowned self] in self.context }
+            )
         )
     }
 


### PR DESCRIPTION
Closes #314. Audit parent: #302.

## Scope

PR 11 of the 13-PR tech-debt refactor. Three findings from the audit:

- **Q14** — `CoreDataStack.shared.viewContext` was hard-coded as the default arg in 9 ViewModels, the NotificationScheduler init, AnalyticsService.initialize, IntentContainer's default resolver, and two PersonDetail view-body inline repo instantiations. This bypassed AppDependencies and made the DI seam advisory rather than the actual production path.
- **Q15** — `DataImportService.backgroundContextProvider: (() -> NSManagedObjectContext)?` forced UseCases to `import CoreData`, breaking the Domain/Data layering boundary.
- **N2** — Verify IntentContainer (PR #305) doesn't boot a fresh Core Data stack on each Siri/Shortcut intent invocation.

## Q14 fix

Added `AppDependencies.shared` as the single production seam in `App/AppDependencies.swift`. It lazily resolves once to `CoreDataStack(.shared.viewContext)` — the same context the defaults previously used. Replaced every `CoreDataStack.shared.viewContext`-based default arg with the matching `AppDependencies.shared.xxxRepository`. The two `PersonDetail` view bodies that instantiated `CoreDataAppSettingsRepository` inline now read `@Environment(\.dependencies)` and call `dependencies.settingsRepository.fetch()`.

After the change:
- `grep -r 'CoreDataStack.shared.viewContext' StayInTouch/StayInTouch/UI/ StayInTouch/StayInTouch/UseCases/` → zero hits
- `grep -r 'CoreDataAppSettingsRepository(' StayInTouch/StayInTouch/UI/Views/` → zero hits
- Outside `App/`, no file references `CoreDataStack.shared.viewContext` at all.

## Q15 fix

Defined `BackgroundWorkScheduler` protocol in `Domain/Protocols/` with an opaque `BackgroundRepositoryScope` payload — four Domain repository protocol references bound to the scope's underlying context. The protocol surface contains zero Core Data types. `CoreDataBackgroundWorkScheduler` in `Data/CoreData/` wraps `NSManagedObjectContext.perform` and constructs the Core Data-backed repositories.

`DataImportService` now takes a `BackgroundWorkScheduler` as a required init dependency, and `import CoreData` is gone. The composition root (`SettingsViewModel`) wires the production scheduler from `CoreDataStack.newBackgroundContext`; the integration test injects a scheduler bound to its in-memory test context so the import path is still exercised end-to-end against real Core Data writes.

After the change:
- `grep -r 'import CoreData' StayInTouch/StayInTouch/UseCases/ StayInTouch/StayInTouch/Domain/` → zero hits in source code (one comment match in the new protocol header).

## N2 outcome — FIXED (no behavior change)

`IntentContainer` already uses a lazy resolver + cached `AppDependencies?` behind an `NSLock`. After Q14 the default resolver returns `AppDependencies.shared`, a process-wide singleton that resolves once to `CoreDataStack.shared.viewContext`. Per-intent invocation reuses the cached container — no fresh Core Data stack boot. Added a header comment to `IntentContainer.swift` recording the verification so this doesn't have to be redone.

## Behavior assertion

North star is unchanged: open the app, notice zero difference. Same ViewModels resolve to the same `CoreDataStack.shared.viewContext`, just routed through the explicit DI seam instead of nine duplicated `CoreDataStack.shared.viewContext` defaults. Tests already passed explicit repositories (no test depended on the default-arg path), so the test infrastructure migration cost was 1 line — the `DataImportService` integration test, which trades its `backgroundContextProvider` closure for an in-memory `CoreDataBackgroundWorkScheduler`.

## Test infrastructure cost

Test files touched: **1** (`StayInTouchTests/DataImportServiceIntegrationTests.swift`) — well under the 30-file NEEDS HUMAN threshold. Test count: 605 passing, 0 failing (stable across two runs).

## Diff size

20 files, +149 / -43 lines, 2 new files (`BackgroundWorkScheduler.swift`, `CoreDataBackgroundWorkScheduler.swift`).

## Commits

1. `[#314] Q14: route VM/service defaults through AppDependencies.shared`
2. `[#314] Q15: BackgroundWorkScheduler protocol restores Domain/Data layering`
3. `[#314] N2: document IntentContainer stack reuse verification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)