### PR TITLE
[#360] Fix stale widget-accent API comment in OverdueLockScreenWidget

### DIFF
--- a/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
+++ b/StayInTouch/KeepInTouchWidget/OverdueLockScreenWidget.swift
@@ -159,8 +159,8 @@ struct AccessoryCircularView: View {
         if let digit {
             // Bigger digit dominates the widget; small people icon stays
             // for "this is people" context. The digit is marked
-            // .widgetAccentedRenderingMode(.accented) on iOS 18+ so it
-            // picks up the wallpaper-derived accent color instead of
+            // .widgetAccentable(true) (via accentedIfAvailable(), iOS 16+)
+            // so it picks up the wallpaper-derived accent color instead of
             // pure white in monochrome contexts.
             VStack(spacing: 0) {
                 Image(systemName: "person.2.fill")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -84,7 +84,7 @@ Shipped the freemium model: 12-contact free tier + one-time non-consumable **Pro
 - Single-merge umbrella PR pattern for a stacked feature; a required CI check with no producing workflow blocks all merges (needs `--admin`)
 
 ### Follow-ups deferred from #351
-- [ ] **#360** Fix stale widget-accent API comment in `OverdueLockScreenWidget` (tech debt, comment-only)
+- [x] **#360** Fix stale widget-accent API comment in `OverdueLockScreenWidget` (tech debt, comment-only) — **PR #365**
 - [ ] **#353** Manual $7.99 → $9.99 price cutover (ASC, no app logic)
 - [ ] **Manual prereq (pre-release)** Create ASC non-consumable IAP `slavins.co.KeepInTouch.pro` ($7.99, Family Sharing on) + active Paid Apps Agreement
 - [x] **#349** Land the CI pipeline — **merged 2026-06-24** (squash `70adc83`). No `--admin` needed: the PR's own `pull_request` run produces the `Build & Unit Test` check, which passed once the test hang was fixed. See Completed section below


### PR DESCRIPTION
## Summary
- `centerView(digit:)` in `OverdueLockScreenWidget.swift` had a comment claiming the digit is marked `.widgetAccentedRenderingMode(.accented)` on iOS 18+, but the code calls `.accentedIfAvailable()` → `.widgetAccentable(true)` (iOS 16+).
- Updated the comment to describe the API the code actually uses, so it no longer misleads maintainers (matches the convention in `tasks/lessons.md`).
- Comment-only; no code or behavior change.

## Test plan
- [x] Build succeeds locally (incremental, clean)
- [ ] CI `Build & Unit Test` green (full unit suite; comment-only change has no test impact)

## Review
- Code review (high, --fix): PASS — 0 findings (2-line comment diff, zero code delta).
- Security review: N/A — no code change, no new input/surface (local-only app PASS precedent).

Closes #360