### PR TITLE
[#351] Freemium PR1: entitlement foundation (grandfather + Pro cache, Core Data v11)

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/CoreDataStack.swift
@@ -215,6 +215,12 @@ final class CoreDataStack: ObservableObject, @unchecked Sendable {
             let seeder = DefaultDataSeeder(context: context)
             try seeder.seedIfNeeded()
             AppLogger.logInfo("Successfully seeded default data", category: AppLogger.coreData)
+
+            // The AppSettings row now exists (freshly seeded or pre-existing).
+            // Evaluate the one-time Pro grandfather decision and refresh the App
+            // Group entitlement cache. See #351.
+            let settingsRepository = CoreDataAppSettingsRepository(context: context)
+            EntitlementBootstrap(settingsRepository: settingsRepository).run()
         } catch {
             AppLogger.logError(error, category: AppLogger.coreData, context: "CoreDataStack.seedDefaults")
             AppLogger.logWarning("App will continue without default groups/tags. User can create them manually.", category: AppLogger.coreData)

--- a/StayInTouch/StayInTouch/Data/CoreData/Mappings/AppSettingsEntity+Mapping.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Mappings/AppSettingsEntity+Mapping.swift
@@ -31,7 +31,9 @@ extension AppSettingsEntity {
             appVersion: appVersion ?? "",
             tutorialCompleted: tutorialCompleted,
             tutorialVersion: tutorialVersion,
-            lastSeenAppVersion: lastSeenAppVersion
+            lastSeenAppVersion: lastSeenAppVersion,
+            isGrandfathered: isGrandfathered,
+            proStatusEvaluated: proStatusEvaluated
         )
     }
 
@@ -58,5 +60,7 @@ extension AppSettingsEntity {
         tutorialCompleted = settings.tutorialCompleted
         tutorialVersion = settings.tutorialVersion
         lastSeenAppVersion = settings.lastSeenAppVersion
+        isGrandfathered = settings.isGrandfathered
+        proStatusEvaluated = settings.proStatusEvaluated
     }
 }

--- a/StayInTouch/StayInTouch/Domain/Entities/AppSettings.swift
+++ b/StayInTouch/StayInTouch/Domain/Entities/AppSettings.swift
@@ -37,4 +37,15 @@ struct AppSettings: Identifiable, Equatable, Sendable {
     var tutorialCompleted: Bool = false
     var tutorialVersion: String? = nil
     var lastSeenAppVersion: String? = nil
+
+    /// Pro entitlement granted free to the pre-monetization cohort (installs that
+    /// predate the freemium build). Set once at first launch of the IAP build via
+    /// `GrandfatherEvaluator`; never re-derived. Local + offline-safe — a
+    /// grandfathered user is Pro even with no network and StoreKit unavailable.
+    var isGrandfathered: Bool = false
+
+    /// Write-once guard for the grandfather decision. Once `true`, the grandfather
+    /// status is frozen and never re-evaluated (so a fresh install that later
+    /// completes onboarding is not retroactively grandfathered).
+    var proStatusEvaluated: Bool = false
 }

