### PR TITLE
[#351] Freemium PR3: paywall + 12-contact free-tier cap

### DIFF
--- a/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
+++ b/StayInTouch/StayInTouch/Data/CoreData/Repositories/CoreDataPersonRepository.swift
@@ -172,6 +172,16 @@ final class CoreDataPersonRepository: PersonRepository, @unchecked Sendable {
         }
     }
 
+    func trackedCount() -> Int {
+        context.performAndWait {
+            let request: NSFetchRequest<PersonEntity> = PersonEntity.fetchRequest()
+            // `isDemoData != YES` matches both stored-false and legacy-nil rows.
+            // Paused people are included — a paused contact still occupies a slot.
+            request.predicate = NSPredicate(format: "isTracked == YES AND isDemoData != YES")
+            return (try? context.count(for: request)) ?? 0
+        }
+    }
+
     private func basePredicate(includePaused: Bool) -> NSPredicate {
         if includePaused {
             return NSPredicate(format: "isTracked == YES")

--- a/StayInTouch/StayInTouch/Domain/Protocols/PersonRepository.swift
+++ b/StayInTouch/StayInTouch/Domain/Protocols/PersonRepository.swift
@@ -31,4 +31,10 @@ protocol PersonRepository: Sendable {
     /// "active vs expired" depends on now, unlike `pausedCount()`. Backed
     /// by `count(for:)` — no row materialization.
     func snoozedCount(referenceDate: Date) -> Int
+
+    /// Returns the number of tracked, non-demo people — the count the free-tier
+    /// contact cap is measured against (#351). Paused people are included (a
+    /// paused contact still occupies a tracked slot). Backed by `count(for:)` —
+    /// no row materialization.
+    func trackedCount() -> Int
 }

--- a/StayInTouch/StayInTouch/Shared/ProConfig.swift
+++ b/StayInTouch/StayInTouch/Shared/ProConfig.swift
@@ -13,8 +13,9 @@ enum ProConfig {
     /// `.storekit` configuration used for development/testing.
     static let proProductID = "slavins.co.KeepInTouch.pro"
 
-    /// Free-tier ceiling: the number of active tracked contacts a non-Pro user may
-    /// keep. Counts `isTracked && !isDemoData`. Pause is a Pro feature, so paused
-    /// contacts cannot exist for free users and never affect this count.
+    /// Free-tier ceiling: the number of tracked contacts a non-Pro user may keep.
+    /// Counts `isTracked && !isDemoData`, paused INCLUDED — a paused contact still
+    /// occupies a slot (matters for a grandfathered/ex-Pro user, since pause is a
+    /// Pro feature and free users can't create paused contacts in the first place).
     static let freeContactLimit = 12
 }

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -19,6 +19,7 @@ final class SettingsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var groupsCount: Int = 0
     @Published private(set) var pausedCount: Int = 0
     @Published private(set) var snoozedCount: Int = 0
+    @Published private(set) var trackedContactCount: Int = 0
     @Published var showNotificationsSettingsAlert = false
     @Published var pendingNewContacts: [ContactSummary] = []
     @Published var contactAccessDenied = false
@@ -102,6 +103,7 @@ final class SettingsViewModel: ObservableObject, ViewModelErrorHandling {
         groupsCount = groupRepository.count()
         pausedCount = personRepository.pausedCount()
         snoozedCount = personRepository.snoozedCount(referenceDate: Date())
+        trackedContactCount = personRepository.trackedCount()
     }
 
     func setTheme(_ theme: Theme) {

--- a/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
+++ b/StayInTouch/StayInTouch/UI/ViewModels/SettingsViewModel.swift
@@ -19,7 +19,6 @@ final class SettingsViewModel: ObservableObject, ViewModelErrorHandling {
     @Published private(set) var groupsCount: Int = 0
     @Published private(set) var pausedCount: Int = 0
     @Published private(set) var snoozedCount: Int = 0
-    @Published private(set) var trackedContactCount: Int = 0
     @Published var showNotificationsSettingsAlert = false
     @Published var pendingNewContacts: [ContactSummary] = []
     @Published var contactAccessDenied = false
@@ -103,7 +102,13 @@ final class SettingsViewModel: ObservableObject, ViewModelErrorHandling {
         groupsCount = groupRepository.count()
         pausedCount = personRepository.pausedCount()
         snoozedCount = personRepository.snoozedCount(referenceDate: Date())
-        trackedContactCount = personRepository.trackedCount()
+    }
+
+    /// Live count of tracked, non-demo people for the contact cap. Read at the
+    /// moment of an add (not a cached snapshot) so the cap can't be bypassed by
+    /// adding contacts after the last `load()`. See #351.
+    func liveTrackedCount() -> Int {
+        personRepository.trackedCount()
     }
 
     func setTheme(_ theme: Theme) {

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -77,7 +77,8 @@ struct HomeView: View {
         .sheet(isPresented: $showNewContactsPicker) {
             NewContactsPickerView(
                 contacts: settingsViewModel.pendingNewContacts,
-                currentTrackedCount: settingsViewModel.trackedContactCount,
+                currentTrackedCount: { settingsViewModel.liveTrackedCount() },
+                capSource: "home",
                 onImport: { selected in
                     Task {
                         await settingsViewModel.importSelectedContacts(selected)

--- a/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Home/HomeView.swift
@@ -12,6 +12,7 @@ import TipKit
 struct HomeView: View {
     @ObservedObject var viewModel: HomeViewModel
     @ObservedObject var selectionCoordinator: SelectionCoordinator
+    @EnvironmentObject private var purchaseManager: PurchaseManager
     var recentGroups: [RecentGroup]
     var selectPerson: (Person) -> Void
     @StateObject private var settingsViewModel = SettingsViewModel()
@@ -76,6 +77,7 @@ struct HomeView: View {
         .sheet(isPresented: $showNewContactsPicker) {
             NewContactsPickerView(
                 contacts: settingsViewModel.pendingNewContacts,
+                currentTrackedCount: settingsViewModel.trackedContactCount,
                 onImport: { selected in
                     Task {
                         await settingsViewModel.importSelectedContacts(selected)
@@ -87,6 +89,7 @@ struct HomeView: View {
                     showNewContactsPicker = false
                 }
             )
+            .environmentObject(purchaseManager)
         }
         .contactAccessAlerts(
             showNoNewContacts: $showNoNewContactsAlert,

--- a/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
@@ -1,0 +1,175 @@
+//
+//  PaywallView.swift
+//  KeepInTouch
+//
+//  The single Pro upgrade screen (#351). Presented from every gated feature via
+//  `PaywallTrigger` so the unlock experience is identical everywhere. Reads the
+//  shared `PurchaseManager` from the environment; dismisses itself once Pro is
+//  unlocked.
+//
+
+import SwiftUI
+
+/// Identifies a paywall presentation and carries the analytics source. Use with
+/// `.sheet(item:)` so presentation can't get stuck on a stale boolean.
+struct PaywallTrigger: Identifiable, Equatable {
+    let id = UUID()
+    /// Analytics source, e.g. "settings_upgrade", "cap_settings", "feature_stats".
+    let source: String
+}
+
+struct PaywallView: View {
+    let source: String
+
+    @EnvironmentObject private var purchaseManager: PurchaseManager
+    @Environment(\.dismiss) private var dismiss
+
+    private let features: [(icon: String, text: String)] = [
+        ("infinity", "Unlimited people"),
+        ("chart.bar.fill", "Stats & insights"),
+        ("square.and.arrow.down", "Import from a backup file"),
+        ("person.2.fill", "Group logging — log a whole hangout at once"),
+        ("slider.horizontal.3", "Unlimited custom cadences"),
+        ("calendar", "Custom due dates"),
+        ("pause.circle", "Pause people"),
+        ("rectangle.3.group.fill", "The full widget family"),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: DS.Spacing.xl) {
+                    header
+                    featureList
+                    Spacer(minLength: DS.Spacing.md)
+                    footer
+                }
+                .padding(.horizontal, DS.Spacing.xl)
+                .padding(.bottom, DS.Spacing.xl)
+            }
+            .background(DS.Colors.pageBg.ignoresSafeArea())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        AnalyticsService.track("pro.paywall_dismissed", parameters: ["source": source])
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+        .onAppear {
+            AnalyticsService.track("pro.paywall_shown", parameters: ["source": source])
+        }
+        .onChange(of: purchaseManager.isPro) { _, isPro in
+            // Unlocked (purchased or restored) — close the paywall.
+            if isPro { dismiss() }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(spacing: DS.Spacing.md) {
+            Image(systemName: "star.circle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(DS.Colors.accent)
+                .padding(.top, DS.Spacing.lg)
+
+            Text("A dozen friends, free.\nGot more people who matter?")
+                .font(DS.Typography.heroTitle)
+                .foregroundStyle(DS.Colors.primaryText)
+                .multilineTextAlignment(.center)
+
+            Text("Unlock unlimited people, plus stats, import, group logging, custom cadences, and the full widget family. Pay once. It's yours forever.")
+                .font(DS.Typography.notesBody)
+                .foregroundStyle(DS.Colors.secondaryText)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var featureList: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.md) {
+            ForEach(features, id: \.text) { feature in
+                HStack(spacing: DS.Spacing.md) {
+                    Image(systemName: feature.icon)
+                        .font(.body)
+                        .foregroundStyle(DS.Colors.accent)
+                        .frame(width: 28)
+                    Text(feature.text)
+                        .font(DS.Typography.notesBody)
+                        .foregroundStyle(DS.Colors.primaryText)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(DS.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DS.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        VStack(spacing: DS.Spacing.md) {
+            if let message = purchaseManager.statusMessage {
+                Text(message)
+                    .font(DS.Typography.metadata)
+                    .foregroundStyle(DS.Colors.secondaryText)
+                    .multilineTextAlignment(.center)
+            }
+
+            unlockButton
+
+            Button {
+                Task { await purchaseManager.restore() }
+            } label: {
+                Text("Restore Purchases")
+                    .font(DS.Typography.notesBody)
+                    .foregroundStyle(DS.Colors.accent)
+            }
+            .disabled(purchaseManager.isProcessing)
+
+            Text("No ads, no account, no cloud. The alternative to charging you is selling you, and I won't.")
+                .font(DS.Typography.metadata)
+                .foregroundStyle(DS.Colors.secondaryText)
+                .multilineTextAlignment(.center)
+                .padding(.top, DS.Spacing.sm)
+        }
+    }
+
+    @ViewBuilder
+    private var unlockButton: some View {
+        if let product = purchaseManager.proProduct {
+            Button {
+                Task { await purchaseManager.purchase() }
+            } label: {
+                if purchaseManager.isProcessing {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Unlock Pro — \(product.displayPrice)")
+                }
+            }
+            .buttonStyle(OnboardingPrimaryButtonStyle())
+            .disabled(purchaseManager.isProcessing)
+        } else {
+            // Product not loaded (offline, or ASC/StoreKit config not ready).
+            Button {
+                Task { await purchaseManager.loadProductAndRefresh() }
+            } label: {
+                if purchaseManager.isProcessing {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Couldn't load — Retry")
+                }
+            }
+            .buttonStyle(OnboardingPrimaryButtonStyle())
+            .disabled(purchaseManager.isProcessing)
+        }
+    }
+}

--- a/StayInTouch/StayInTouch/UI/Views/Settings/NewContactsPickerView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/NewContactsPickerView.swift
@@ -12,7 +12,11 @@ struct NewContactsPickerView: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
 
     let contacts: [ContactSummary]
-    let currentTrackedCount: Int
+    /// Live count of currently-tracked people, evaluated at Import time (not a
+    /// snapshot) so the cap can't be bypassed by adds made after presentation.
+    let currentTrackedCount: () -> Int
+    /// Analytics source for the cap/paywall, e.g. "settings" or "home".
+    let capSource: String
     let onImport: ([ContactSummary]) -> Void
     let onCancel: () -> Void
 
@@ -85,15 +89,15 @@ struct NewContactsPickerView: View {
                     Button("Import") {
                         let selected = contacts.filter { selection.contains($0.identifier) }
                         if ContactCapGate.wouldExceedFreeLimit(
-                            currentTrackedCount: currentTrackedCount,
+                            currentTrackedCount: currentTrackedCount(),
                             adding: selected.count,
                             isPro: purchaseManager.isPro
                         ) {
                             AnalyticsService.track(
                                 "pro.cap_blocked",
-                                parameters: ["trigger": "settings", "attempted": String(selected.count)]
+                                parameters: ["source": capSource, "attempted": String(selected.count)]
                             )
-                            paywallTrigger = PaywallTrigger(source: "cap_settings")
+                            paywallTrigger = PaywallTrigger(source: "cap_\(capSource)")
                         } else {
                             onImport(selected)
                             dismiss()

--- a/StayInTouch/StayInTouch/UI/Views/Settings/NewContactsPickerView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/NewContactsPickerView.swift
@@ -9,13 +9,16 @@ import SwiftUI
 
 struct NewContactsPickerView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
     let contacts: [ContactSummary]
+    let currentTrackedCount: Int
     let onImport: ([ContactSummary]) -> Void
     let onCancel: () -> Void
 
     @State private var selection: Set<String> = []
     @State private var searchText = ""
+    @State private var paywallTrigger: PaywallTrigger?
 
     private var groupedContacts: [(String, [ContactSummary])] {
         let filtered = searchText.isEmpty ? contacts : contacts.filter { contact in
@@ -81,11 +84,27 @@ struct NewContactsPickerView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Import") {
                         let selected = contacts.filter { selection.contains($0.identifier) }
-                        onImport(selected)
-                        dismiss()
+                        if ContactCapGate.wouldExceedFreeLimit(
+                            currentTrackedCount: currentTrackedCount,
+                            adding: selected.count,
+                            isPro: purchaseManager.isPro
+                        ) {
+                            AnalyticsService.track(
+                                "pro.cap_blocked",
+                                parameters: ["trigger": "settings", "attempted": String(selected.count)]
+                            )
+                            paywallTrigger = PaywallTrigger(source: "cap_settings")
+                        } else {
+                            onImport(selected)
+                            dismiss()
+                        }
                     }
                     .disabled(selection.isEmpty)
                 }
+            }
+            .sheet(item: $paywallTrigger) { trigger in
+                PaywallView(source: trigger.source)
+                    .environmentObject(purchaseManager)
             }
         }
     }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
+    @State private var paywallTrigger: PaywallTrigger?
     @State private var showNoNewContactsAlert = false
     @State private var showLimitedAccessAlert = false
     @State private var showContactsSettingsAlert = false
@@ -23,6 +25,7 @@ struct SettingsView: View {
 
     var body: some View {
         List {
+            proSection
             appearanceSection
             peopleSection
             notificationsSection
@@ -71,6 +74,7 @@ struct SettingsView: View {
             case .pickingContacts:
                 NewContactsPickerView(
                     contacts: viewModel.pendingNewContacts,
+                    currentTrackedCount: viewModel.trackedContactCount,
                     onImport: { selected in
                         pendingImportStep = .assigningGroups(selected: selected)
                         contactImportStep = nil
@@ -81,6 +85,7 @@ struct SettingsView: View {
                         contactImportStep = nil
                     }
                 )
+                .environmentObject(purchaseManager)
             case .assigningGroups(let selected):
                 SettingsCadenceAssignmentView(
                     contacts: selected,
@@ -115,9 +120,45 @@ struct SettingsView: View {
                 )
             }
         }
+        .sheet(item: $paywallTrigger) { trigger in
+            PaywallView(source: trigger.source)
+                .environmentObject(purchaseManager)
+        }
         .onAppear { viewModel.load() }
         .onReceive(NotificationCenter.default.publisher(for: .personDidChange)) { _ in
             viewModel.load()
+        }
+    }
+
+    private var proSection: some View {
+        Section {
+            if purchaseManager.isPro {
+                HStack {
+                    Label("Keep In Touch Pro", systemImage: "checkmark.seal.fill")
+                        .foregroundStyle(DS.Colors.accent)
+                    Spacer()
+                    Text("Active")
+                        .font(DS.Typography.metadata)
+                        .foregroundStyle(DS.Colors.secondaryText)
+                }
+            } else {
+                Button {
+                    paywallTrigger = PaywallTrigger(source: "settings_upgrade")
+                } label: {
+                    Label("Unlock Keep In Touch Pro", systemImage: "star.circle.fill")
+                }
+            }
+
+            Button {
+                Task { await purchaseManager.restore() }
+            } label: {
+                Label("Restore Purchases", systemImage: "arrow.clockwise")
+            }
+            .accessibilityHint("Restores a previous Pro purchase")
+        } header: {
+            if !purchaseManager.isPro {
+                Text("Upgrade")
+            }
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -74,7 +74,8 @@ struct SettingsView: View {
             case .pickingContacts:
                 NewContactsPickerView(
                     contacts: viewModel.pendingNewContacts,
-                    currentTrackedCount: viewModel.trackedContactCount,
+                    currentTrackedCount: { viewModel.liveTrackedCount() },
+                    capSource: "settings",
                     onImport: { selected in
                         pendingImportStep = .assigningGroups(selected: selected)
                         contactImportStep = nil

--- a/StayInTouch/StayInTouch/UseCases/ContactCapGate.swift
+++ b/StayInTouch/StayInTouch/UseCases/ContactCapGate.swift
@@ -1,0 +1,27 @@
+//
+//  ContactCapGate.swift
+//  KeepInTouch
+//
+//  Pure decision logic for the free-tier contact cap (#351). Pro users are never
+//  capped. The count is of tracked, non-demo people (paused included). Adding is
+//  block-all: if a batch would cross the cap, the whole batch is blocked and the
+//  paywall is shown — never a partial add.
+//
+
+import Foundation
+
+enum ContactCapGate {
+    /// Whether adding `adding` tracked contacts would push a non-Pro user past the
+    /// free-tier limit. Pro users are never capped.
+    static func wouldExceedFreeLimit(currentTrackedCount: Int, adding: Int, isPro: Bool) -> Bool {
+        guard !isPro else { return false }
+        return currentTrackedCount + adding > ProConfig.freeContactLimit
+    }
+
+    /// Remaining free slots for a non-Pro user (clamped to >= 0); `nil` for Pro
+    /// (unlimited). Used for the near-cap soft signal.
+    static func remainingFreeSlots(currentTrackedCount: Int, isPro: Bool) -> Int? {
+        guard !isPro else { return nil }
+        return max(0, ProConfig.freeContactLimit - currentTrackedCount)
+    }
+}

--- a/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
+++ b/StayInTouch/StayInTouchTests/AppIntents/IntentTestHarness.swift
@@ -61,6 +61,7 @@ final class IntentTestPersonRepository: PersonRepository, @unchecked Sendable {
     }
     func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
     func snoozedCount(referenceDate: Date) -> Int { people.filter { $0.isTracked && ($0.snoozedUntil.map { $0 > referenceDate } ?? false) }.count }
+    func trackedCount() -> Int { people.filter { $0.isTracked && !$0.isDemoData }.count }
 }
 
 @MainActor

--- a/StayInTouch/StayInTouchTests/ContactCapTests.swift
+++ b/StayInTouch/StayInTouchTests/ContactCapTests.swift
@@ -1,0 +1,76 @@
+//
+//  ContactCapTests.swift
+//  KeepInTouchTests
+//
+//  Pure cap-gate logic (#351, PR3) + the repository tracked-count it depends on.
+//
+
+import CoreData
+import XCTest
+@testable import StayInTouch
+
+final class ContactCapTests: XCTestCase {
+
+    // MARK: - ContactCapGate.wouldExceedFreeLimit
+
+    func testCap_proIsNeverLimited() {
+        XCTAssertFalse(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 999, adding: 50, isPro: true))
+    }
+
+    func testCap_freeUnderLimit_allowed() {
+        // 6 + 3 = 9 <= 12
+        XCTAssertFalse(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 6, adding: 3, isPro: false))
+    }
+
+    func testCap_freeExactlyAtLimit_allowed() {
+        // 10 + 2 = 12 (== limit) is allowed; only > 12 is blocked.
+        XCTAssertFalse(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 10, adding: 2, isPro: false))
+    }
+
+    func testCap_freeOverLimit_blocked() {
+        // 10 + 3 = 13 > 12
+        XCTAssertTrue(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 10, adding: 3, isPro: false))
+    }
+
+    func testCap_freeAtLimitAddingOne_blocked() {
+        XCTAssertTrue(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 12, adding: 1, isPro: false))
+    }
+
+    func testCap_onboardingBatchOverLimit_blocked() {
+        // Onboarding: trackedCount == 0, selecting 13 should be blocked.
+        XCTAssertTrue(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 0, adding: 13, isPro: false))
+        XCTAssertFalse(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 0, adding: 12, isPro: false))
+    }
+
+    // MARK: - ContactCapGate.remainingFreeSlots
+
+    func testRemaining_proIsNil() {
+        XCTAssertNil(ContactCapGate.remainingFreeSlots(currentTrackedCount: 5, isPro: true))
+    }
+
+    func testRemaining_freeClampedToZero() {
+        XCTAssertEqual(ContactCapGate.remainingFreeSlots(currentTrackedCount: 5, isPro: false), 7)
+        XCTAssertEqual(ContactCapGate.remainingFreeSlots(currentTrackedCount: 12, isPro: false), 0)
+        XCTAssertEqual(ContactCapGate.remainingFreeSlots(currentTrackedCount: 20, isPro: false), 0)
+    }
+
+    // MARK: - Repository trackedCount (isTracked && !isDemoData, paused included)
+
+    func testTrackedCount_countsTrackedNonDemoIncludingPaused() throws {
+        let context = CoreDataTestStack().container.viewContext
+        let repo = CoreDataPersonRepository(context: context)
+
+        try repo.save(TestFactory.makePerson(name: "Active"))
+        try repo.save(TestFactory.makePerson(name: "Paused", isPaused: true))   // paused still counts
+        try repo.save(TestFactory.makePerson(name: "Untracked", isTracked: false)) // excluded
+        try repo.save(TestFactory.makePerson(name: "Demo", isDemoData: true))       // excluded
+
+        XCTAssertEqual(repo.trackedCount(), 2)
+    }
+
+    func testTrackedCount_emptyIsZero() {
+        let context = CoreDataTestStack().container.viewContext
+        let repo = CoreDataPersonRepository(context: context)
+        XCTAssertEqual(repo.trackedCount(), 0)
+    }
+}

--- a/StayInTouch/StayInTouchTests/ContactCapTests.swift
+++ b/StayInTouch/StayInTouchTests/ContactCapTests.swift
@@ -36,8 +36,10 @@ final class ContactCapTests: XCTestCase {
         XCTAssertTrue(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 12, adding: 1, isPro: false))
     }
 
-    func testCap_onboardingBatchOverLimit_blocked() {
-        // Onboarding: trackedCount == 0, selecting 13 should be blocked.
+    func testCap_batchFromEmptyOverLimit_blocked() {
+        // From an empty base (e.g. trackedCount == 0), a batch of 13 is blocked,
+        // 12 is allowed. (Pure-function coverage; the onboarding *flow* gate lands
+        // in a later PR.)
         XCTAssertTrue(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 0, adding: 13, isPro: false))
         XCTAssertFalse(ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 0, adding: 12, isPro: false))
     }

--- a/StayInTouch/StayInTouchTests/FreshStartIntegrationTests.swift
+++ b/StayInTouch/StayInTouchTests/FreshStartIntegrationTests.swift
@@ -298,6 +298,7 @@ private struct StubPersonRepository: PersonRepository {
     func delete(id: UUID) throws {}
     func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
     func snoozedCount(referenceDate: Date) -> Int { people.filter { $0.isTracked && ($0.snoozedUntil.map { $0 > referenceDate } ?? false) }.count }
+    func trackedCount() -> Int { people.filter { $0.isTracked && !$0.isDemoData }.count }
 }
 
 private struct StubCadenceRepository: CadenceRepository {

--- a/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
+++ b/StayInTouch/StayInTouchTests/HomeViewModelTests.swift
@@ -322,6 +322,7 @@ final class HomeViewModelTests: XCTestCase {
         func delete(id: UUID) throws {}
         func pausedCount() -> Int { people.filter { $0.isTracked && $0.isPaused }.count }
         func snoozedCount(referenceDate: Date) -> Int { people.filter { $0.isTracked && ($0.snoozedUntil.map { $0 > referenceDate } ?? false) }.count }
+        func trackedCount() -> Int { people.filter { $0.isTracked && !$0.isDemoData }.count }
     }
 
     private struct InMemoryCadenceRepository: CadenceRepository {

--- a/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
+++ b/StayInTouch/StayInTouchTests/TestHelpers/MockRepositories.swift
@@ -66,6 +66,12 @@ final class MockPersonRepository: PersonRepository, @unchecked Sendable {
         snoozedCountCallCount += 1
         return people.filter { $0.isTracked && ($0.snoozedUntil.map { $0 > referenceDate } ?? false) }.count
     }
+
+    var trackedCountCallCount = 0
+    func trackedCount() -> Int {
+        trackedCountCallCount += 1
+        return people.filter { $0.isTracked && !$0.isDemoData }.count
+    }
 }
 
 // MARK: - MockCadenceRepository
@@ -202,7 +208,8 @@ enum TestFactory {
         customDueDate: Date? = nil,
         birthday: Birthday? = nil,
         birthdayNotificationsEnabled: Bool = true,
-        cnIdentifier: String? = nil
+        cnIdentifier: String? = nil,
+        isDemoData: Bool = false
     ) -> Person {
         Person(
             identity: Person.Identity(
@@ -231,7 +238,7 @@ enum TestFactory {
             ),
             metadata: Person.Metadata(
                 contactUnavailable: false,
-                isDemoData: false,
+                isDemoData: isDemoData,
                 createdAt: Date(),
                 modifiedAt: Date(),
                 sortOrder: 0


### PR DESCRIPTION
## Summary
Third stacked PR for freemium (#351). The first user-visible monetization: the paywall and the contact cap.

- **PaywallView** — the single Pro upgrade screen (warm spec copy, feature list, live price, Unlock / Restore, load-failure retry). Presented everywhere via `PaywallTrigger` + `.sheet(item:)`; auto-dismisses when `isPro` flips. This is the shared paywall PR4's feature gates will reuse.
- **ContactCapGate** (pure): block-all free-tier decision — Pro is never capped; `> 12` blocks the whole batch (exactly 12 allowed).
- **`PersonRepository.trackedCount()`** — `count(for:)` of `isTracked && !isDemoData` (paused included; a paused contact still occupies a slot). Added to protocol + Core Data + all test stubs.
- **Settings → "Upgrade" section** — unlock entry / owned state / **Restore Purchases**.
- **Cap enforced (block-all + paywall)** on both Add-from-Contacts entry points (Settings **and** Home), using a **live** count read at Import time (not a snapshot) so it can't be bypassed by session adds. Fires `pro.cap_blocked` and presents the paywall with a per-source tag.

## Deferred to PR4 (documented, not a miss)
The **onboarding picker** (`ContactPickerView`) is a *separate* flow with a multi-step view-model bridge; its cap enforcement lands in PR4 alongside the other gates (pause, stats, import, bulk-log, custom cadences, custom due dates), all reusing this paywall. Until PR4, a new user could exceed 12 during first-run onboarding — closed before any merge since these PRs are reviewed/merged as a stack.

## Test plan
- [x] Build + full suite green; new `ContactCapTests` (cap matrix + repo trackedCount incl. demo/paused/untracked exclusion)
- [ ] Manual (needs Configuration.storekit selected in scheme, see PR2): at 12 contacts, Add-from-Contacts → paywall; buy in sandbox → cap lifts; Settings → Upgrade/Restore
- [ ] Manual: paywall visual polish review (built against DesignSystem; copy is locked, layout is yours to tweak)

## Review
- Code review (high, --fix): applied — live cap count (fixed a Home-path bypass from a stale snapshot), per-source paywall/cap analytics unified on the `source` key, corrected ProConfig paused-counting doc, renamed a misleading test. 
- Security review: clean PASS — static Core Data predicate (no injection), analytics carry counts/enums only (no PII), pure cap arithmetic.

Stacked on #355. Part of #351.