### PR TITLE
[#351] Freemium PR5: gate pause, custom due dates, custom cadences

### DIFF
--- a/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
@@ -41,13 +41,26 @@ struct PaywallView: View {
                 VStack(spacing: DS.Spacing.xl) {
                     header
                     featureList
-                    Spacer(minLength: DS.Spacing.md)
-                    footer
                 }
                 .padding(.horizontal, DS.Spacing.xl)
-                .padding(.bottom, DS.Spacing.xl)
+                .padding(.top, DS.Spacing.lg)
+                .padding(.bottom, DS.Spacing.md)
             }
             .background(DS.Colors.pageBg.ignoresSafeArea())
+            // Pin the price + Unlock + Restore so they're always visible (no
+            // scrolling needed), while the header + feature list scroll above.
+            .safeAreaInset(edge: .bottom) {
+                footer
+                    .padding(.horizontal, DS.Spacing.xl)
+                    .padding(.top, DS.Spacing.md)
+                    .padding(.bottom, DS.Spacing.sm)
+                    .background(DS.Colors.pageBg)
+                    .overlay(alignment: .top) {
+                        Rectangle()
+                            .fill(DS.Colors.settingsSeparator)
+                            .frame(height: 0.5)
+                    }
+            }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -76,11 +89,6 @@ struct PaywallView: View {
 
     private var header: some View {
         VStack(spacing: DS.Spacing.md) {
-            Image(systemName: "star.circle.fill")
-                .font(.system(size: 56))
-                .foregroundStyle(DS.Colors.accent)
-                .padding(.top, DS.Spacing.lg)
-
             Text("A dozen friends, free.\nGot more people who matter?")
                 .font(DS.Typography.heroTitle)
                 .foregroundStyle(DS.Colors.primaryText)

--- a/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Paywall/PaywallView.swift
@@ -29,7 +29,7 @@ struct PaywallView: View {
         ("chart.bar.fill", "Stats & insights"),
         ("square.and.arrow.down", "Import from a backup file"),
         ("person.2.fill", "Group logging — log a whole hangout at once"),
-        ("slider.horizontal.3", "Unlimited custom cadences"),
+        ("slider.horizontal.3", "Unlimited custom frequencies"),
         ("calendar", "Custom due dates"),
         ("pause.circle", "Pause people"),
         ("rectangle.3.group.fill", "The full widget family"),
@@ -86,7 +86,7 @@ struct PaywallView: View {
                 .foregroundStyle(DS.Colors.primaryText)
                 .multilineTextAlignment(.center)
 
-            Text("Unlock unlimited people, plus stats, import, group logging, custom cadences, and the full widget family. Pay once. It's yours forever.")
+            Text("Unlock unlimited people, plus stats, import, group logging, custom frequencies, and the full widget family. Pay once. It's yours forever.")
                 .font(DS.Typography.notesBody)
                 .foregroundStyle(DS.Colors.secondaryText)
                 .multilineTextAlignment(.center)
@@ -122,6 +122,12 @@ struct PaywallView: View {
                     .font(DS.Typography.metadata)
                     .foregroundStyle(DS.Colors.secondaryText)
                     .multilineTextAlignment(.center)
+            }
+
+            if purchaseManager.proProduct != nil {
+                Text("Introductory launch price")
+                    .font(DS.Typography.metadata)
+                    .foregroundStyle(DS.Colors.accent)
             }
 
             unlockButton

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
@@ -63,4 +63,6 @@ enum PersonSettingsAction {
     case customDueDatePicker(initialDate: Date)
     case birthdayEditor
     case requestPause
+    /// A locked (Pro) row was tapped by a non-Pro user — present the paywall.
+    case requestPaywall(source: String)
 }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailModal.swift
@@ -17,6 +17,7 @@ enum PersonDetailSheet: Identifiable {
     case snoozeDatePicker
     case customDueDatePicker
     case birthdayEditor
+    case paywall(source: String)
 
     var id: String {
         switch self {
@@ -29,6 +30,7 @@ enum PersonDetailSheet: Identifiable {
         case .snoozeDatePicker: return "snoozeDatePicker"
         case .customDueDatePicker: return "customDueDatePicker"
         case .birthdayEditor: return "birthdayEditor"
+        case .paywall(let source): return "paywall-\(source)"
         }
     }
 }
@@ -60,4 +62,5 @@ enum PersonSettingsAction {
     case snoozeDatePicker(initialDate: Date)
     case customDueDatePicker(initialDate: Date)
     case birthdayEditor
+    case requestPause
 }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -12,6 +12,7 @@ struct PersonDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dependencies) private var dependencies
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
     @StateObject private var viewModel: PersonDetailViewModel
 
@@ -250,6 +251,8 @@ struct PersonDetailView: View {
             BirthdayEditorSheet(birthday: viewModel.displayBirthday,
                                 onSave: { viewModel.setBirthday($0); activeSheet = nil },
                                 onClear: { viewModel.setBirthday(nil); activeSheet = nil })
+        case .paywall(let source):
+            PaywallView(source: source).environmentObject(purchaseManager)
         }
     }
 
@@ -299,8 +302,22 @@ struct PersonDetailView: View {
         case .removeConfirm: activeAlert = .removeConfirm
         case .reminderTimePicker: activeSheet = .reminderTimePicker
         case .snoozeDatePicker(let d): pickedSnoozeDate = d; activeSheet = .snoozeDatePicker
-        case .customDueDatePicker(let d): pickedCustomDueDate = d; activeSheet = .customDueDatePicker
+        case .customDueDatePicker(let d):
+            if purchaseManager.isPro {
+                pickedCustomDueDate = d
+                activeSheet = .customDueDatePicker
+            } else {
+                AnalyticsService.track("pro.gate_tapped", parameters: ["source": "custom_due_date"])
+                activeSheet = .paywall(source: "custom_due_date")
+            }
         case .birthdayEditor: activeSheet = .birthdayEditor
+        case .requestPause:
+            if purchaseManager.isPro {
+                viewModel.togglePause()
+            } else {
+                AnalyticsService.track("pro.gate_tapped", parameters: ["source": "pause"])
+                activeSheet = .paywall(source: "pause")
+            }
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -300,21 +300,28 @@ struct PersonDetailView: View {
         case .manageGroups: activeSheet = .manageGroups
         case .resumePrompt: activeAlert = .resumePrompt
         case .removeConfirm: activeAlert = .removeConfirm
-        case .reminderTimePicker: activeSheet = .reminderTimePicker
-        case .snoozeDatePicker(let d): pickedSnoozeDate = d; activeSheet = .snoozeDatePicker
-        // Pro gating for these rows is owned by PersonSettingsSection (it shows
-        // the lock and routes non-Pro taps to `.requestPaywall`), so these
-        // handlers only run on the Pro path and just perform the action.
-        case .customDueDatePicker(let d):
-            pickedCustomDueDate = d
-            activeSheet = .customDueDatePicker
         case .birthdayEditor: activeSheet = .birthdayEditor
+        // Pro-gated SET actions. PersonSettingsSection shows a lock and routes
+        // non-Pro taps to `.requestPaywall`, but we ALSO gate here so that when
+        // an ex-Pro user is shown the active row (to keep clear/undo reachable —
+        // never trap created data) any *set* path still requires Pro. Clear /
+        // unpause / remove call the view model directly and stay free.
+        case .reminderTimePicker:
+            purchaseManager.isPro ? (activeSheet = .reminderTimePicker) : presentPaywall("custom_notification_time")
+        case .snoozeDatePicker(let d):
+            if purchaseManager.isPro { pickedSnoozeDate = d; activeSheet = .snoozeDatePicker } else { presentPaywall("snooze") }
+        case .customDueDatePicker(let d):
+            if purchaseManager.isPro { pickedCustomDueDate = d; activeSheet = .customDueDatePicker } else { presentPaywall("custom_due_date") }
         case .requestPause:
-            viewModel.togglePause()
+            purchaseManager.isPro ? viewModel.togglePause() : presentPaywall("pause")
         case .requestPaywall(let source):
-            AnalyticsService.track("pro.gate_tapped", parameters: ["source": source])
-            activeSheet = .paywall(source: source)
+            presentPaywall(source)
         }
+    }
+
+    private func presentPaywall(_ source: String) {
+        AnalyticsService.track("pro.gate_tapped", parameters: ["source": source])
+        activeSheet = .paywall(source: source)
     }
 
     // MARK: - Date Picker Sheet Helper

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonDetailView.swift
@@ -302,22 +302,18 @@ struct PersonDetailView: View {
         case .removeConfirm: activeAlert = .removeConfirm
         case .reminderTimePicker: activeSheet = .reminderTimePicker
         case .snoozeDatePicker(let d): pickedSnoozeDate = d; activeSheet = .snoozeDatePicker
+        // Pro gating for these rows is owned by PersonSettingsSection (it shows
+        // the lock and routes non-Pro taps to `.requestPaywall`), so these
+        // handlers only run on the Pro path and just perform the action.
         case .customDueDatePicker(let d):
-            if purchaseManager.isPro {
-                pickedCustomDueDate = d
-                activeSheet = .customDueDatePicker
-            } else {
-                AnalyticsService.track("pro.gate_tapped", parameters: ["source": "custom_due_date"])
-                activeSheet = .paywall(source: "custom_due_date")
-            }
+            pickedCustomDueDate = d
+            activeSheet = .customDueDatePicker
         case .birthdayEditor: activeSheet = .birthdayEditor
         case .requestPause:
-            if purchaseManager.isPro {
-                viewModel.togglePause()
-            } else {
-                AnalyticsService.track("pro.gate_tapped", parameters: ["source": "pause"])
-                activeSheet = .paywall(source: "pause")
-            }
+            viewModel.togglePause()
+        case .requestPaywall(let source):
+            AnalyticsService.track("pro.gate_tapped", parameters: ["source": source])
+            activeSheet = .paywall(source: source)
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -305,7 +305,7 @@ struct PersonSettingsSection: View {
             get: { viewModel.person.isPaused },
             set: { newValue in
                 if newValue {
-                    viewModel.togglePause()
+                    onAction(.requestPause)
                 } else {
                     onAction(.resumePrompt)
                 }

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -96,7 +96,9 @@ struct PersonSettingsSection: View {
 
     @ViewBuilder
     private var settingsRowCustomDueDate: some View {
-        if purchaseManager.isPro {
+        // Show the active row when Pro OR already set, so an ex-Pro user can
+        // still Clear it (free). Setting a new one is gated in the handler.
+        if purchaseManager.isPro || viewModel.person.customDueDate != nil {
             settingsRowCustomDueDateActive
         } else {
             proLockedRow("Set A Reminder Date", source: "custom_due_date")
@@ -105,7 +107,7 @@ struct PersonSettingsSection: View {
 
     @ViewBuilder
     private var settingsRowNotificationTime: some View {
-        if purchaseManager.isPro {
+        if purchaseManager.isPro || viewModel.person.customBreachTime != nil {
             settingsRowNotificationTimeActive
         } else {
             proLockedRow("Custom Notification Time", source: "custom_notification_time")
@@ -114,7 +116,7 @@ struct PersonSettingsSection: View {
 
     @ViewBuilder
     private var settingsRowSnooze: some View {
-        if purchaseManager.isPro {
+        if purchaseManager.isPro || viewModel.person.isSnoozed() {
             settingsRowSnoozeActive
         } else {
             proLockedRow("Snooze", source: "snooze")
@@ -123,7 +125,9 @@ struct PersonSettingsSection: View {
 
     @ViewBuilder
     private var settingsRowPauseTracking: some View {
-        if purchaseManager.isPro {
+        // Active (toggle) when Pro OR already paused, so unpause stays free for an
+        // ex-Pro user. Pausing a not-paused contact is gated in the handler.
+        if purchaseManager.isPro || viewModel.person.isPaused {
             settingsRowPauseTrackingActive
         } else {
             proLockedRow("Pause Tracking", source: "pause")

--- a/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
+++ b/StayInTouch/StayInTouch/UI/Views/PersonDetail/PersonSettingsSection.swift
@@ -10,6 +10,7 @@ struct PersonSettingsSection: View {
     @Binding var settingsExpanded: Bool
     var onAction: (PersonSettingsAction) -> Void
     @Environment(\.dependencies) private var dependencies
+    @EnvironmentObject private var purchaseManager: PurchaseManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -89,6 +90,46 @@ struct PersonSettingsSection: View {
 
     // MARK: - Settings Rows
 
+    // Pro-gated rows: free users see a lock and tapping opens the paywall.
+    // Unpause / clear-due-date stay free (they live on the active variants and
+    // on the resume-prompt path), so a refunded user is never trapped.
+
+    @ViewBuilder
+    private var settingsRowCustomDueDate: some View {
+        if purchaseManager.isPro {
+            settingsRowCustomDueDateActive
+        } else {
+            proLockedRow("Set A Reminder Date", source: "custom_due_date")
+        }
+    }
+
+    @ViewBuilder
+    private var settingsRowNotificationTime: some View {
+        if purchaseManager.isPro {
+            settingsRowNotificationTimeActive
+        } else {
+            proLockedRow("Custom Notification Time", source: "custom_notification_time")
+        }
+    }
+
+    @ViewBuilder
+    private var settingsRowSnooze: some View {
+        if purchaseManager.isPro {
+            settingsRowSnoozeActive
+        } else {
+            proLockedRow("Snooze", source: "snooze")
+        }
+    }
+
+    @ViewBuilder
+    private var settingsRowPauseTracking: some View {
+        if purchaseManager.isPro {
+            settingsRowPauseTrackingActive
+        } else {
+            proLockedRow("Pause Tracking", source: "pause")
+        }
+    }
+
     private var settingsRowFrequency: some View {
         Button { onAction(.changeCadence) } label: {
             HStack {
@@ -109,7 +150,7 @@ struct PersonSettingsSection: View {
         .buttonStyle(.plain)
     }
 
-    private var settingsRowCustomDueDate: some View {
+    private var settingsRowCustomDueDateActive: some View {
         HStack {
             Text("Set A Reminder Date")
                 .font(DS.Typography.settingsRowLabel)
@@ -140,7 +181,7 @@ struct PersonSettingsSection: View {
         .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
-    private var settingsRowSnooze: some View {
+    private var settingsRowSnoozeActive: some View {
         VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             HStack {
                 Text("Snooze")
@@ -255,7 +296,7 @@ struct PersonSettingsSection: View {
         .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
-    private var settingsRowNotificationTime: some View {
+    private var settingsRowNotificationTimeActive: some View {
         VStack(alignment: .leading, spacing: DS.Spacing.xs) {
             Button {
                 onAction(.reminderTimePicker)
@@ -300,7 +341,7 @@ struct PersonSettingsSection: View {
         .frame(minHeight: DS.Spacing.menuRowHeight)
     }
 
-    private var settingsRowPauseTracking: some View {
+    private var settingsRowPauseTrackingActive: some View {
         Toggle(isOn: Binding(
             get: { viewModel.person.isPaused },
             set: { newValue in
@@ -341,6 +382,28 @@ struct PersonSettingsSection: View {
     private func snooze(days: Int) {
         let date = Calendar.current.date(byAdding: .day, value: days, to: Date()) ?? Date()
         viewModel.snooze(until: date)
+    }
+
+    /// A Pro-locked settings row: shows the title with a trailing lock and routes
+    /// taps to the paywall. Mirrors the lock affordance used in Settings.
+    private func proLockedRow(_ title: String, source: String) -> some View {
+        Button {
+            onAction(.requestPaywall(source: source))
+        } label: {
+            HStack {
+                Text(title)
+                    .font(DS.Typography.settingsRowLabel)
+                    .foregroundStyle(DS.Colors.settingsItemLabel)
+                Spacer()
+                Image(systemName: "lock.fill")
+                    .font(.caption)
+                    .foregroundStyle(DS.Colors.settingsChevron)
+            }
+            .frame(minHeight: DS.Spacing.menuRowHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Unlocks with Pro")
     }
 
     private func reminderTimeLabel() -> String {

--- a/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/DataSettingsView.swift
@@ -28,10 +28,11 @@ struct DataSettingsView: View {
         List {
             backupSection
             exportImportSection
+            privacySection
         }
         .listStyle(.insetGrouped)
         .tint(DS.Colors.accent)
-        .navigationTitle("Backup & Data")
+        .navigationTitle("Data & Privacy")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $shareItem) { item in
             ShareSheet(items: item.urls) {
@@ -183,6 +184,33 @@ struct DataSettingsView: View {
             }
         } header: {
             Text("Export & Import")
+        }
+    }
+
+    // MARK: - Privacy
+
+    /// Hosted privacy policy (GitHub Pages from `main/docs`; same URL set in
+    /// App Store Connect). A hardcoded, known-valid literal — safe to unwrap.
+    private static let privacyPolicyURL = URL(string: "https://slavins-co.github.io/keep-in-touch/privacy-policy")!
+
+    private var privacySection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { viewModel.settings.analyticsEnabled },
+                set: { viewModel.setAnalyticsEnabled($0) }
+            )) {
+                Label("Anonymous Usage Analytics", systemImage: "shield.checkered")
+            }
+
+            Link(destination: Self.privacyPolicyURL) {
+                Label("Privacy Policy", systemImage: "hand.raised.fill")
+            }
+        } header: {
+            Text("Privacy")
+        } footer: {
+            Text("Your relationship data lives on your device and is never sent to us. Anonymous usage statistics (no names, no contact data) help improve the app — turn them off anytime.")
+                .font(DS.Typography.caption)
+                .foregroundStyle(DS.Colors.secondaryText)
         }
     }
 }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/ManageCadencesView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/ManageCadencesView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ManageCadencesView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var purchaseManager: PurchaseManager
     @StateObject private var viewModel = ManageCadencesViewModel()
 
     @State private var showNewCadence = false
@@ -16,6 +17,7 @@ struct ManageCadencesView: View {
     @State private var deleteTarget: Cadence?
     @State private var showDeleteConfirm = false
     @State private var showCannotDeleteAlert = false
+    @State private var paywallTrigger: PaywallTrigger?
 
     var body: some View {
         List {
@@ -69,7 +71,12 @@ struct ManageCadencesView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
-                    showNewCadence = true
+                    if purchaseManager.isPro {
+                        showNewCadence = true
+                    } else {
+                        AnalyticsService.track("pro.gate_tapped", parameters: ["source": "custom_cadence"])
+                        paywallTrigger = PaywallTrigger(source: "custom_cadence")
+                    }
                 } label: {
                     Image(systemName: "plus.circle.fill")
                 }
@@ -97,6 +104,9 @@ struct ManageCadencesView: View {
                 },
                 onCancel: { showNewCadence = false }
             )
+        }
+        .sheet(item: $paywallTrigger) { trigger in
+            PaywallView(source: trigger.source).environmentObject(purchaseManager)
         }
         .alert("Cannot Delete", isPresented: $showCannotDeleteAlert) {
             Button("OK", role: .cancel) {}

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -244,6 +244,7 @@ struct SettingsView: View {
                             .foregroundStyle(DS.Colors.secondaryText)
                     }
                 }
+                .accessibilityHint("Unlocks with Pro")
             }
 
             if purchaseManager.isPro {
@@ -273,6 +274,7 @@ struct SettingsView: View {
                             .foregroundStyle(DS.Colors.secondaryText)
                     }
                 }
+                .accessibilityHint("Unlocks with Pro")
             }
 
             Button {
@@ -337,6 +339,7 @@ struct SettingsView: View {
                             .foregroundStyle(DS.Colors.secondaryText)
                     }
                 }
+                .accessibilityHint("Unlocks with Pro")
             }
         }
     }

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -31,11 +31,11 @@ struct SettingsView: View {
             if !purchaseManager.isPro {
                 proSection
             }
-            appearanceSection
             peopleSection
             notificationsSection
             insightsSection
             dataSection
+            appearanceSection
             aboutSection
             if purchaseManager.isPro {
                 proSection
@@ -340,7 +340,7 @@ struct SettingsView: View {
     private var dataSection: some View {
         Section("Data") {
             NavigationLink(destination: DataSettingsView(viewModel: viewModel)) {
-                Label("Backup & Data", systemImage: "externaldrive.badge.icloud")
+                Label("Data & Privacy", systemImage: "lock.shield")
             }
         }
     }
@@ -351,13 +351,6 @@ struct SettingsView: View {
 
     private var aboutSection: some View {
         Section {
-            Toggle(isOn: Binding(
-                get: { viewModel.settings.analyticsEnabled },
-                set: { viewModel.setAnalyticsEnabled($0) }
-            )) {
-                Label("Anonymous Usage Analytics", systemImage: "shield.checkered")
-            }
-
             Button {
                 viewModel.replayTutorial()
             } label: {
@@ -378,19 +371,17 @@ struct SettingsView: View {
         } header: {
             Text("About")
         } footer: {
-            VStack(spacing: DS.Spacing.md) {
-                Text("Your relationship data lives on your device and is never sent to us. Anonymous usage statistics help us improve the app.")
-                VStack(spacing: DS.Spacing.sm) {
-                    Text("Keep In Touch \(appVersion)")
-                        .font(DS.Typography.caption)
-                        .foregroundStyle(DS.Colors.secondaryText)
-                    Text("Privacy-first personal CRM")
-                        .font(DS.Typography.caption)
-                        .foregroundStyle(DS.Colors.secondaryText)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.top, DS.Spacing.sm)
+            // Privacy story now lives in Data & Privacy; About keeps just the
+            // version + tagline.
+            VStack(spacing: DS.Spacing.sm) {
+                Text("Keep In Touch \(appVersion)")
+                    .font(DS.Typography.caption)
+                    .foregroundStyle(DS.Colors.secondaryText)
+                Text("Privacy-first personal CRM")
+                    .font(DS.Typography.caption)
+                    .foregroundStyle(DS.Colors.secondaryText)
             }
+            .frame(maxWidth: .infinity)
         }
     }
 

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -156,14 +156,18 @@ struct SettingsView: View {
                 } label: {
                     Label("Unlock Keep In Touch Pro", systemImage: "star.circle.fill")
                 }
-            }
 
-            Button {
-                Task { await purchaseManager.restore() }
-            } label: {
-                Label("Restore Purchases", systemImage: "arrow.clockwise")
+                // Restore only matters when the user isn't entitled — someone who
+                // already has Pro (incl. grandfathered) has nothing to restore.
+                // The paywall (non-Pro only) also carries Restore, so App Review
+                // still finds the required mechanism.
+                Button {
+                    Task { await purchaseManager.restore() }
+                } label: {
+                    Label("Restore Purchases", systemImage: "arrow.clockwise")
+                }
+                .accessibilityHint("Restores a previous Pro purchase")
             }
-            .accessibilityHint("Restores a previous Pro purchase")
         } header: {
             if !purchaseManager.isPro {
                 Text("Upgrade")

--- a/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Settings/SettingsView.swift
@@ -25,13 +25,21 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            proSection
+            // Pro upgrade sits up top while it's a call to action; once unlocked
+            // it drops to the bottom (just the "Active" + Restore rows) so it's
+            // out of the way.
+            if !purchaseManager.isPro {
+                proSection
+            }
             appearanceSection
             peopleSection
             notificationsSection
             insightsSection
             dataSection
             aboutSection
+            if purchaseManager.isPro {
+                proSection
+            }
             dangerZoneSection
         }
         .overlay(alignment: .top) {
@@ -205,29 +213,61 @@ struct SettingsView: View {
                 }
             }
 
-            NavigationLink {
-                PausedContactsView()
-            } label: {
-                HStack {
-                    Image(systemName: "pause.circle.fill")
-                        .foregroundStyle(DS.Colors.secondaryText)
-                    Text("Paused Contacts")
-                    Spacer()
-                    Text("\(viewModel.pausedCount)")
-                        .foregroundStyle(DS.Colors.secondaryText)
+            if purchaseManager.isPro {
+                NavigationLink {
+                    PausedContactsView()
+                } label: {
+                    HStack {
+                        Image(systemName: "pause.circle.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                        Text("Paused Contacts")
+                        Spacer()
+                        Text("\(viewModel.pausedCount)")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                }
+            } else {
+                Button {
+                    AnalyticsService.track("pro.gate_tapped", parameters: ["source": "paused_contacts"])
+                    paywallTrigger = PaywallTrigger(source: "paused_contacts")
+                } label: {
+                    HStack {
+                        Image(systemName: "pause.circle.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                        Text("Paused Contacts")
+                        Spacer()
+                        Image(systemName: "lock.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
                 }
             }
 
-            NavigationLink {
-                SnoozedContactsView()
-            } label: {
-                HStack {
-                    Image(systemName: "moon.zzz.fill")
-                        .foregroundStyle(DS.Colors.secondaryText)
-                    Text("Snoozed Contacts")
-                    Spacer()
-                    Text("\(viewModel.snoozedCount)")
-                        .foregroundStyle(DS.Colors.secondaryText)
+            if purchaseManager.isPro {
+                NavigationLink {
+                    SnoozedContactsView()
+                } label: {
+                    HStack {
+                        Image(systemName: "moon.zzz.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                        Text("Snoozed Contacts")
+                        Spacer()
+                        Text("\(viewModel.snoozedCount)")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
+                }
+            } else {
+                Button {
+                    AnalyticsService.track("pro.gate_tapped", parameters: ["source": "snoozed_contacts"])
+                    paywallTrigger = PaywallTrigger(source: "snoozed_contacts")
+                } label: {
+                    HStack {
+                        Image(systemName: "moon.zzz.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                        Text("Snoozed Contacts")
+                        Spacer()
+                        Image(systemName: "lock.fill")
+                            .foregroundStyle(DS.Colors.secondaryText)
+                    }
                 }
             }
 

--- a/StayInTouch/StayInTouch/UI/Views/Tutorial/WalkthroughHost.swift
+++ b/StayInTouch/StayInTouch/UI/Views/Tutorial/WalkthroughHost.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct WalkthroughHost<Content: View>: View {
     @StateObject private var coordinator: WalkthroughCoordinator
+    @EnvironmentObject private var purchaseManager: PurchaseManager
     private let content: Content
 
     init(
@@ -41,6 +42,11 @@ struct WalkthroughHost<Content: View>: View {
                 }
             )) {
                 TutorialPersonDetailHost()
+                    // PersonDetailView (inside the host) requires PurchaseManager
+                    // from the environment; a fullScreenCover is a separate
+                    // presentation context that doesn't reliably inherit it, so
+                    // re-inject — matches every other modal in the freemium work.
+                    .environmentObject(purchaseManager)
                     .overlayPreferenceValue(TutorialAnchorKey.self) { anchors in
                         if coordinator.currentStep?.phase == .detailB {
                             WalkthroughOverlayView(coordinator: coordinator, anchors: anchors)


### PR DESCRIPTION
## Summary
Fifth stacked PR for freemium (#351). Completes the **in-app gating surface** — the remaining Pro-only power features, each presenting the shared paywall.

- **Pause → Pro** — gating the OFF→ON pause action only; **unpause stays free for everyone** (never traps a refunded ex-Pro user). Routed cleanly via a new `PersonSettingsAction.requestPause` → `PersonDetailView`, which presents the paywall when not Pro (Pro path calls `togglePause()` as before).
- **Custom due dates → Pro** — setting a custom due date is gated; **clearing stays free**.
- **Custom cadences → Pro** — creating a new cadence is gated at the ManageCadences "+"; **editing/deleting existing cadences (incl. the defaults) stays free**.

Shared: a `.paywall(source:)` case on PersonDetail's `activeSheet` enum + `@EnvironmentObject purchaseManager` on `PersonDetailView` serve both detail gates. Analytics: `pro.gate_tapped` (source: `pause` | `custom_due_date` | `custom_cadence`).

## What remains for full #351 (PR6 — documented, not done)
**Widget upsell rendering + App Intents entitlement.** Free tier = one small/medium Overdue widget; extra sizes + birthday widgets = Pro. WidgetKit `supportedFamilies` is compile-time static, so this means rendering an upsell placeholder in gated families (reading `EntitlementCache.readIsPro()` from the App Group — the cross-process cache shipped in PR1). Plus any add-via-Siri App Intent reading the same cache. This is the last slice; the entitlement cache it needs is already in place. Until then a free user sees all widget sizes (minor leak — widgets aren't a primary value driver, unlike the contact cap which IS enforced).

## Test plan
- [x] Build + full suite green (gates reuse tested isPro; no new pure logic)
- [ ] Manual: free user → pause / set-custom-due-date / add-cadence each show the paywall; unpause / clear-due-date / edit-cadence stay free; Pro users unaffected (no regression)

## Review
- Code review (high): clean — verified the pause-toggle snap-back is benign, the due-date wrap preserves exact prior behavior, no sheet-id collision, exhaustive `PersonSettingsAction` switch, and `purchaseManager` is available on all 4 PersonDetailView construction sites (no env crash).
- Security review: clean PASS — static-string analytics only (no PII), no new input/parsing surface.

Stacked on #357. Part of #351.