### PR TITLE
fix: bump MARKETING_VERSION to 0.5.0 for correct archive version

### DIFF
--- a/StayInTouch/StayInTouch.xcodeproj/project.pbxproj
+++ b/StayInTouch/StayInTouch.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch.KeepInTouchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -494,7 +494,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch.KeepInTouchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -652,7 +652,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -686,7 +686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -705,7 +705,7 @@
 				DEVELOPMENT_TEAM = AFG8NJ774P;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouchTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -724,7 +724,7 @@
 				DEVELOPMENT_TEAM = AFG8NJ774P;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouchTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -741,7 +741,7 @@
 				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = AFG8NJ774P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouchUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -758,7 +758,7 @@
 				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = AFG8NJ774P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = slavins.co.KeepInTouchUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;


### PR DESCRIPTION
## Problem

Archiving v0.5.0 in Xcode produced an archive reporting version **0.4.0**.

## Root cause

The archive's `CFBundleShortVersionString` is sourced from the `MARKETING_VERSION` build setting, **not** the git tag. The git tag only feeds the in-app `GeneratedVersion.swift` label (the About-screen string). The v0.5.0 release prep ([#337](https://github.com/slavins-co/keep-in-touch/pull/337)) intentionally left `MARKETING_VERSION` at `0.4.0` on the mistaken assumption it was display-only - so archives kept reporting 0.4.0.

## Fix

Bump `MARKETING_VERSION` 0.4.0 -> 0.5.0 across all 8 build configs. The build number (`CURRENT_PROJECT_VERSION` = 14) is already correct.

After merge: pull `main` and re-archive - it will report 0.5.0 (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)