### PR TITLE
[#351] Freemium PR4: gate Pro features (onboarding cap, stats, import, bulk logging)

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/MainTabView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/MainTabView.swift
@@ -14,8 +14,10 @@ struct MainTabView: View {
     @State private var bulkLogState: BulkLogPresentation?
     @State private var batchEditContext: BatchEditContext?
     @State private var recentGroups: [RecentGroup] = []
+    @State private var paywallTrigger: PaywallTrigger?
     private let recentGroupsStore = RecentGroupsStore()
     @Environment(\.dependencies) private var dependencies
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
     var body: some View {
         TabView(selection: $deepLinkRouter.selectedTab) {
@@ -93,6 +95,10 @@ struct MainTabView: View {
         }
         .sheet(item: $bulkLogState) { state in
             bulkLogSheet(for: state)
+        }
+        .sheet(item: $paywallTrigger) { trigger in
+            PaywallView(source: trigger.source)
+                .environmentObject(purchaseManager)
         }
         .onChange(of: deepLinkRouter.pending) { _, newValue in
             if newValue != nil { processPendingDeepLink() }
@@ -191,6 +197,11 @@ struct MainTabView: View {
 
     private func commitBulkLog() {
         guard selectionCoordinator.hasSelection else { return }
+        if !purchaseManager.isPro {
+            AnalyticsService.track("pro.gate_tapped", parameters: ["source": "bulk_log"])
+            paywallTrigger = PaywallTrigger(source: "bulk_log")
+            return
+        }
         let ids = Array(selectionCoordinator.selection)
         let people = ids.compactMap { dependencies.personRepository.fetch(id: $0) }
         if let ctx = batchEditContext {

--- a/StayInTouch/StayInTouch/UI/Views/Onboarding/ContactPickerView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Onboarding/ContactPickerView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ContactPickerView: View {
     @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject private var purchaseManager: PurchaseManager
+
+    @State private var paywallTrigger: PaywallTrigger?
 
     private var groupedContacts: [(String, [ContactSummary])] {
         let grouped = Dictionary(grouping: viewModel.filteredContacts) { contact -> String in
@@ -90,11 +93,20 @@ struct ContactPickerView: View {
             }
 
             Button("Continue") {
-                viewModel.continueFromContactPicker()
+                if ContactCapGate.wouldExceedFreeLimit(currentTrackedCount: 0, adding: viewModel.selectedContactIds.count, isPro: purchaseManager.isPro) {
+                    AnalyticsService.track("pro.cap_blocked", parameters: ["source": "onboarding", "attempted": String(viewModel.selectedContactIds.count)])
+                    paywallTrigger = PaywallTrigger(source: "cap_onboarding")
+                } else {
+                    viewModel.continueFromContactPicker()
+                }
             }
             .buttonStyle(OnboardingPrimaryButtonStyle())
             .padding(.horizontal)
             .padding(.bottom)
+        }
+        .sheet(item: $paywallTrigger) { trigger in
+            PaywallView(source: trigger.source)
+                .environmentObject(purchaseManager)
         }
     }
 }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
@@ -10,7 +10,9 @@ import UniformTypeIdentifiers
 
 struct DataSettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
+    @State private var paywallTrigger: PaywallTrigger?
     @State private var shareItem: ShareItem?
     @State private var showFilePicker = false
     @State private var importPreview: ImportPreview?
@@ -109,6 +111,10 @@ struct DataSettingsView: View {
         } message: {
             Text(importResultMessage)
         }
+        .sheet(item: $paywallTrigger) { trigger in
+            PaywallView(source: trigger.source)
+                .environmentObject(purchaseManager)
+        }
     }
 
     // MARK: - Backup
@@ -157,7 +163,12 @@ struct DataSettingsView: View {
             }
 
             Button {
-                showFilePicker = true
+                if purchaseManager.isPro {
+                    showFilePicker = true
+                } else {
+                    AnalyticsService.track("pro.gate_tapped", parameters: ["source": "import"])
+                    paywallTrigger = PaywallTrigger(source: "import")
+                }
             } label: {
                 Label("Import Contacts", systemImage: "square.and.arrow.down")
             }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -275,10 +275,24 @@ struct SettingsView: View {
 
     private var insightsSection: some View {
         Section("Insights") {
-            NavigationLink {
-                StatsView(viewModel: StatsViewModel())
-            } label: {
-                Label("Stats & insights", systemImage: "chart.bar")
+            if purchaseManager.isPro {
+                NavigationLink {
+                    StatsView(viewModel: StatsViewModel())
+                } label: {
+                    Label("Stats & insights", systemImage: "chart.bar")
+                }
+            } else {
+                Button {
+                    AnalyticsService.track("pro.gate_tapped", parameters: ["source": "stats"])
+                    paywallTrigger = PaywallTrigger(source: "stats")
+                } label: {
+                    HStack {
+                        Label("Stats & insights", systemImage: "chart.bar")
+                        Spacer()
+                        Image(systemName: "lock.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fourth stacked PR for freemium (#351). Gates the Pro-only features behind the shared paywall, and closes the onboarding cap bypass left open in PR3. Each gate sets `paywallTrigger` and presents `PaywallView` via `.sheet(item:)` (environmentObject re-injected).

- **Onboarding contact cap** — `ContactPickerView` "Continue" blocks a >12 selection (`ContactCapGate`, block-all) and shows the paywall. This closes the bypass where a new user could exceed 12 during first-run onboarding.
- **Stats & insights** — the Settings row becomes a lock affordance + paywall when not Pro; Pro keeps the normal NavigationLink.
- **File / JSON import** — `DataSettingsView`'s file import is gated. **Export stays free** (data-never-hostage).
- **Group / bulk logging** — gated at the single chokepoint `MainTabView.commitBulkLog()`, which catches all multi-select entry points (Home/Contacts select chips, recent groups). Free users can explore select mode but hit the paywall on commit; the early return preserves selection so it works immediately after unlocking.

Analytics: `pro.gate_tapped` (source: `stats` | `import` | `bulk_log`), `pro.cap_blocked` (source: `onboarding`).

## Still deferred (intentional, for a follow-up)
The remaining in-detail gates — **pause** (PersonDetail toggle), **custom due dates** (PersonDetail), **unlimited/custom cadence groups** (ManageCadences) — and **widget upsell rendering + App Intents entitlement** (PR5). These are more intricate per the gate map and are documented for the next pass. The paywall + isPro pattern they'll reuse is fully established here.

## Test plan
- [x] Build + full suite green (gates reuse the already-tested ContactCapGate / isPro; no new pure logic)
- [ ] Manual (Configuration.storekit in scheme): free user → each gated feature shows the paywall; buy → feature unlocks; onboarding select >12 → paywall
- [ ] Manual: confirm Pro users see no gate (no regression) on stats/import/bulk-log

## Review
- Code review (high): clean — no findings. Verified gate placement, bulk-log selection-state on early return, no Pro-user regression, environment availability.
- Security review: clean PASS — analytics carry static sources + a count only (no PII); file-import gate is a pure UI check (no boundary change).

Stacked on #356. Part of #351.