### PR TITLE
[#79] Tier 0 iCloud-backup UX: Backup reassurance + Data sub-view

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
@@ -1,0 +1,182 @@
+//
+//  DataSettingsView.swift
+//  KeepInTouch
+//
+//  Backup reassurance + data export/import, extracted from SettingsView.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DataSettingsView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+
+    @State private var shareItem: ShareItem?
+    @State private var showFilePicker = false
+    @State private var importPreview: ImportPreview?
+    @State private var showImportSuccessAlert = false
+    @State private var showImportErrorAlert = false
+    @State private var importResultMessage = ""
+    @State private var showExportFormatPicker = false
+    @State private var showPostImportMatch = false
+    @State private var postImportResult: ImportResult?
+    @State private var postImportMatchSummary: ContactMatchSummary?
+
+    var body: some View {
+        List {
+            backupSection
+            exportImportSection
+        }
+        .listStyle(.insetGrouped)
+        .tint(DS.Colors.accent)
+        .navigationTitle("Backup & Data")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $shareItem) { item in
+            ShareSheet(items: item.urls) {
+                for url in item.urls {
+                    try? FileManager.default.removeItem(at: url)
+                }
+            }
+        }
+        .fileImporter(isPresented: $showFilePicker, allowedContentTypes: [UTType.json]) { result in
+            switch result {
+            case .success(let url):
+                Task {
+                    if let preview = await viewModel.parseImportFile(url: url) {
+                        importPreview = preview
+                    } else {
+                        importResultMessage = "Could not read the file. Make sure it is a valid Keep In Touch export."
+                        showImportErrorAlert = true
+                    }
+                }
+            case .failure:
+                importResultMessage = "Could not open the file."
+                showImportErrorAlert = true
+            }
+        }
+        .sheet(item: $importPreview) { preview in
+            ImportPreviewView(
+                preview: preview,
+                onImport: { resolvedPreview in
+                    importPreview = nil
+                    Task {
+                        let (result, matchSummary) = await viewModel.performFileImport(resolvedPreview)
+
+                        if let matchSummary {
+                            postImportResult = result
+                            postImportMatchSummary = matchSummary
+                            showPostImportMatch = true
+                        } else {
+                            var parts: [String] = []
+                            if result.totalPeople > 0 {
+                                parts.append("\(result.totalPeople) contact\(result.totalPeople == 1 ? "" : "s")")
+                            }
+                            if result.cadencesCreated > 0 {
+                                parts.append("\(result.cadencesCreated) frequenc\(result.cadencesCreated == 1 ? "y" : "ies")")
+                            }
+                            if result.groupsCreated > 0 {
+                                parts.append("\(result.groupsCreated) group\(result.groupsCreated == 1 ? "" : "s")")
+                            }
+                            importResultMessage = parts.isEmpty
+                                ? "Nothing was imported."
+                                : "Imported \(parts.joined(separator: ", ")) successfully."
+                            showImportSuccessAlert = true
+                        }
+                    }
+                },
+                onCancel: {
+                    importPreview = nil
+                }
+            )
+        }
+        .sheet(isPresented: $showPostImportMatch) {
+            if let result = postImportResult, let matchSummary = postImportMatchSummary {
+                PostImportMatchView(
+                    importResult: result,
+                    matchSummary: matchSummary,
+                    viewModel: viewModel,
+                    onDismiss: { showPostImportMatch = false }
+                )
+            }
+        }
+        .alert("Import Complete", isPresented: $showImportSuccessAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importResultMessage)
+        }
+        .alert("Import Failed", isPresented: $showImportErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importResultMessage)
+        }
+    }
+
+    // MARK: - Backup
+
+    private var backupSection: some View {
+        Section {
+            HStack(spacing: DS.Spacing.md) {
+                Image(systemName: "externaldrive.fill")
+                    .font(.title3)
+                    .foregroundStyle(DS.Colors.statusAllGood)
+                Text("Your data is backed up with your device")
+                    .font(DS.Typography.settingsRowLabel)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Your data is backed up with your device")
+            .accessibilityHint("Your relationship data is restored automatically when you set up a new iPhone from an iCloud backup")
+        } header: {
+            Text("Backup")
+        } footer: {
+            Text("Keep In Touch stores everything on your device, and your relationship data is never sent to us. When iCloud Backup is turned on in iOS Settings, this app's data is included in your device's encrypted backup and restores automatically on a new iPhone. For a portable copy you control, use Export below to save a file to Files or iCloud Drive.")
+                .font(DS.Typography.caption)
+                .foregroundStyle(DS.Colors.secondaryText)
+        }
+    }
+
+    // MARK: - Export & Import
+
+    private var exportImportSection: some View {
+        Section {
+            Button {
+                showExportFormatPicker = true
+            } label: {
+                Label("Export Contacts", systemImage: "square.and.arrow.up")
+            }
+            .confirmationDialog("Export Format", isPresented: $showExportFormatPicker) {
+                ForEach(ExportFormat.allCases, id: \.self) { format in
+                    Button(format.displayName) {
+                        let urls = viewModel.exportContacts(format: format)
+                        if !urls.isEmpty {
+                            shareItem = ShareItem(urls: urls)
+                        }
+                    }
+                }
+            } message: {
+                Text("Choose a format for your export.")
+            }
+
+            Button {
+                showFilePicker = true
+            } label: {
+                Label("Import Contacts", systemImage: "square.and.arrow.down")
+            }
+
+            if viewModel.isImporting {
+                HStack(spacing: DS.Spacing.md) {
+                    ProgressView()
+                    Text("Importing...")
+                        .font(DS.Typography.metadata)
+                        .foregroundStyle(DS.Colors.secondaryText)
+                }
+            }
+        } header: {
+            Text("Export & Import")
+        }
+    }
+}
+
+private struct ShareItem: Identifiable {
+    let id = UUID()
+    let urls: [URL]
+}

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -6,12 +6,10 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
 
