### PR TITLE
[#315] Tech debt: ViewModelErrorHandling helper (Q9)

### DIFF
--- a/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/CadenceContactsViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class CadenceContactsViewModel: ObservableObject {
+final class CadenceContactsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var people: [Person] = []
     @Published private(set) var available: [Person] = []
     @Published private(set) var otherCadences: [Cadence] = []
@@ -54,11 +54,8 @@ final class CadenceContactsViewModel: ObservableObject {
 
     func movePerson(_ person: Person, to destinationCadenceId: UUID) {
         let updated = AssignCadenceUseCase().assign(person: person, to: destinationCadenceId)
-        do {
+        handleWrite("CadenceContactsViewModel.movePerson", fallback: .saveFailed("CadenceContacts")) {
             try personRepository.save(updated)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "CadenceContactsViewModel.movePerson")
-            ErrorToastManager.shared.show(.saveFailed("CadenceContacts"))
         }
         NotificationCenter.default.post(name: .personDidChange, object: updated.id)
         load()
@@ -81,11 +78,8 @@ final class CadenceContactsViewModel: ObservableObject {
             load()
             return
         }
-        do {
+        handleWrite("CadenceContactsViewModel.addPeople", fallback: .saveFailed("CadenceContacts")) {
             try personRepository.batchSave(updates)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "CadenceContactsViewModel.addPeople")
-            ErrorToastManager.shared.show(.saveFailed("CadenceContacts"))
         }
         // Pass nil as object since the post covers a set of people; observers
         // ignore the object payload (they reload everything anyway).

--- a/StayInTouch/StayInTouch/UI/ViewModels/GroupContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/GroupContactsViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class GroupContactsViewModel: ObservableObject {
+final class GroupContactsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var people: [Person] = []
     @Published private(set) var available: [Person] = []
 
@@ -37,11 +37,8 @@ final class GroupContactsViewModel: ObservableObject {
         var updated = person
         updated.groupIds = updated.groupIds.filter { $0 != group.id }
         updated.modifiedAt = Date()
-        do {
+        handleWrite("GroupContactsViewModel.removeGroup", fallback: .saveFailed("GroupContacts")) {
             try personRepository.save(updated)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "GroupContactsViewModel.removeGroup")
-            ErrorToastManager.shared.show(.saveFailed("GroupContacts"))
         }
         NotificationCenter.default.post(name: .personDidChange, object: updated.id)
         load()
@@ -54,11 +51,8 @@ final class GroupContactsViewModel: ObservableObject {
                 updated.groupIds.append(group.id)
             }
             updated.modifiedAt = Date()
-            do {
+            handleWrite("GroupContactsViewModel.addGroup", fallback: .saveFailed("GroupContacts")) {
                 try personRepository.save(updated)
-            } catch {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "GroupContactsViewModel.addGroup")
-                ErrorToastManager.shared.show(.saveFailed("GroupContacts"))
             }
             NotificationCenter.default.post(name: .personDidChange, object: updated.id)
         }

--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageCadencesViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageCadencesViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class ManageCadencesViewModel: ObservableObject {
+final class ManageCadencesViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var cadences: [Cadence] = []
     @Published private(set) var countsByCadence: [UUID: Int] = [:]
 
@@ -57,27 +57,15 @@ final class ManageCadencesViewModel: ObservableObject {
                 var cleared = existing
                 cleared.isDefault = false
                 cleared.modifiedAt = Date()
-                do {
+                handleRepositoryWrite("ManageCadencesViewModel.save.clearDefault", fallback: .saveFailed("ManageCadences")) {
                     try cadenceRepository.save(cleared)
-                } catch let error as RepositoryError {
-                    AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.save.clearDefault")
-                    ErrorToastManager.shared.show(AppError(message: error.userMessage))
-                } catch {
-                    AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.save.clearDefault (unexpected)")
-                    ErrorToastManager.shared.show(.saveFailed("ManageCadences"))
                 }
             }
             updated.isDefault = true
         }
 
-        do {
+        handleRepositoryWrite("ManageCadencesViewModel.save", fallback: .saveFailed("ManageCadences")) {
             try cadenceRepository.save(updated)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.save")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.save (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("ManageCadences"))
         }
         load()
     }
@@ -88,14 +76,8 @@ final class ManageCadencesViewModel: ObservableObject {
             ?? cadences.first(where: { $0.id != cadence.id }) {
             movePeople(from: cadence, to: fallback)
         }
-        do {
+        handleRepositoryWrite("ManageCadencesViewModel.delete", fallback: .deleteFailed("ManageCadences")) {
             try cadenceRepository.delete(id: cadence.id)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.delete")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.delete (unexpected)")
-            ErrorToastManager.shared.show(.deleteFailed("ManageCadences"))
         }
         load()
     }
@@ -111,14 +93,8 @@ final class ManageCadencesViewModel: ObservableObject {
             updated.modifiedAt = now
             return updated
         }
-        do {
+        handleRepositoryWrite("ManageCadencesViewModel.movePeople", fallback: .saveFailed("ManageCadences")) {
             try personRepository.batchSave(updatedPeople)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.movePeople")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageCadencesViewModel.movePeople (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("ManageCadences"))
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ManageGroupsViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class ManageGroupsViewModel: ObservableObject {
+final class ManageGroupsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var groups: [Group] = []
     @Published private(set) var countsByGroup: [UUID: Int] = [:]
 
@@ -50,14 +50,8 @@ final class ManageGroupsViewModel: ObservableObject {
     func save(_ group: Group) {
         var updated = group
         updated.modifiedAt = Date()
-        do {
+        handleRepositoryWrite("ManageGroupsViewModel.save", fallback: .saveFailed("ManageGroups")) {
             try groupRepository.save(updated)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.save")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.save (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("ManageGroups"))
         }
         load()
     }
@@ -66,14 +60,8 @@ final class ManageGroupsViewModel: ObservableObject {
         // Remove group references from persons first, then delete entity
         // This order prevents orphaned groupId references on crash
         removeGroupFromPeople(groupId: group.id)
-        do {
+        handleRepositoryWrite("ManageGroupsViewModel.delete", fallback: .deleteFailed("ManageGroups")) {
             try groupRepository.delete(id: group.id)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.delete")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.delete (unexpected)")
-            ErrorToastManager.shared.show(.deleteFailed("ManageGroups"))
         }
         load()
     }
@@ -89,14 +77,8 @@ final class ManageGroupsViewModel: ObservableObject {
             updatedPeople.append(updated)
         }
         guard !updatedPeople.isEmpty else { return }
-        do {
+        handleRepositoryWrite("ManageGroupsViewModel.removeGroupFromPeople", fallback: .saveFailed("ManageGroups")) {
             try personRepository.batchSave(updatedPeople)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.removeGroupFromPeople")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "ManageGroupsViewModel.removeGroupFromPeople (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("ManageGroups"))
         }
     }
 }

--- a/StayInTouch/StayInTouch/UI/ViewModels/OnboardingViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/OnboardingViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import UserNotifications
 
 @MainActor
-final class OnboardingViewModel: ObservableObject {
+final class OnboardingViewModel: ObservableObject, ViewModelErrorHandling {
     enum Step {
         case welcome
         case contactsPermission
@@ -261,11 +261,8 @@ final class OnboardingViewModel: ObservableObject {
     private func updateNotificationsEnabled(_ enabled: Bool) {
         guard var settings else { return }
         settings.notificationsEnabled = enabled
-        do {
+        handleWrite("OnboardingViewModel.updateNotificationsEnabled", fallback: .saveFailed("Onboarding")) {
             try settingsRepository.save(settings)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "OnboardingViewModel.updateNotificationsEnabled")
-            ErrorToastManager.shared.show(.saveFailed("Onboarding"))
         }
         self.settings = settings
     }
@@ -273,11 +270,8 @@ final class OnboardingViewModel: ObservableObject {
     private func seedDemoData() {
         guard var settings else { return }
         settings.demoModeEnabled = true
-        do {
+        handleWrite("OnboardingViewModel.seedDemoData", fallback: .saveFailed("Onboarding")) {
             try settingsRepository.save(settings)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "OnboardingViewModel.seedDemoData")
-            ErrorToastManager.shared.show(.saveFailed("Onboarding"))
         }
         self.settings = settings
 
@@ -292,11 +286,8 @@ final class OnboardingViewModel: ObservableObject {
         AnalyticsService.track("onboarding.completed")
         guard var settings else { return }
         settings.onboardingCompleted = true
-        do {
+        handleWrite("OnboardingViewModel.completeOnboarding", fallback: .saveFailed("Onboarding")) {
             try settingsRepository.save(settings)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "OnboardingViewModel.completeOnboarding")
-            ErrorToastManager.shared.show(.saveFailed("Onboarding"))
         }
         self.settings = settings
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/PausedContactsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PausedContactsViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class PausedContactsViewModel: ObservableObject {
+final class PausedContactsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var people: [Person] = []
 
     private let personRepository: PersonRepository
@@ -35,11 +35,8 @@ final class PausedContactsViewModel: ObservableObject {
             updated.lastTouchAt = lastTouchAt
         }
         updated.modifiedAt = Date()
-        do {
+        handleWrite("PausedContactsViewModel.resume", fallback: .saveFailed("PausedContacts")) {
             try personRepository.save(updated)
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PausedContactsViewModel.resume")
-            ErrorToastManager.shared.show(.saveFailed("PausedContacts"))
         }
         NotificationCenter.default.post(name: .personDidChange, object: updated.id)
     }

--- a/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/PersonDetailViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class PersonDetailViewModel: ObservableObject {
+final class PersonDetailViewModel: ObservableObject, ViewModelErrorHandling {
     /// Operating mode. `.preview` is used by the tutorial walkthrough to render
     /// PersonDetailView against an in-memory demo contact without touching the
     /// real repositories. All mutation methods early-return in `.preview` mode.
@@ -283,14 +283,8 @@ final class PersonDetailViewModel: ObservableObject {
                 createdAt: Date(),
                 modifiedAt: Date()
             )
-            do {
+            handleRepositoryWrite("PersonDetailViewModel.resumeAndUpdateLastTouch", fallback: .saveFailed("PersonDetail")) {
                 try touchRepository.save(touch)
-            } catch let error as RepositoryError {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.resumeAndUpdateLastTouch")
-                ErrorToastManager.shared.show(AppError(message: error.userMessage))
-            } catch {
-                AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.resumeAndUpdateLastTouch (unexpected)")
-                ErrorToastManager.shared.show(.saveFailed("PersonDetail"))
             }
 
             updated.lastTouchAt = date
@@ -335,14 +329,8 @@ final class PersonDetailViewModel: ObservableObject {
             createdAt: now,
             modifiedAt: now
         )
-        do {
+        handleRepositoryWrite("PersonDetailViewModel.logTouch", fallback: .saveFailed("PersonDetail")) {
             try touchRepository.save(touch)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.logTouch")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.logTouch (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("PersonDetail"))
         }
 
         // Newest-wins: a back-dated touch should not overwrite the
@@ -360,14 +348,8 @@ final class PersonDetailViewModel: ObservableObject {
         updatedTouch.timeOfDay = timeOfDay
         updatedTouch.notes = notes
         updatedTouch.modifiedAt = Date()
-        do {
+        handleRepositoryWrite("PersonDetailViewModel.updateTouch", fallback: .saveFailed("PersonDetail")) {
             try touchRepository.save(updatedTouch)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.updateTouch")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.updateTouch (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("PersonDetail"))
         }
 
         touchEvents = fetchSortedEvents()
@@ -384,14 +366,8 @@ final class PersonDetailViewModel: ObservableObject {
     func deleteTouch(_ touch: TouchEvent) {
         if isPreview { return }
         AnalyticsService.track("connection.deleted")
-        do {
+        handleRepositoryWrite("PersonDetailViewModel.deleteTouch", fallback: .deleteFailed("PersonDetail")) {
             try touchRepository.delete(id: touch.id)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.deleteTouch")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.deleteTouch (unexpected)")
-            ErrorToastManager.shared.show(.deleteFailed("PersonDetail"))
         }
         touchEvents = fetchSortedEvents()
 
@@ -419,7 +395,7 @@ final class PersonDetailViewModel: ObservableObject {
     func deletePerson() {
         if isPreview { return }
         AnalyticsService.track("person.deleted")
-        do {
+        handleRepositoryWrite("PersonDetailViewModel.deletePerson", fallback: .deleteFailed("PersonDetail")) {
             // E8: cascade-delete all TouchEvents for this person in one save
             // + one widget refresh instead of N transactions / N refreshes.
             // batchDelete is a no-op when events is empty, matching the
@@ -429,12 +405,6 @@ final class PersonDetailViewModel: ObservableObject {
             try touchRepository.batchDelete(ids: eventIds)
             try personRepository.delete(id: person.id)
             NotificationCenter.default.post(name: .personDidChange, object: person.id)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.deletePerson")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.deletePerson (unexpected)")
-            ErrorToastManager.shared.show(.deleteFailed("PersonDetail"))
         }
     }
 
@@ -606,7 +576,7 @@ final class PersonDetailViewModel: ObservableObject {
     /// the scheduler side coalesces bursts without dropping any.
     private func savePerson(_ updated: Person) {
         let previous = person
-        do {
+        handleRepositoryWrite("PersonDetailViewModel.savePerson", fallback: .saveFailed("PersonDetail")) {
             try personRepository.save(updated)
             person = updated
 
@@ -619,12 +589,6 @@ final class PersonDetailViewModel: ObservableObject {
             }
 
             NotificationCenter.default.post(name: .personDidChange, object: updated.id)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.savePerson")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "PersonDetailViewModel.savePerson (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("PersonDetail"))
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -10,7 +10,7 @@ import UserNotifications
 import Contacts
 
 @MainActor
-final class SettingsViewModel: ObservableObject {
+final class SettingsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var settings: AppSettings
     @Published private(set) var allCadences: [Cadence] = []
     @Published private(set) var cadencesCount: Int = 0
@@ -440,14 +440,8 @@ final class SettingsViewModel: ObservableObject {
     // MARK: - Private
 
     private func save() {
-        do {
+        handleRepositoryWrite("SettingsViewModel.save", fallback: .saveFailed("Settings")) {
             try settingsRepository.save(settings)
-        } catch let error as RepositoryError {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "SettingsViewModel.save")
-            ErrorToastManager.shared.show(AppError(message: error.userMessage))
-        } catch {
-            AppLogger.logError(error, category: AppLogger.viewModel, context: "SettingsViewModel.save (unexpected)")
-            ErrorToastManager.shared.show(.saveFailed("Settings"))
         }
         NotificationCenter.default.post(name: .settingsDidChange, object: nil)
     }

--- a/StayInTouch/StayInTouch/UI/ViewModels/ViewModelErrorHandling.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/ViewModelErrorHandling.swift
@@ -1,0 +1,77 @@
+//
+//  ViewModelErrorHandling.swift
+//  KeepInTouch
+//
+//  Created by Claude Code on 5/27/26.
+//
+
+import Foundation
+
+/// Marker protocol for view models that route repository write/delete
+/// failures through the standard log + error-toast path.
+///
+/// The two helpers below collapse the ~16 near-identical catch blocks that
+/// previously lived inline in each view model. Behavior is preserved exactly:
+/// same `AppLogger` category + context strings, same `ErrorToastManager.shared`
+/// toasts. Conformers gain the helpers for free via the extension; the protocol
+/// itself carries no requirements because every call site already reaches the
+/// toast manager through its `.shared` singleton.
+///
+/// `@MainActor` because both helpers touch `ErrorToastManager.shared`, which is
+/// main-actor isolated. All conforming view models are already `@MainActor`.
+@MainActor
+protocol ViewModelErrorHandling {}
+
+extension ViewModelErrorHandling {
+    /// Runs `block`, routing a thrown error through the standard log + toast
+    /// path. Mirrors the original two-branch catch:
+    ///
+    /// - `RepositoryError`: logged under `context`, toast shows the error's
+    ///   own `userMessage`.
+    /// - any other error: logged under `"\(context) (unexpected)"`, toast
+    ///   shows the supplied `fallback` (e.g. `.saveFailed` / `.deleteFailed`).
+    ///
+    /// Returns the block's result, or `nil` on failure. Discard the result for
+    /// `Void`-returning blocks — control still returns to the caller so any
+    /// post-catch work (state updates, reloads, notifications) runs exactly as
+    /// it did before.
+    @discardableResult
+    func handleRepositoryWrite<T>(
+        _ context: String,
+        fallback: AppError,
+        _ block: () throws -> T
+    ) -> T? {
+        do {
+            return try block()
+        } catch let error as RepositoryError {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: context)
+            ErrorToastManager.shared.show(AppError(message: error.userMessage))
+            return nil
+        } catch {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: "\(context) (unexpected)")
+            ErrorToastManager.shared.show(fallback)
+            return nil
+        }
+    }
+
+    /// Runs `block`, routing any thrown error through a single log + toast
+    /// path (no typed `RepositoryError` branch). Mirrors the call sites that
+    /// used one untyped `catch`: logged under `context`, toast shows
+    /// `fallback`.
+    ///
+    /// Returns the block's result, or `nil` on failure.
+    @discardableResult
+    func handleWrite<T>(
+        _ context: String,
+        fallback: AppError,
+        _ block: () throws -> T
+    ) -> T? {
+        do {
+            return try block()
+        } catch {
+            AppLogger.logError(error, category: AppLogger.viewModel, context: context)
+            ErrorToastManager.shared.show(fallback)
+            return nil
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/UI/ViewModels/WalkthroughCoordinator.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/WalkthroughCoordinator.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @MainActor
-final class WalkthroughCoordinator: ObservableObject {
+final class WalkthroughCoordinator: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var currentStep: WalkthroughStep?
     @Published private(set) var isPresentingDemoDetail: Bool = false
     private(set) var stepHistory: [WalkthroughStep] = []
@@ -166,15 +166,8 @@ final class WalkthroughCoordinator: ObservableObject {
         guard var settings = settingsRepository.fetch() else { return }
         settings.tutorialCompleted = true
         settings.tutorialVersion = Self.currentVersion
-        do {
+        handleWrite("WalkthroughCoordinator.saveCompletionFlag", fallback: .saveFailed("Tutorial")) {
             try settingsRepository.save(settings)
-        } catch {
-            AppLogger.logError(
-                error,
-                category: AppLogger.viewModel,
-                context: "WalkthroughCoordinator.saveCompletionFlag"
-            )
-            ErrorToastManager.shared.show(.saveFailed("Tutorial"))
         }
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the repeated repository-error catch boilerplate (~16 sites, ~115 LOC of duplication) into a `ViewModelErrorHandling` protocol with default-implemented `handleWrite` / `handleRepositoryWrite` helpers. Any future catch site routes log + toast through one place, removing the risk of a new site silently dropping an error.

## Changes

- **New** `UI/ViewModels/ViewModelErrorHandling.swift` (77 LOC) — protocol + extension with two helpers:
  - `handleRepositoryWrite` — typed `catch let as RepositoryError` path (shows `error.userMessage`) + untyped fallback path (shows static fallback, appends `" (unexpected)"` to log context)
  - `handleWrite` — single-catch path that shows the static fallback for all errors (Pattern B sites)
- **Migrated 9 ViewModels**: CadenceContactsViewModel, GroupContactsViewModel, ManageCadencesViewModel, ManageGroupsViewModel, OnboardingViewModel, PausedContactsViewModel, PersonDetailViewModel, SettingsViewModel, WalkthroughCoordinator

## Behavior preservation (audited per-site)

- **On-success multi-statement work** (e.g. `deletePerson`/`savePerson` posting `.personDidChange` + re-deriving caches) stays INSIDE the closure — runs only when no error thrown, identical to the original `do` block
- **Typed vs untyped context suffix**: `" (unexpected)"` appended only in the untyped branch, matching every original site
- **Fallback AppErrors**: each site keeps its original fallback (`.saveFailed` / `.deleteFailed` / etc.) passed as a parameter
- **3 sites with divergent semantics deliberately NOT migrated** — left with their inline catch blocks (they do extra rollback/state-reset work beyond log + toast)
- `@discardableResult` on the helpers since no call site uses the return value

## Verification

- Build clean (Swift 6 strict concurrency — all VMs + helper are `@MainActor`, closures non-escaping)
- `** TEST SUCCEEDED **` — full suite, no count drop
- Error-path tests pass unchanged (proves toast/log behavior preserved)

Closes #315. Tracked in #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)