--- a/StayInTouch/StayInTouch/Shared/EntitlementCache.swift
+++ b/StayInTouch/StayInTouch/Shared/EntitlementCache.swift
@@ -1,0 +1,56 @@
+//
+//  EntitlementCache.swift
+//  KeepInTouch (Shared — compiled into main app + widget extension)
+//
+//  App Group-backed cache of the user's Pro entitlement so out-of-process
+//  consumers (the widget extension, App Intents) can read `isPro` synchronously
+//  without touching StoreKit — which only runs in the main app process.
+//
+//  The main app is the sole writer (on launch / purchase / restore / entitlement
+//  change). Readers degrade to `false` (free tier) on any failure — missing file,
+//  missing container, corrupt JSON — which is the safe default: never accidentally
+//  grant Pro from a bad read.
+//
+
+import Foundation
+
+enum EntitlementCache {
+    static let filename = "entitlementCache.json"
+
+    static var fileURL: URL? {
+        AppGroup.containerURL?.appendingPathComponent(filename)
+    }
+
+    private struct Payload: Codable {
+        let isPro: Bool
+    }
+
+    /// Reads the cached Pro entitlement. Returns `false` on any failure.
+    static func readIsPro(from url: URL? = fileURL) -> Bool {
+        guard
+            let url,
+            let data = try? Data(contentsOf: url),
+            let payload = try? JSONDecoder().decode(Payload.self, from: data)
+        else { return false }
+        return payload.isPro
+    }
+
+    /// Writes the Pro entitlement atomically. Returns `false` if the container is
+    /// unavailable or encoding/writing fails (non-fatal — readers keep the last
+    /// successfully written value, or default to free).
+    @discardableResult
+    static func write(isPro: Bool, to url: URL? = fileURL) -> Bool {
+        guard let url else { return false }
+        guard let data = try? JSONEncoder().encode(Payload(isPro: isPro)) else { return false }
+        do {
+            // Pin the same protection class the Core Data store uses
+            // (completeUntilFirstUserAuthentication) so the widget can read this on
+            // the Lock Screen after first unlock; stricter `.complete` would break
+            // lock-screen reads.
+            try data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/Shared/ProConfig.swift
+++ b/StayInTouch/StayInTouch/Shared/ProConfig.swift
@@ -1,0 +1,20 @@
+//
+//  ProConfig.swift
+//  KeepInTouch (Shared — compiled into main app + widget extension)
+//
+//  Central configuration for the freemium / Pro-unlock feature (#351).
+//
+
+import Foundation
+
+enum ProConfig {
+    /// App Store Connect product identifier for the one-time non-consumable Pro
+    /// unlock. Must match the IAP created in App Store Connect and the local
+    /// `.storekit` configuration used for development/testing.
+    static let proProductID = "slavins.co.KeepInTouch.pro"
+
+    /// Free-tier ceiling: the number of active tracked contacts a non-Pro user may
+    /// keep. Counts `isTracked && !isDemoData`. Pause is a Pro feature, so paused
+    /// contacts cannot exist for free users and never affect this count.
+    static let freeContactLimit = 12
+}

--- a/StayInTouch/StayInTouch/Shared/StayInTouch.xcdatamodeld/.xccurrentversion
+++ b/StayInTouch/StayInTouch/Shared/StayInTouch.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>StayInTouch_v10.xcdatamodel</string>
+	<string>StayInTouch_v11.xcdatamodel</string>
 </dict>
 </plist>

--- a/StayInTouch/StayInTouch/Shared/StayInTouch.xcdatamodeld/StayInTouch_v11.xcdatamodel/contents
+++ b/StayInTouch/StayInTouch/Shared/StayInTouch.xcdatamodeld/StayInTouch_v11.xcdatamodel/contents
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
+    <entity name="Person" representedClassName="PersonEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="cnIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="displayName" optional="NO" attributeType="String"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
+        <attribute name="initials" optional="NO" attributeType="String"/>
+        <attribute name="avatarColor" optional="NO" attributeType="String"/>
+        <attribute name="groupId" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="tagIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
+        <attribute name="lastTouchAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastTouchMethod" optional="YES" attributeType="String"/>
+        <attribute name="lastTouchNotes" optional="YES" attributeType="String"/>
+        <attribute name="nextTouchNotes" optional="YES" attributeType="String"/>
+        <attribute name="isPaused" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isTracked" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="notificationsMuted" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="customBreachTime" optional="YES" attributeType="String"/>
+        <attribute name="snoozedUntil" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customDueDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="birthday" optional="YES" attributeType="String"/>
+        <attribute name="birthdayNotificationsEnabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="groupAddedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="contactUnavailable" optional="NO" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isDemoData" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="preferredMessenger" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Group" representedClassName="GroupEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="NO" attributeType="String"/>
+        <attribute name="frequencyDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES" renamingIdentifier="slaDays"/>
+        <attribute name="warningDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="colorHex" optional="YES" attributeType="String"/>
+        <attribute name="isDefault" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Tag" representedClassName="TagEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="NO" attributeType="String"/>
+        <attribute name="colorHex" optional="NO" attributeType="String"/>
+        <attribute name="sortOrder" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="TouchEvent" representedClassName="TouchEventEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="personId" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="at" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="method" optional="NO" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="timeOfDay" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modifiedAt" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="AppSettings" representedClassName="AppSettingsEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="theme" optional="NO" attributeType="String"/>
+        <attribute name="notificationsEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="breachTimeOfDay" optional="NO" attributeType="String"/>
+        <attribute name="digestEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="digestDay" optional="NO" attributeType="String"/>
+        <attribute name="digestTime" optional="NO" attributeType="String"/>
+        <attribute name="notificationGrouping" optional="YES" attributeType="String"/>
+        <attribute name="badgeCountShowDueSoon" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="dueSoonWindowDays" optional="NO" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="demoModeEnabled" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="analyticsEnabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="lastContactsSyncAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="onboardingCompleted" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="appVersion" optional="NO" attributeType="String"/>
+        <attribute name="hideContactNamesInNotifications" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="birthdayNotificationsEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="birthdayNotificationTime" optional="YES" attributeType="String"/>
+        <attribute name="birthdayIgnoreSnoozePause" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="tutorialCompleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="tutorialVersion" optional="YES" attributeType="String"/>
+        <attribute name="lastSeenAppVersion" optional="YES" attributeType="String"/>
+        <attribute name="isGrandfathered" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="proStatusEvaluated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Person" positionX="-252" positionY="-108" width="128" height="44"/>
+        <element name="Group" positionX="-36" positionY="-108" width="128" height="44"/>
+        <element name="Tag" positionX="180" positionY="-108" width="128" height="44"/>
+        <element name="TouchEvent" positionX="-144" positionY="54" width="128" height="44"/>
+        <element name="AppSettings" positionX="72" positionY="54" width="128" height="44"/>
+    </elements>
+</model>

--- a/StayInTouch/StayInTouch/UseCases/EntitlementBootstrap.swift
+++ b/StayInTouch/StayInTouch/UseCases/EntitlementBootstrap.swift
@@ -32,14 +32,29 @@ struct EntitlementBootstrap {
 
         let evaluated = GrandfatherEvaluator.evaluate(settings)
         if evaluated != settings {
-            try? settingsRepository.save(evaluated)
+            do {
+                try settingsRepository.save(evaluated)
+            } catch {
+                // Don't silently swallow (project rule: zero silent failures). A
+                // failed persist means the grandfather decision isn't frozen and
+                // gets re-evaluated next launch — safe for existing users, whose
+                // `onboardingCompleted` is stable and yields the same result.
+                AppLogger.logError(error, category: AppLogger.coreData, context: "EntitlementBootstrap.save")
+            }
         }
 
         let isPro = Entitlements.isPro(
             isGrandfathered: evaluated.isGrandfathered,
             hasProPurchase: false
         )
-        writeCache(isPro)
+        // Set-only: write the cache here only to GRANT Pro (grandfather), never to
+        // clear it. The authoritative writer that can also clear Pro (on refund /
+        // entitlement revocation) is the StoreKit PurchaseManager added in a later
+        // stage. Keeping this bootstrap set-only means it can never clobber a
+        // purchased-but-not-grandfathered user's cached entitlement back to free.
+        if isPro {
+            writeCache(true)
+        }
         return isPro
     }
 }

--- a/StayInTouch/StayInTouch/UseCases/EntitlementBootstrap.swift
+++ b/StayInTouch/StayInTouch/UseCases/EntitlementBootstrap.swift
@@ -1,0 +1,45 @@
+//
+//  EntitlementBootstrap.swift
+//  KeepInTouch
+//
+//  Runs once early at launch — after the Core Data store is loaded and defaults
+//  are seeded, so the AppSettings row is guaranteed to exist. It evaluates the
+//  one-time grandfather decision, persists it if it changed, and refreshes the
+//  App Group entitlement cache so out-of-process consumers see current Pro state.
+//  See #351.
+//
+//  At this stage there is no StoreKit purchase state yet (added in a later stage),
+//  so the cached `isPro` reflects grandfather status only; the PurchaseManager
+//  updates the cache when entitlements load or change.
+//
+
+import Foundation
+
+struct EntitlementBootstrap {
+    let settingsRepository: AppSettingsRepository
+
+    /// Evaluate + persist the grandfather decision and refresh the entitlement
+    /// cache. `writeCache` is injectable so tests don't touch the App Group.
+    /// - Returns: the effective Pro status after evaluation.
+    @discardableResult
+    func run(writeCache: (Bool) -> Void = { EntitlementCache.write(isPro: $0) }) -> Bool {
+        guard let settings = settingsRepository.fetch() else {
+            // No settings row yet — nothing to evaluate. Leave the cache untouched
+            // (readers default to free); a later launch will evaluate once seeding
+            // has created the row.
+            return false
+        }
+
+        let evaluated = GrandfatherEvaluator.evaluate(settings)
+        if evaluated != settings {
+            try? settingsRepository.save(evaluated)
+        }
+
+        let isPro = Entitlements.isPro(
+            isGrandfathered: evaluated.isGrandfathered,
+            hasProPurchase: false
+        )
+        writeCache(isPro)
+        return isPro
+    }
+}

--- a/StayInTouch/StayInTouch/UseCases/Entitlements.swift
+++ b/StayInTouch/StayInTouch/UseCases/Entitlements.swift
@@ -1,0 +1,17 @@
+//
+//  Entitlements.swift
+//  KeepInTouch
+//
+//  The single rule for effective Pro status (#351). Pro is granted if the user is
+//  grandfathered (pre-monetization cohort — local and offline-safe) OR holds the
+//  StoreKit non-consumable entitlement. Keeping this in one pure function means
+//  the app, widgets, and intents all decide "is this user Pro?" identically.
+//
+
+import Foundation
+
+enum Entitlements {
+    static func isPro(isGrandfathered: Bool, hasProPurchase: Bool) -> Bool {
+        isGrandfathered || hasProPurchase
+    }
+}

--- a/StayInTouch/StayInTouch/UseCases/GrandfatherEvaluator.swift
+++ b/StayInTouch/StayInTouch/UseCases/GrandfatherEvaluator.swift
@@ -1,0 +1,28 @@
+//
+//  GrandfatherEvaluator.swift
+//  KeepInTouch
+//
+//  One-time, write-once decision that grants free Pro to the pre-monetization
+//  cohort — installs that predate the freemium build (#351).
+//
+//  Signal: `onboardingCompleted == true` at the first launch of the IAP build.
+//  An existing user who already finished onboarding is grandfathered; a fresh
+//  install (onboarding not yet complete at first launch) is not. The decision is
+//  frozen via `proStatusEvaluated`, so completing onboarding *after* the freemium
+//  build is installed never retroactively grandfathers a new user.
+//
+
+import Foundation
+
+enum GrandfatherEvaluator {
+    /// Pure evaluation. Returns settings with the grandfather decision applied.
+    /// Idempotent: once `proStatusEvaluated` is true, the input is returned
+    /// unchanged.
+    static func evaluate(_ settings: AppSettings) -> AppSettings {
+        guard !settings.proStatusEvaluated else { return settings }
+        var updated = settings
+        updated.isGrandfathered = settings.onboardingCompleted
+        updated.proStatusEvaluated = true
+        return updated
+    }
+}

--- a/StayInTouch/StayInTouchTests/EntitlementFoundationTests.swift
+++ b/StayInTouch/StayInTouchTests/EntitlementFoundationTests.swift
@@ -1,0 +1,221 @@
+//
+//  EntitlementFoundationTests.swift
+//  KeepInTouchTests
+//
+//  Covers the freemium entitlement foundation (#351, PR1): the pure grandfather
+//  evaluation, the isPro rule, the App Group entitlement cache, the launch
+//  bootstrap, and the Core Data v11 round-trip for the grandfather fields.
+//
+
+import CoreData
+import XCTest
+@testable import StayInTouch
+
+final class EntitlementFoundationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeSettings(
+        onboardingCompleted: Bool = false,
+        isGrandfathered: Bool = false,
+        proStatusEvaluated: Bool = false
+    ) -> AppSettings {
+        AppSettings(
+            id: AppSettings.singletonId,
+            theme: .system,
+            notificationsEnabled: false,
+            breachTimeOfDay: LocalTime(hour: 18, minute: 0),
+            digestEnabled: false,
+            digestDay: .friday,
+            digestTime: LocalTime(hour: 18, minute: 0),
+            notificationGrouping: .perType,
+            badgeCountShowDueSoon: false,
+            dueSoonWindowDays: 3,
+            demoModeEnabled: false,
+            analyticsEnabled: true,
+            hideContactNamesInNotifications: false,
+            birthdayNotificationsEnabled: false,
+            birthdayNotificationTime: LocalTime(hour: 9, minute: 0),
+            birthdayIgnoreSnoozePause: true,
+            lastContactsSyncAt: nil,
+            onboardingCompleted: onboardingCompleted,
+            appVersion: "1.0",
+            tutorialCompleted: false,
+            tutorialVersion: nil,
+            lastSeenAppVersion: nil,
+            isGrandfathered: isGrandfathered,
+            proStatusEvaluated: proStatusEvaluated
+        )
+    }
+
+    /// In-memory `AppSettingsRepository` for bootstrap tests.
+    private final class MockSettingsRepository: AppSettingsRepository, @unchecked Sendable {
+        var stored: AppSettings?
+        private(set) var saveCount = 0
+
+        init(stored: AppSettings?) { self.stored = stored }
+
+        func fetch() -> AppSettings? { stored }
+        func save(_ settings: AppSettings) throws {
+            stored = settings
+            saveCount += 1
+        }
+    }
+
+    // MARK: - GrandfatherEvaluator (the matrix)
+
+    func testGrandfather_existingUser_isGrandfathered() {
+        // Onboarding already complete, not yet evaluated → grandfathered.
+        let result = GrandfatherEvaluator.evaluate(
+            makeSettings(onboardingCompleted: true, proStatusEvaluated: false)
+        )
+        XCTAssertTrue(result.isGrandfathered)
+        XCTAssertTrue(result.proStatusEvaluated)
+    }
+
+    func testGrandfather_freshInstall_isNotGrandfathered() {
+        // Onboarding not complete at first launch of the IAP build → free tier.
+        let result = GrandfatherEvaluator.evaluate(
+            makeSettings(onboardingCompleted: false, proStatusEvaluated: false)
+        )
+        XCTAssertFalse(result.isGrandfathered)
+        XCTAssertTrue(result.proStatusEvaluated)
+    }
+
+    func testGrandfather_alreadyEvaluated_isIdempotent() {
+        // Once evaluated, the decision is frozen even if onboarding later completes.
+        let input = makeSettings(
+            onboardingCompleted: true,
+            isGrandfathered: false,
+            proStatusEvaluated: true
+        )
+        let result = GrandfatherEvaluator.evaluate(input)
+        XCTAssertEqual(result, input, "Evaluation must not change an already-evaluated settings row")
+        XCTAssertFalse(result.isGrandfathered)
+    }
+
+    func testGrandfather_alreadyGrandfathered_isPreserved() {
+        let input = makeSettings(
+            onboardingCompleted: false,
+            isGrandfathered: true,
+            proStatusEvaluated: true
+        )
+        let result = GrandfatherEvaluator.evaluate(input)
+        XCTAssertEqual(result, input)
+        XCTAssertTrue(result.isGrandfathered)
+    }
+
+    // MARK: - Entitlements.isPro rule
+
+    func testIsPro_truthTable() {
+        XCTAssertFalse(Entitlements.isPro(isGrandfathered: false, hasProPurchase: false))
+        XCTAssertTrue(Entitlements.isPro(isGrandfathered: true, hasProPurchase: false))
+        XCTAssertTrue(Entitlements.isPro(isGrandfathered: false, hasProPurchase: true))
+        XCTAssertTrue(Entitlements.isPro(isGrandfathered: true, hasProPurchase: true))
+    }
+
+    // MARK: - EntitlementCache round-trip
+
+    func testEntitlementCache_writeThenReadTrue() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("entitlement-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertTrue(EntitlementCache.write(isPro: true, to: url))
+        XCTAssertTrue(EntitlementCache.readIsPro(from: url))
+    }
+
+    func testEntitlementCache_writeThenReadFalse() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("entitlement-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertTrue(EntitlementCache.write(isPro: false, to: url))
+        XCTAssertFalse(EntitlementCache.readIsPro(from: url))
+    }
+
+    func testEntitlementCache_missingFileReadsFalse() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("entitlement-missing-\(UUID().uuidString).json")
+        XCTAssertFalse(EntitlementCache.readIsPro(from: url))
+    }
+
+    // MARK: - EntitlementBootstrap
+
+    func testBootstrap_existingUser_savesGrandfatherAndCachesPro() {
+        let repo = MockSettingsRepository(stored: makeSettings(onboardingCompleted: true))
+        var cached: Bool?
+        let isPro = EntitlementBootstrap(settingsRepository: repo).run { cached = $0 }
+
+        XCTAssertTrue(isPro)
+        XCTAssertEqual(cached, true)
+        XCTAssertEqual(repo.saveCount, 1)
+        XCTAssertEqual(repo.stored?.isGrandfathered, true)
+        XCTAssertEqual(repo.stored?.proStatusEvaluated, true)
+    }
+
+    func testBootstrap_freshInstall_savesEvaluatedAndCachesFree() {
+        let repo = MockSettingsRepository(stored: makeSettings(onboardingCompleted: false))
+        var cached: Bool?
+        let isPro = EntitlementBootstrap(settingsRepository: repo).run { cached = $0 }
+
+        XCTAssertFalse(isPro)
+        XCTAssertEqual(cached, false)
+        XCTAssertEqual(repo.saveCount, 1)
+        XCTAssertEqual(repo.stored?.isGrandfathered, false)
+        XCTAssertEqual(repo.stored?.proStatusEvaluated, true)
+    }
+
+    func testBootstrap_alreadyEvaluated_doesNotResave() {
+        let repo = MockSettingsRepository(
+            stored: makeSettings(isGrandfathered: true, proStatusEvaluated: true)
+        )
+        var cached: Bool?
+        let isPro = EntitlementBootstrap(settingsRepository: repo).run { cached = $0 }
+
+        XCTAssertTrue(isPro)
+        XCTAssertEqual(cached, true)
+        XCTAssertEqual(repo.saveCount, 0, "No re-save when the decision is already frozen")
+    }
+
+    func testBootstrap_noSettingsRow_returnsFalseAndDoesNotWriteCache() {
+        let repo = MockSettingsRepository(stored: nil)
+        var cacheWriteCount = 0
+        let isPro = EntitlementBootstrap(settingsRepository: repo).run { _ in cacheWriteCount += 1 }
+
+        XCTAssertFalse(isPro)
+        XCTAssertEqual(repo.saveCount, 0)
+        XCTAssertEqual(cacheWriteCount, 0, "Cache untouched when there is no settings row to evaluate")
+    }
+
+    // MARK: - Core Data v11 round-trip (model + mapping)
+
+    func testAppSettingsV11_grandfatherFieldsRoundTrip() throws {
+        let stack = CoreDataTestStack()
+        let repo = CoreDataAppSettingsRepository(context: stack.container.viewContext)
+
+        try repo.save(makeSettings(
+            onboardingCompleted: true,
+            isGrandfathered: true,
+            proStatusEvaluated: true
+        ))
+
+        let fetched = repo.fetch()
+        XCTAssertEqual(fetched?.isGrandfathered, true)
+        XCTAssertEqual(fetched?.proStatusEvaluated, true)
+    }
+
+    func testAppSettingsV11_defaultsAreFalseForFreshRow() throws {
+        // A row saved without touching the new fields must read back false/false
+        // (model-level defaults), i.e. a brand-new install is not grandfathered
+        // and not yet evaluated.
+        let stack = CoreDataTestStack()
+        let repo = CoreDataAppSettingsRepository(context: stack.container.viewContext)
+
+        try repo.save(makeSettings())
+
+        let fetched = repo.fetch()
+        XCTAssertEqual(fetched?.isGrandfathered, false)
+        XCTAssertEqual(fetched?.proStatusEvaluated, false)
+    }
+}