-    @State private var shareItem: ShareItem?
     @State private var showNoNewContactsAlert = false
     @State private var showLimitedAccessAlert = false
     @State private var showContactsSettingsAlert = false
@@ -20,17 +18,8 @@ struct SettingsView: View {
     @State private var showImportSuccessBanner = false
     @State private var importSuccessCount = 0
     @State private var importBannerTask: Task<Void, Never>?
-    @State private var showFilePicker = false
-    @State private var importPreview: ImportPreview?
-    @State private var showImportSuccessAlert = false
-    @State private var showImportErrorAlert = false
-    @State private var importResultMessage = ""
-    @State private var showExportFormatPicker = false
     @State private var showResetFrequenciesConfirmation = false
     @State private var showResetTipsConfirm = false
-    @State private var showPostImportMatch = false
-    @State private var postImportResult: ImportResult?
-    @State private var postImportMatchSummary: ContactMatchSummary?
 
     var body: some View {
         List {
@@ -52,13 +41,6 @@ struct SettingsView: View {
         .listStyle(.insetGrouped)
         .tint(DS.Colors.accent)
         .navigationTitle("Settings")
-        .sheet(item: $shareItem) { item in
-            ShareSheet(items: item.urls) {
-                for url in item.urls {
-                    try? FileManager.default.removeItem(at: url)
-                }
-            }
-        }
         .contactAccessAlerts(
             showNoNewContacts: $showNoNewContactsAlert,
             showLimitedAccess: $showLimitedAccessAlert,
@@ -133,80 +115,8 @@ struct SettingsView: View {
                 )
             }
         }
-        .fileImporter(isPresented: $showFilePicker, allowedContentTypes: [UTType.json]) { result in
-            switch result {
-            case .success(let url):
-                Task {
-                    if let preview = await viewModel.parseImportFile(url: url) {
-                        importPreview = preview
-                    } else {
-                        importResultMessage = "Could not read the file. Make sure it is a valid Keep In Touch export."
-                        showImportErrorAlert = true
-                    }
-                }
-            case .failure:
-                importResultMessage = "Could not open the file."
-                showImportErrorAlert = true
-            }
-        }
-        .sheet(item: $importPreview) { preview in
-            ImportPreviewView(
-                preview: preview,
-                onImport: { resolvedPreview in
-                    importPreview = nil
-                    Task {
-                        let (result, matchSummary) = await viewModel.performFileImport(resolvedPreview)
-
-                        if let matchSummary {
-                            postImportResult = result
-                            postImportMatchSummary = matchSummary
-                            showPostImportMatch = true
-                        } else {
-                            var parts: [String] = []
-                            if result.totalPeople > 0 {
-                                parts.append("\(result.totalPeople) contact\(result.totalPeople == 1 ? "" : "s")")
-                            }
-                            if result.cadencesCreated > 0 {
-                                parts.append("\(result.cadencesCreated) frequenc\(result.cadencesCreated == 1 ? "y" : "ies")")
-                            }
-                            if result.groupsCreated > 0 {
-                                parts.append("\(result.groupsCreated) group\(result.groupsCreated == 1 ? "" : "s")")
-                            }
-                            importResultMessage = parts.isEmpty
-                                ? "Nothing was imported."
-                                : "Imported \(parts.joined(separator: ", ")) successfully."
-                            showImportSuccessAlert = true
-                        }
-                    }
-                },
-                onCancel: {
-                    importPreview = nil
-                }
-            )
-        }
-        .sheet(isPresented: $showPostImportMatch) {
-            if let result = postImportResult, let matchSummary = postImportMatchSummary {
-                PostImportMatchView(
-                    importResult: result,
-                    matchSummary: matchSummary,
-                    viewModel: viewModel,
-                    onDismiss: { showPostImportMatch = false }
-                )
-            }
-        }
-        .alert("Import Complete", isPresented: $showImportSuccessAlert) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(importResultMessage)
-        }
-        .alert("Import Failed", isPresented: $showImportErrorAlert) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(importResultMessage)
-        }
         .onAppear { viewModel.load() }
         .onReceive(NotificationCenter.default.publisher(for: .personDidChange)) { _ in
-            guard !showPostImportMatch else { return }
             viewModel.load()
         }
     }
