### PR TITLE
[#351] Freemium PR2: StoreKit 2 PurchaseManager + gateway seam

### DIFF
--- a/StayInTouch/Configuration.storekit
+++ b/StayInTouch/Configuration.storekit
@@ -1,0 +1,30 @@
+{
+  "identifier" : "5C9F1A20",
+  "nonRenewingSubscriptions" : [],
+  "products" : [
+    {
+      "displayPrice" : "7.99",
+      "familyShareable" : true,
+      "internalID" : "PRO0000001",
+      "localizations" : [
+        {
+          "description" : "Unlock unlimited contacts, stats, import, group logging, custom cadences, custom due dates, pause, and the full widget family. Pay once.",
+          "displayName" : "Keep In Touch Pro",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "slavins.co.KeepInTouch.pro",
+      "referenceName" : "Pro Unlock",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "0000000000",
+    "_developerTeamID" : "0000000000"
+  },
+  "subscriptionGroups" : [],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/StayInTouch/StayInTouch/App/StayInTouchApp.swift
+++ b/StayInTouch/StayInTouch/App/StayInTouchApp.swift
@@ -12,12 +12,9 @@ import TipKit
 @main
 struct KeepInTouchApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    private let coreDataStack: CoreDataStack = {
-        if ProcessInfo.processInfo.arguments.contains("-uiTesting") {
-            return CoreDataStack.make(inMemory: true, shouldSeedDefaults: false)
-        }
-        return CoreDataStack.shared
-    }()
+    private let coreDataStack: CoreDataStack
+    private let isUITesting: Bool
+    @StateObject private var purchaseManager: PurchaseManager
     @State private var showMigrationAlert = false
 
     init() {
@@ -29,6 +26,20 @@ struct KeepInTouchApp: App {
             .displayFrequency(.immediate),
             TipsDatastore.location(),
         ])
+
+        let isUITesting = ProcessInfo.processInfo.arguments.contains("-uiTesting")
+        let stack: CoreDataStack = isUITesting
+            ? CoreDataStack.make(inMemory: true, shouldSeedDefaults: false)
+            : CoreDataStack.shared
+        self.isUITesting = isUITesting
+        self.coreDataStack = stack
+
+        // Pro entitlement source of truth, bound to the same store the app uses
+        // (so it reads the correct grandfather flag, including under UI testing).
+        _purchaseManager = StateObject(wrappedValue: PurchaseManager(
+            gateway: LiveStoreKitGateway(),
+            settingsRepository: CoreDataAppSettingsRepository(context: stack.viewContext)
+        ))
     }
 
     var body: some Scene {
@@ -36,6 +47,12 @@ struct KeepInTouchApp: App {
             ContentView()
                 .environment(\.managedObjectContext, coreDataStack.viewContext)
                 .environment(\.dependencies, AppDependencies(context: coreDataStack.viewContext))
+                .environmentObject(purchaseManager)
+                .task {
+                    // Start StoreKit entitlement loading + the updates listener.
+                    // Skipped under UI testing to keep launch smoke tests hermetic.
+                    if !isUITesting { purchaseManager.start() }
+                }
                 // Note: in `-uiTesting` runs the coreDataStack is in-memory,
                 // so we pass it through explicitly here. Outside tests
                 // `AppDependencies.shared` already resolves to the same

--- a/StayInTouch/StayInTouch/UseCases/LiveStoreKitGateway.swift
+++ b/StayInTouch/StayInTouch/UseCases/LiveStoreKitGateway.swift
@@ -1,0 +1,78 @@
+//
+//  LiveStoreKitGateway.swift
+//  KeepInTouch
+//
+//  Thin StoreKit 2 adapter behind `StoreKitGateway`. Intentionally logic-light
+//  (no entitlement decisions here — that's `PurchaseManager`); this only maps
+//  StoreKit calls/types to the gateway's plain value types. See #351.
+//
+
+import Foundation
+import StoreKit
+
+struct LiveStoreKitGateway: StoreKitGateway {
+    func loadProducts(ids: [String]) async throws -> [ProProduct] {
+        let products = try await Product.products(for: ids)
+        return products.map {
+            ProProduct(id: $0.id, displayName: $0.displayName, displayPrice: $0.displayPrice)
+        }
+    }
+
+    func ownedProductIDs() async -> Set<String> {
+        var owned: Set<String> = []
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result else { continue }
+            guard transaction.revocationDate == nil else { continue }
+            owned.insert(transaction.productID)
+        }
+        return owned
+    }
+
+    func purchase(productID: String) async throws -> PurchaseOutcome {
+        let products = try await Product.products(for: [productID])
+        guard let product = products.first else { throw PurchaseError.productNotFound }
+
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            let transaction = try Self.checkVerified(verification)
+            await transaction.finish()
+            return .success
+        case .pending:
+            return .pending
+        case .userCancelled:
+            return .cancelled
+        @unknown default:
+            return .cancelled
+        }
+    }
+
+    func sync() async throws {
+        try await AppStore.sync()
+    }
+
+    func transactionUpdates() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            // Iterate StoreKit's update stream off the main actor; finish each
+            // transaction and signal the manager to re-read entitlements.
+            let task = Task.detached {
+                for await result in Transaction.updates {
+                    guard case .verified(let transaction) = result else { continue }
+                    await transaction.finish()
+                    continuation.yield(())
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    static func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw PurchaseError.verificationFailed
+        case .verified(let value):
+            return value
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/UseCases/PurchaseManager.swift
+++ b/StayInTouch/StayInTouch/UseCases/PurchaseManager.swift
@@ -1,0 +1,130 @@
+//
+//  PurchaseManager.swift
+//  KeepInTouch
+//
+//  App-wide source of truth for Pro entitlement (#351). Computes
+//  `isPro = grandfathered || owns the non-consumable`, publishes it for the UI,
+//  and is the AUTHORITATIVE writer of the App Group entitlement cache — it can
+//  both grant Pro and clear it (on refund/revocation), unlike the launch
+//  bootstrap which is set-only.
+//
+//  StoreKit access is isolated behind `StoreKitGateway` so this type's logic is
+//  unit-tested with a fake. Grandfather status is read from persisted AppSettings.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class PurchaseManager: ObservableObject {
+    /// Effective Pro status: grandfathered OR owns the Pro non-consumable.
+    @Published private(set) var isPro: Bool
+    /// Display info for the Pro product (nil until loaded, or if loading failed).
+    @Published private(set) var proProduct: ProProduct?
+    /// True while a purchase or restore is in flight (drives paywall button state).
+    @Published private(set) var isProcessing = false
+    /// User-facing message for the most recent purchase/restore failure or pending
+    /// state. Set for the paywall to surface; cleared when a new action starts.
+    @Published var statusMessage: String?
+
+    private let gateway: StoreKitGateway
+    private let settingsRepository: AppSettingsRepository
+    private let writeCache: (Bool) -> Void
+    private var updatesTask: Task<Void, Never>?
+
+    init(
+        gateway: StoreKitGateway,
+        settingsRepository: AppSettingsRepository,
+        writeCache: @escaping (Bool) -> Void = { EntitlementCache.write(isPro: $0) }
+    ) {
+        self.gateway = gateway
+        self.settingsRepository = settingsRepository
+        self.writeCache = writeCache
+        // Seed from grandfather immediately so the UI is never briefly wrong
+        // before entitlements load (and this path is offline-safe).
+        self.isPro = settingsRepository.fetch()?.isGrandfathered ?? false
+    }
+
+    deinit { updatesTask?.cancel() }
+
+    /// Begin the entitlement listener and load product + current entitlements.
+    /// Call once from the app root.
+    func start() {
+        guard updatesTask == nil else { return }
+        updatesTask = Task { [weak self] in
+            guard let self else { return }
+            for await _ in self.gateway.transactionUpdates() {
+                await self.refreshEntitlements()
+            }
+        }
+        Task { await self.loadProductAndRefresh() }
+    }
+
+    /// Load the Pro product display info and refresh entitlement state.
+    func loadProductAndRefresh() async {
+        await refreshEntitlements()
+        do {
+            let products = try await gateway.loadProducts(ids: [ProConfig.proProductID])
+            proProduct = products.first(where: { $0.id == ProConfig.proProductID }) ?? products.first
+        } catch {
+            // Leave proProduct nil; the paywall surfaces a load-failure/retry state.
+            proProduct = nil
+        }
+    }
+
+    /// Recompute `isPro` from grandfather status + owned products and write the
+    /// authoritative entitlement cache (this is the only place that may clear Pro).
+    func refreshEntitlements() async {
+        let owned = await gateway.ownedProductIDs()
+        let isGrandfathered = settingsRepository.fetch()?.isGrandfathered ?? false
+        let pro = Entitlements.isPro(
+            isGrandfathered: isGrandfathered,
+            hasProPurchase: owned.contains(ProConfig.proProductID)
+        )
+        isPro = pro
+        writeCache(pro)
+    }
+
+    /// Purchase the Pro unlock.
+    func purchase() async {
+        guard !isProcessing else { return }
+        statusMessage = nil
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            let outcome = try await gateway.purchase(productID: ProConfig.proProductID)
+            switch outcome {
+            case .success:
+                await refreshEntitlements()
+                AnalyticsService.track("pro.purchased")
+            case .pending:
+                statusMessage = "Your purchase is pending approval. You'll get Pro once it's approved."
+            case .cancelled:
+                break
+            }
+        } catch {
+            statusMessage = "Purchase couldn't be completed. Please try again."
+            AnalyticsService.track("pro.purchase_failed")
+        }
+    }
+
+    /// Restore a previous purchase (explicit user action).
+    func restore() async {
+        guard !isProcessing else { return }
+        statusMessage = nil
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            try await gateway.sync()
+            await refreshEntitlements()
+            AnalyticsService.track("pro.restored", parameters: ["result": isPro ? "pro" : "none"])
+            if !isPro {
+                statusMessage = "No previous purchase found to restore."
+            }
+        } catch {
+            statusMessage = "Restore couldn't be completed. Please try again."
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/UseCases/PurchaseManager.swift
+++ b/StayInTouch/StayInTouch/UseCases/PurchaseManager.swift
@@ -125,6 +125,7 @@ final class PurchaseManager: ObservableObject {
             }
         } catch {
             statusMessage = "Restore couldn't be completed. Please try again."
+            AnalyticsService.track("pro.restore_failed")
         }
     }
 }

--- a/StayInTouch/StayInTouch/UseCases/StoreKitGateway.swift
+++ b/StayInTouch/StayInTouch/UseCases/StoreKitGateway.swift
@@ -1,0 +1,51 @@
+//
+//  StoreKitGateway.swift
+//  KeepInTouch
+//
+//  A narrow seam over StoreKit 2 so `PurchaseManager`'s logic is fully testable
+//  without StoreKit (which can't be faked — `Product`/`Transaction` have no public
+//  initializers). The live adapter (`LiveStoreKitGateway`) is a thin, untested
+//  wrapper; tests drive `PurchaseManager` through a fake conforming type. See #351.
+//
+
+import Foundation
+
+/// A StoreKit product reduced to the fields the app/UI needs — keeps StoreKit
+/// types out of the app and UI layers.
+struct ProProduct: Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let displayPrice: String
+}
+
+/// The non-throwing outcomes of a purchase attempt. Genuine failures are thrown.
+enum PurchaseOutcome: Equatable, Sendable {
+    case success
+    case pending
+    case cancelled
+}
+
+enum PurchaseError: Error {
+    case productNotFound
+    case verificationFailed
+}
+
+protocol StoreKitGateway: Sendable {
+    /// Load display info for the given product identifiers.
+    func loadProducts(ids: [String]) async throws -> [ProProduct]
+
+    /// The set of currently-owned (verified, non-revoked) product identifiers.
+    func ownedProductIDs() async -> Set<String>
+
+    /// Attempt to purchase a product. Throws on genuine failure; returns the
+    /// non-error outcome (success / pending / cancelled) otherwise.
+    func purchase(productID: String) async throws -> PurchaseOutcome
+
+    /// Force a StoreKit account sync (the explicit "Restore Purchases" action).
+    func sync() async throws
+
+    /// Emits `()` whenever entitlements may have changed (Ask-to-Buy approvals,
+    /// cross-device purchases, refunds). Each emission should prompt a re-read of
+    /// `ownedProductIDs()`. The stream finishes when the listener is torn down.
+    func transactionUpdates() -> AsyncStream<Void>
+}

--- a/StayInTouch/StayInTouchTests/PurchaseManagerTests.swift
+++ b/StayInTouch/StayInTouchTests/PurchaseManagerTests.swift
@@ -1,0 +1,231 @@
+//
+//  PurchaseManagerTests.swift
+//  KeepInTouchTests
+//
+//  Drives PurchaseManager through a fake StoreKitGateway (#351, PR2): isPro
+//  computation (grandfather || owned), authoritative cache writes (incl. clear),
+//  purchase outcomes, and restore.
+//
+
+import XCTest
+@testable import StayInTouch
+
+@MainActor
+final class PurchaseManagerTests: XCTestCase {
+
+    // MARK: - Fakes / helpers
+
+    private final class FakeGateway: StoreKitGateway, @unchecked Sendable {
+        var owned: Set<String> = []
+        var products: [ProProduct] = [
+            ProProduct(id: ProConfig.proProductID, displayName: "Pro", displayPrice: "$7.99")
+        ]
+        var nextOutcome: PurchaseOutcome = .success
+        var grantOnSuccess = true
+        var purchaseError: Error?
+        var loadError: Error?
+        private(set) var syncCalled = false
+
+        func loadProducts(ids: [String]) async throws -> [ProProduct] {
+            if let loadError { throw loadError }
+            return products
+        }
+        func ownedProductIDs() async -> Set<String> { owned }
+        func purchase(productID: String) async throws -> PurchaseOutcome {
+            if let purchaseError { throw purchaseError }
+            if nextOutcome == .success && grantOnSuccess { owned.insert(productID) }
+            return nextOutcome
+        }
+        func sync() async throws { syncCalled = true }
+        func transactionUpdates() -> AsyncStream<Void> { AsyncStream { $0.finish() } }
+    }
+
+    private final class StubSettingsRepository: AppSettingsRepository, @unchecked Sendable {
+        var grandfathered: Bool
+        init(grandfathered: Bool) { self.grandfathered = grandfathered }
+        func fetch() -> AppSettings? { Self.make(grandfathered: grandfathered) }
+        func save(_ settings: AppSettings) throws {}
+
+        static func make(grandfathered: Bool) -> AppSettings {
+            AppSettings(
+                id: AppSettings.singletonId,
+                theme: .system,
+                notificationsEnabled: false,
+                breachTimeOfDay: LocalTime(hour: 18, minute: 0),
+                digestEnabled: false,
+                digestDay: .friday,
+                digestTime: LocalTime(hour: 18, minute: 0),
+                notificationGrouping: .perType,
+                badgeCountShowDueSoon: false,
+                dueSoonWindowDays: 3,
+                demoModeEnabled: false,
+                analyticsEnabled: true,
+                hideContactNamesInNotifications: false,
+                birthdayNotificationsEnabled: false,
+                birthdayNotificationTime: LocalTime(hour: 9, minute: 0),
+                birthdayIgnoreSnoozePause: true,
+                lastContactsSyncAt: nil,
+                onboardingCompleted: true,
+                appVersion: "1.0",
+                isGrandfathered: grandfathered,
+                proStatusEvaluated: true
+            )
+        }
+    }
+
+    private final class CacheRecorder {
+        var values: [Bool] = []
+        var last: Bool? { values.last }
+    }
+
+    private func makeManager(
+        gateway: FakeGateway,
+        grandfathered: Bool,
+        recorder: CacheRecorder
+    ) -> PurchaseManager {
+        PurchaseManager(
+            gateway: gateway,
+            settingsRepository: StubSettingsRepository(grandfathered: grandfathered),
+            writeCache: { recorder.values.append($0) }
+        )
+    }
+
+    // MARK: - init seeding
+
+    func testInit_grandfathered_seedsProTrue() {
+        let manager = makeManager(gateway: FakeGateway(), grandfathered: true, recorder: CacheRecorder())
+        XCTAssertTrue(manager.isPro)
+    }
+
+    func testInit_notGrandfathered_seedsProFalse() {
+        let manager = makeManager(gateway: FakeGateway(), grandfathered: false, recorder: CacheRecorder())
+        XCTAssertFalse(manager.isPro)
+    }
+
+    // MARK: - refreshEntitlements
+
+    func testRefresh_ownsProduct_isProAndCachesTrue() async {
+        let gateway = FakeGateway()
+        gateway.owned = [ProConfig.proProductID]
+        let recorder = CacheRecorder()
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: recorder)
+
+        await manager.refreshEntitlements()
+
+        XCTAssertTrue(manager.isPro)
+        XCTAssertEqual(recorder.last, true)
+    }
+
+    func testRefresh_freeAndNotOwned_clearsProAndCachesFalse() async {
+        let recorder = CacheRecorder()
+        let manager = makeManager(gateway: FakeGateway(), grandfathered: false, recorder: recorder)
+
+        await manager.refreshEntitlements()
+
+        XCTAssertFalse(manager.isPro)
+        // Authoritative writer: PurchaseManager may CLEAR the cache (unlike the bootstrap).
+        XCTAssertEqual(recorder.last, false)
+    }
+
+    func testRefresh_grandfatheredWithoutPurchase_isProAndCachesTrue() async {
+        let recorder = CacheRecorder()
+        let manager = makeManager(gateway: FakeGateway(), grandfathered: true, recorder: recorder)
+
+        await manager.refreshEntitlements()
+
+        XCTAssertTrue(manager.isPro)
+        XCTAssertEqual(recorder.last, true)
+    }
+
+    // MARK: - purchase
+
+    func testPurchase_success_grantsPro() async {
+        let gateway = FakeGateway()
+        gateway.nextOutcome = .success
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.purchase()
+
+        XCTAssertTrue(manager.isPro)
+        XCTAssertFalse(manager.isProcessing)
+    }
+
+    func testPurchase_cancelled_staysFree() async {
+        let gateway = FakeGateway()
+        gateway.nextOutcome = .cancelled
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.purchase()
+
+        XCTAssertFalse(manager.isPro)
+        XCTAssertNil(manager.statusMessage)
+    }
+
+    func testPurchase_pending_setsStatusMessage() async {
+        let gateway = FakeGateway()
+        gateway.nextOutcome = .pending
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.purchase()
+
+        XCTAssertFalse(manager.isPro)
+        XCTAssertNotNil(manager.statusMessage)
+    }
+
+    func testPurchase_error_setsStatusMessageAndStaysFree() async {
+        let gateway = FakeGateway()
+        gateway.purchaseError = PurchaseError.verificationFailed
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.purchase()
+
+        XCTAssertFalse(manager.isPro)
+        XCTAssertNotNil(manager.statusMessage)
+    }
+
+    // MARK: - restore
+
+    func testRestore_withPriorPurchase_grantsPro() async {
+        let gateway = FakeGateway()
+        gateway.owned = [ProConfig.proProductID]
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.restore()
+
+        XCTAssertTrue(gateway.syncCalled)
+        XCTAssertTrue(manager.isPro)
+    }
+
+    func testRestore_withNothing_setsStatusMessage() async {
+        let gateway = FakeGateway()
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.restore()
+
+        XCTAssertTrue(gateway.syncCalled)
+        XCTAssertFalse(manager.isPro)
+        XCTAssertNotNil(manager.statusMessage)
+    }
+
+    // MARK: - product loading
+
+    func testLoadProduct_populatesProProduct() async {
+        let gateway = FakeGateway()
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.loadProductAndRefresh()
+
+        XCTAssertEqual(manager.proProduct?.id, ProConfig.proProductID)
+        XCTAssertEqual(manager.proProduct?.displayPrice, "$7.99")
+    }
+
+    func testLoadProduct_failureLeavesProductNil() async {
+        let gateway = FakeGateway()
+        gateway.loadError = PurchaseError.productNotFound
+        let manager = makeManager(gateway: gateway, grandfathered: false, recorder: CacheRecorder())
+
+        await manager.loadProductAndRefresh()
+
+        XCTAssertNil(manager.proProduct)
+    }
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -49,6 +49,7 @@ Compact prevention rules. Full narratives archived in `tasks/lessons-archive.md`
 - **CoreData renamingIdentifier for attribute renames**: Add `renamingIdentifier="oldName"` to renamed attributes in versioned models. Without it, CoreData treats rename as delete+add, losing data
 - **Never auto-delete persistent store on failure**: Surface migration failures to the user with explicit confirmation before destructive recovery. Never silently delete the SQLite store
 - **Demo mode must apply immediately**: Settings toggles that affect data must trigger the data operation (seed/remove) immediately, not just update the settings flag
+- **Core Data model versions are NOT in pbxproj — adding vN+1 needs no project edit**: The `.xcdatamodeld` lives in a `PBXFileSystemSynchronizedRootGroup`, so individual `_vN.xcdatamodel` versions are picked up from disk automatically (v2–v10 aren't listed in pbxproj yet migrate fine). To add a version: create `StayInTouch_vN.xcdatamodel/contents` (copy prior version's `contents` verbatim, add only the new optional+defaulted attributes), then bump `.xccurrentversion`'s `_XCCurrentVersionName`. No `XCVersionGroup`/pbxproj edit. New optional attrs with `defaultValueString` = inferred lightweight migration; `CoreDataTestStack` loads the current version from the `.momd` so round-trip tests see it automatically (#351 PR1)
 
 ## Contacts Framework
 


### PR DESCRIPTION
## Summary
Second stacked PR for freemium (#351). Adds the StoreKit 2 purchase layer that feeds the entitlement engine from PR1. **Still no UI / no gating** — `isPro` is computed and published but nothing consumes it yet (gates land in PR3).

- **StoreKitGateway** protocol + `ProProduct` / `PurchaseOutcome` value types — a seam that keeps StoreKit's un-fakeable types out of the app/UI and makes `PurchaseManager` fully unit-testable.
- **LiveStoreKitGateway**: thin StoreKit 2 adapter — `Product.products`, `Transaction.currentEntitlements` (verified + non-revoked only), `product.purchase()` + `finish()`, `AppStore.sync()`, and a `Transaction.updates` listener iterated **off the main actor** via a detached task/`AsyncStream`.
- **PurchaseManager** (`@MainActor` `ObservableObject`): app-wide `isPro = grandfathered || owns Pro`; the **authoritative** entitlement-cache writer (can clear on refund, unlike PR1's set-only bootstrap); `purchase()` / `restore()` / `start()`; seeds `isPro` from grandfather at init (offline-safe); re-reads grandfather per refresh so the first-IAP-build grandfather grant is picked up after the async launch bootstrap commits.
- **Configuration.storekit**: local non-consumable (`slavins.co.KeepInTouch.pro`, $7.99, Family Sharing on) for dev/manual testing.
- Wired `PurchaseManager` at the app root (`environmentObject`; `start()` skipped under `-uiTesting`).

## ⚠️ Manual step before testing the purchase flow in the simulator
There is no shared `.xcscheme` in the repo (scheme is auto-generated), so I did **not** wire the StoreKit config via scheme XML (too risky to hand-edit). To exercise purchase/restore in the simulator: **Edit Scheme → Run → Options → StoreKit Configuration → `Configuration.storekit`**. Without it, `Product.products(for:)` returns empty and the paywall (PR3) shows its load-failure state. Unit tests don't need this (they use a fake gateway).

## Test plan
- [x] Build + full suite green; 14 new `PurchaseManagerTests` via `FakeStoreKitGateway`
- [x] isPro matrix (grandfather/owned), authoritative cache grant **and clear**, purchase success/cancelled/pending/error, restore (found / none), product load + failure
- [ ] Manual: select Configuration.storekit in scheme → buy in sandbox → isPro flips; refund → clears; Restore works
- [ ] Manual: ASC IAP `slavins.co.KeepInTouch.pro` must be created + Paid Apps Agreement active for production (not done autonomously)

## Review
- Code review (high, --fix): 1 fix applied (`pro.restore_failed` analytics). Rejected with reasoning: caching the grandfather flag at init (would break grandfather pickup after the async bootstrap commit), double-refresh and product re-fetch (idempotent / intentional stateless seam).
- Security review: clean PASS — transaction verification correctly rejects `.unverified` on all entitlement paths; no secrets in the dev `.storekit`; no PII; no unsafe deserialization.

Stacked on #354. Part of #351.