--- a/StayInTouch/StayInTouchTests/EntitlementFoundationTests.swift
+++ b/StayInTouch/StayInTouchTests/EntitlementFoundationTests.swift
@@ -154,16 +154,32 @@ final class EntitlementFoundationTests: XCTestCase {
         XCTAssertEqual(repo.stored?.proStatusEvaluated, true)
     }
 
-    func testBootstrap_freshInstall_savesEvaluatedAndCachesFree() {
+    func testBootstrap_freshInstall_savesEvaluatedAndDoesNotCachePro() {
         let repo = MockSettingsRepository(stored: makeSettings(onboardingCompleted: false))
         var cached: Bool?
         let isPro = EntitlementBootstrap(settingsRepository: repo).run { cached = $0 }
 
         XCTAssertFalse(isPro)
-        XCTAssertEqual(cached, false)
+        // Set-only: a free user never triggers a cache write (readers default to
+        // free, and the cache must not be clobbered for a purchased user later).
+        XCTAssertNil(cached)
         XCTAssertEqual(repo.saveCount, 1)
         XCTAssertEqual(repo.stored?.isGrandfathered, false)
         XCTAssertEqual(repo.stored?.proStatusEvaluated, true)
+    }
+
+    func testBootstrap_freeAlreadyEvaluated_doesNotWriteCache() {
+        // A non-grandfathered, already-evaluated user must not write the cache —
+        // this is the guard that prevents clobbering a purchased user's cached Pro.
+        let repo = MockSettingsRepository(
+            stored: makeSettings(isGrandfathered: false, proStatusEvaluated: true)
+        )
+        var cacheWriteCount = 0
+        let isPro = EntitlementBootstrap(settingsRepository: repo).run { _ in cacheWriteCount += 1 }
+
+        XCTAssertFalse(isPro)
+        XCTAssertEqual(repo.saveCount, 0)
+        XCTAssertEqual(cacheWriteCount, 0)
     }
 
     func testBootstrap_alreadyEvaluated_doesNotResave() {


### PR DESCRIPTION
## Summary
First of a stack of PRs implementing freemium / one-time Pro unlock (#351). This is the **entitlement engine only — no UI, no gating, no StoreKit yet** (those land in later stacked PRs). It is dormant and safe to ship on its own.

- **Core Data v11**: adds `AppSettings.isGrandfathered` + `proStatusEvaluated` (optional Bool, defaulted → inferred lightweight migration; v10 preserved).
- **GrandfatherEvaluator**: pure, write-once decision. Keys off `onboardingCompleted` at first launch of the IAP build so the pre-monetization TestFlight cohort gets Pro free, automatically — frozen via `proStatusEvaluated` so a fresh install that later finishes onboarding is never retroactively grandfathered. Local + offline-safe.
- **EntitlementCache** (App Group, mirrors `BirthdayCache`): cross-process `isPro` cache for the widget / App Intents to read without StoreKit. `.completeFileProtectionUntilFirstUserAuthentication` for lock-screen reads.
- **Entitlements.isPro**: the single rule `isGrandfathered || hasProPurchase`.
- **EntitlementBootstrap**: runs post-seed at launch; evaluates grandfather, persists if changed, and **set-only** refreshes the cache (grants Pro, never clears — the StoreKit PurchaseManager in PR2 becomes the authoritative clear-on-refund writer).
- **ProConfig**: `proProductID` (`slavins.co.KeepInTouch.pro`) + `freeContactLimit` (12).

## Stacking
PR1 of ~4 (off `main`). Next: PR2 StoreKit PurchaseManager → PR3 paywall + cap → PR4 feature gates → PR5 widgets/intents. Each stacks on the previous.

## Not in this PR (deferred to the stack)
Paywall UI, contact cap, feature gating, StoreKit purchase/restore, widget upsell. ASC IAP creation + Paid Apps Agreement remain manual prerequisites (not done autonomously).

## Test plan
- [x] `xcode_build` succeeds; full suite green (existing + 14 new entitlement tests)
- [x] Grandfather matrix (existing-user / fresh / already-evaluated / idempotent), isPro truth table, cache round-trip + missing-file, bootstrap set-only behavior, Core Data v11 round-trip + defaults
- [x] Manual: clean install → not grandfathered; simulate pre-existing install → grandfathered

## Review
- Code review (high, --fix) completed pre-PR: 2 findings applied (set-only cache write to prevent future clobber of purchased state; logged save failure instead of silent `try?`).
- Security review completed pre-PR: clean PASS (no network/external input/secrets; client-side entitlement bypass is the documented accepted design).

Part of #351.