@@ -333,37 +243,8 @@ struct SettingsView: View {
 
     private var dataSection: some View {
         Section("Data") {
-            Button {
-                showExportFormatPicker = true
-            } label: {
-                Label("Export Contacts", systemImage: "square.and.arrow.up")
-            }
-            .confirmationDialog("Export Format", isPresented: $showExportFormatPicker) {
-                ForEach(ExportFormat.allCases, id: \.self) { format in
-                    Button(format.displayName) {
-                        let urls = viewModel.exportContacts(format: format)
-                        if !urls.isEmpty {
-                            shareItem = ShareItem(urls: urls)
-                        }
-                    }
-                }
-            } message: {
-                Text("Choose a format for your export.")
-            }
-
-            Button {
-                showFilePicker = true
-            } label: {
-                Label("Import Contacts", systemImage: "square.and.arrow.down")
-            }
-
-            if viewModel.isImporting {
-                HStack(spacing: DS.Spacing.md) {
-                    ProgressView()
-                    Text("Importing...")
-                        .font(DS.Typography.metadata)
-                        .foregroundStyle(DS.Colors.secondaryText)
-                }
+            NavigationLink(destination: DataSettingsView(viewModel: viewModel)) {
+                Label("Backup & Data", systemImage: "externaldrive.badge.icloud")
             }
         }
     }
@@ -402,7 +283,7 @@ struct SettingsView: View {
             Text("About")
         } footer: {
             VStack(spacing: DS.Spacing.md) {
-                Text("Your relationship data never leaves your phone. Anonymous usage statistics help us improve the app.")
+                Text("Your relationship data lives on your device and is never sent to us. Anonymous usage statistics help us improve the app.")
                 VStack(spacing: DS.Spacing.sm) {
                     Text("Keep In Touch \(appVersion)")
                         .font(DS.Typography.caption)
@@ -467,11 +348,6 @@ struct SettingsView: View {
         .padding(.horizontal, DS.Spacing.lg)
         .padding(.top, DS.Spacing.sm)
     }
-}
-
-private struct ShareItem: Identifiable {
-    let id = UUID()
-    let urls: [URL]
 }
 
 private enum ContactImportStep: Identifiable {


### PR DESCRIPTION
## What & why

Tier 0 of #79. Rather than build CloudKit sync/backup, this surfaces the iCloud **device** backup the app *already* gets for free, and tidies the data controls.

**Key finding behind this scope:** the Core Data store lives in the App Group container (`group.slavins.co.KeepInTouch`) and is **not** excluded from backup, so it's already included in the user's iCloud device backup and restores automatically on a new/erased device. The real gap was UX/perception — users had no signal that their irreplaceable, hand-built relationship data is safe. So this is a UI/copy change, **not** new persistence.

## Changes

- **New `DataSettingsView`** sub-view: a device-first **Backup** reassurance section (icon + footer explaining on-device storage + iCloud device-backup coverage + Export for a portable copy), plus the relocated **Export/Import** controls.
- **`SettingsView`**: the "Data" section is now a single `NavigationLink` → "Backup & Data". Export/import state and modifiers moved out. The Contacts-import success **banner stays put** — it belongs to the People → "Add from Contacts" flow, not file import (moving it would have broken that flow).
- **Footer copy reconciled**: "never leaves your phone" → "lives on your device and is never sent to us" (honest once iCloud backup is acknowledged). Onboarding copy intentionally unchanged.

## Not in scope

No CloudKit, no `NSPersistentCloudKitContainer`, no Core Data model change, no background tasks. Export/import **services** untouched. The full CloudKit backup design (Tier 2) is documented and banked if post-launch signal justifies it. (App Store listing copy that says "no cloud backup" is a separate launch-prep follow-up.)

## Verification

- ✅ Build clean (0 warnings, 0 errors)
- ✅ 666 unit tests pass (`StayInTouchTests`)
- ✅ `/code-review` (high, `--fix`): 0 correctness bugs; 4 cleanup/convention candidates all verified false-positive (no changes)
- ✅ `/security-review`: PASS — pure view relocation, no new attack surface
- ⬜ Manual click-through (Settings → Backup & Data; export → Save to Files; import; **People → Add from Contacts banner regression**) — recommend before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)